### PR TITLE
Update Sensereo integration documentation to sensor platform

### DIFF
--- a/source/_integrations/sensereo.markdown
+++ b/source/_integrations/sensereo.markdown
@@ -4,19 +4,19 @@ description: Control your Sensereo Matter devices using the Matter integration.
 ha_release: 2026.5
 ha_iot_class: Local Push
 ha_category:
-  - Switch
+  - Sensor
 ha_domain: sensereo
 ha_integration_type: brand
+works_with:
+  - matter
 ha_platforms:
-  - switch
+  - sensor
 ha_iot_standard: matter
 ha_brand: true
 ---
 
-[Sensereo](https://sensereo.com/) is committed to making sure their products are up-to-date and ready to use in Home Assistant.
+{% include integrations/wwha.md url="https://sensereo.com/" %}
 
-Sensereo Matter devices work locally and integrate seamlessly with the Matter integration in Home Assistant. As all connectivity is happening locally, status updates and controlling your devices happen instantly in Home Assistant.
+## Supported devices
 
- {% my add_matter_device badge domain=page.ha_domain %}
-
-[Learn more about Matter in Home Assistant.](/integrations/matter/)
+{% include integrations/device_list.html brand="sensereo" %}


### PR DESCRIPTION
## Proposed change

Updates the Sensereo integration documentation to reflect that it uses the sensor platform instead of switch, and modernizes the documentation structure to use standard integration includes.

## Type of change

- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).

## Changes made

- Changed `ha_category` from "Switch" to "Sensor"
- Changed `ha_platforms` from "switch" to "sensor"
- Added `works_with` section specifying Matter support
- Replaced custom introductory text with the standard `integrations/wwha.md` include
- Replaced custom device information and Matter link with the standard `integrations/device_list.html` include
- Removed the custom Matter badge button in favor of the standardized device list approach

These changes align the Sensereo documentation with current Home Assistant documentation standards and accurately reflect the integration's platform type.

## Additional information

- This change corrects the platform categorization for the Sensereo integration
- Uses standardized documentation includes for consistency across the Home Assistant documentation site

## Checklist

- [x] This PR uses the correct branch (`current` branch for documentation updates)
- [x] The documentation follows the Home Assistant documentation standards

https://claude.ai/code/session_01G413huKFH5sGbKJFpQZt3s