### PR TITLE
Environment Canada: document radar camera options flow

### DIFF
--- a/source/_integrations/environment_canada.markdown
+++ b/source/_integrations/environment_canada.markdown
@@ -95,13 +95,13 @@ To configure the radar camera display, go to {% my integrations title="**Setting
 
 The following settings are available:
 
-- **Radar type**: The radar layer to display. Options are Rain, Snow, or Precipitation type (default: Precipitation type).
+- **Radar type**: The radar layer to display: Rain, Snow, or Precipitation type (a composite layer showing the type of precipitation). The default is Precipitation type.
 - **Show legend**: Whether to show the color legend on the radar image (default: off).
 - **Show timestamp**: Whether to show the timestamp on the radar image (default: on).
 - **Radar opacity**: Opacity of the radar overlay, from 0 to 100 (default: 65).
-- **Map radius**: Radius of the radar map in kilometres, from 10 to 2,000 (default: 200 km).
+- **Map radius**: Radius of the radar map in kilometres, from 10 to 2,000 km (default: 200 km).
 
-Changing these settings reloads the integration so the new radar settings take effect immediately.
+Changing these settings reloads the integration so the new radar settings take effect immediately. The radar camera entity will be briefly unavailable during the reload.
 
 ## Solving problems
 

--- a/source/_integrations/environment_canada.markdown
+++ b/source/_integrations/environment_canada.markdown
@@ -42,8 +42,8 @@ The integration will create the entities listed below.
 ### Radar map (Camera)
 
 - Loop of radar imagery from the last 3 hours.
-- This entity is disabled by default can be enabled in the entry's settings dialog.
-- By default, this entity uses the radar rain layer from 1 April to 30 November and the snow layer from 1 December to 31 March. The rain/snow layer can be changed using the action described below.
+- This entity is disabled by default and can be enabled in the entry's settings dialog.
+- Radar display settings can be customized through the integration options. See [Radar camera options](#radar-camera-options) below.
 
 ### Sensors
 
@@ -88,6 +88,20 @@ The integration will create the entities listed below.
 - Endings
 
 The alert sensors use the number of current alerts as their state, with an attribute containing the title of each alert.
+
+## Radar camera options
+
+To configure the radar camera display, go to {% my integrations title="**Settings** > **Devices & services**" %}, select the **Environment Canada** integration, and select **Configure**.
+
+The following settings are available:
+
+- **Radar type**: The radar layer to display. Options are Rain, Snow, or Precipitation type (default: Precipitation type).
+- **Show legend**: Whether to show the color legend on the radar image (default: off).
+- **Show timestamp**: Whether to show the timestamp on the radar image (default: on).
+- **Radar opacity**: Opacity of the radar overlay, from 0 to 100 (default: 65).
+- **Map radius**: Radius of the radar map in kilometres, from 10 to 2,000 (default: 200 km).
+
+Changing these settings reloads the integration so the new radar settings take effect immediately.
 
 ## Solving problems
 

--- a/source/_integrations/environment_canada.markdown
+++ b/source/_integrations/environment_canada.markdown
@@ -91,17 +91,26 @@ The alert sensors use the number of current alerts as their state, with an attri
 
 ## Radar camera options
 
-To configure the radar camera display, go to {% my integrations title="**Settings** > **Devices & services**" %}, select the **Environment Canada** integration, and select **Configure**.
-
+You can customize the radar display settings.
 The following settings are available:
 
-- **Radar type**: The radar layer to display: Rain, Snow, or Precipitation type (a composite layer showing the type of precipitation). The default is Precipitation type.
+- **Radar type**: The radar layer to display: **Rain**, **Snow**, or **Precipitation type** (a composite layer showing the type of precipitation). The default is **Precipitation type**.
 - **Show legend**: Whether to show the color legend on the radar image (default: off).
 - **Show timestamp**: Whether to show the timestamp on the radar image (default: on).
 - **Radar opacity**: Opacity of the radar overlay, from 0 to 100 (default: 65).
-- **Map radius**: Radius of the radar map in kilometres, from 10 to 2,000 km (default: 200 km).
+- **Map radius**: Radius of the radar map in kilometers, from 10 to 2,000 km (default: 200 km).
 
-Changing these settings reloads the integration so the new radar settings take effect immediately. The radar camera entity will be briefly unavailable during the reload.
+### Configuring radar camera display
+
+To configure the radar camera display:
+
+1. Go to {% my integrations title="**Settings** > **Devices & services**" %}.
+2. Select the **Environment Canada** integration.
+3. Select **Configure** (the cogwheel icon).
+4. Change the options you want.
+5. Select **Submit**.
+
+Changing these settings reloads the integration, so the new radar settings take effect immediately. The radar camera entity is briefly unavailable during the reload.
 
 ## Solving problems
 


### PR DESCRIPTION
## Proposed change

Documents the new radar camera options flow added in home-assistant/core#173415.

That PR adds a UI-based options flow for the Environment Canada radar camera, exposing five previously hard-coded settings:

- **Radar type**: Rain, Snow, or Precipitation type
- **Show legend**: on/off
- **Show timestamp**: on/off
- **Radar opacity**: 0–100 slider
- **Map radius**: 10–2,000 km

Updates the Radar map (Camera) entity description and adds a new **Radar camera options** section documenting all five settings, their defaults, and how to access them via **Settings** > **Devices & services** > **Configure**.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/173415
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards