### PR TITLE
Remove known issues section for Verisure integration

### DIFF
--- a/source/_integrations/verisure.markdown
+++ b/source/_integrations/verisure.markdown
@@ -85,16 +85,6 @@ automation:
 | auto | Lock was locked/unlocked automatically by Verisure rule |
 | remote | Lock was locked/unlocked automatically by Verisure App |
 
-## Limitations and known issues
-
-Some users have reported that this integration currently doesn't work in the following countries:
-
-- France
-- Ireland
-- Italy
-- Spain
-- Sweden
-
 ## Troubleshooting
 
 If you get an error message stating something like *"The code for lock.XXX doesn't match pattern `^\d{0}$`."*, make sure the number of digits for your code matches the number defined in the [configuration options](#options).


### PR DESCRIPTION
## Proposed change

Removes the "Limitations and known issues" section from the Verisure integration documentation. The section claimed the integration did not work in France, Ireland, Italy, Spain, and Sweden, but there are no open issues or confirmed reports in the upstream [`python-verisure`](https://github.com/persandstrom/python-verisure) dependency to substantiate this. Keeping unverified country-level limitations in the docs is likely to discourage users in those countries from using a working integration.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: N/A
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: N/A

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards