### PR TITLE
Clarify UniFi Access API token must come from the Access app, not the console

### DIFF
--- a/source/_integrations/unifi_access.markdown
+++ b/source/_integrations/unifi_access.markdown
@@ -48,7 +48,7 @@ Before setting up this integration, make sure you have the following:
 - A running UniFi Access controller (for example, on a UniFi Dream Machine Pro or Cloud Key Gen2 Plus with the Access application installed).
 - An API token generated in the UniFi Access controller's web interface:
   1. Open your console's IP address in a browser and select **Access** at the top.
-  2. Go to **Settings** > **System** > **API Token** and select **Create New**.
+  2. In the left menu, go to **Settings** > **General**, then under **API Token**, select **Create New**.
   3. Give the token a descriptive name, for example _Home Assistant_, and copy it — you will need it during setup.
 
   For full details, see Ubiquiti's [Getting Started with the Official UniFi API](https://help.ui.com/hc/en-us/articles/30076656117655-Getting-Started-with-the-Official-UniFi-API) and the [UniFi Access API reference (PDF)](https://assets.identity.ui.com/unifi-access/api_reference.pdf), section "1.1 Create API Token & Download API Documentation".

--- a/source/_integrations/unifi_access.markdown
+++ b/source/_integrations/unifi_access.markdown
@@ -47,12 +47,16 @@ Before setting up this integration, make sure you have the following:
 
 - A running UniFi Access controller (for example, on a UniFi Dream Machine Pro or Cloud Key Gen2 Plus with the Access application installed).
 - An API token generated from the UniFi Access controller settings:
-  1. Open the UniFi Access web interface.
-  2. Navigate to **Settings** > **Advanced**.
+  1. Open the **UniFi Access** application.
+  2. Go to **Settings** > **Advanced**.
   3. Under **API Token**, select **Create Token**.
   4. Give the token a descriptive name (for example, _Home Assistant_) and save it.
   5. Copy the generated token — you will need it during setup.
 - Your Home Assistant instance must be able to reach the UniFi Access controller on your local network.
+
+{% important %}
+Create the token from inside the **UniFi Access** application, as shown above — not from the console's **Integrations** page (the UniFi OS Control Plane, where UniFi Protect API keys are created). A key made there belongs to the console rather than UniFi Access, and setup fails with a message that the key is associated with UniFi Protect. On newer consoles, the two pages look similar, so it is easy to pick the wrong one.
+{% endimportant %}
 
 {% include integrations/config_flow.md %}
 

--- a/source/_integrations/unifi_access.markdown
+++ b/source/_integrations/unifi_access.markdown
@@ -46,16 +46,16 @@ This integration supports any door managed by a UniFi Access controller, includi
 Before setting up this integration, make sure you have the following:
 
 - A running UniFi Access controller (for example, on a UniFi Dream Machine Pro or Cloud Key Gen2 Plus with the Access application installed).
-- An API token generated from the UniFi Access controller settings:
-  1. Open the **UniFi Access** application.
-  2. Go to **Settings** > **Advanced**.
-  3. Under **API Token**, select **Create Token**.
-  4. Give the token a descriptive name (for example, _Home Assistant_) and save it.
-  5. Copy the generated token — you will need it during setup.
+- An API token generated in the UniFi Access controller's web interface:
+  1. Open your console's IP address in a browser and select **Access** at the top.
+  2. Go to **Settings** > **System** > **API Token** and select **Create New**.
+  3. Give the token a descriptive name, for example _Home Assistant_, and copy it — you will need it during setup.
+
+  For full details, see Ubiquiti's [Getting Started with the Official UniFi API](https://help.ui.com/hc/en-us/articles/30076656117655-Getting-Started-with-the-Official-UniFi-API) and the [UniFi Access API reference (PDF)](https://assets.identity.ui.com/unifi-access/api_reference.pdf), section "1.1 Create API Token & Download API Documentation".
 - Your Home Assistant instance must be able to reach the UniFi Access controller on your local network.
 
 {% important %}
-Create the token from inside the **UniFi Access** application, as shown above. Do not use the console's **Integrations** page (the UniFi OS Control Plane), where UniFi Protect API keys are created. A key made there belongs to the console, and UniFi Access rejects it with a message that the key is associated with UniFi Protect. On newer consoles, the two pages look similar, so it is easy to pick the wrong one.
+Create the token in the **UniFi Access** controller's web interface, as shown above. Do not use the console's **Integrations** page (the UniFi OS Control Plane), where UniFi Protect API keys are created. A key made there belongs to the console, and UniFi Access rejects it with a message that the key is associated with UniFi Protect. On newer consoles, the two pages look similar, so it is easy to pick the wrong one.
 {% endimportant %}
 
 {% include integrations/config_flow.md %}

--- a/source/_integrations/unifi_access.markdown
+++ b/source/_integrations/unifi_access.markdown
@@ -55,7 +55,7 @@ Before setting up this integration, make sure you have the following:
 - Your Home Assistant instance must be able to reach the UniFi Access controller on your local network.
 
 {% important %}
-Create the token from inside the **UniFi Access** application, as shown above — not from the console's **Integrations** page (the UniFi OS Control Plane, where UniFi Protect API keys are created). A key made there belongs to the console rather than UniFi Access, and setup fails with a message that the key is associated with UniFi Protect. On newer consoles, the two pages look similar, so it is easy to pick the wrong one.
+Create the token from inside the **UniFi Access** application, as shown above. Do not use the console's **Integrations** page (the UniFi OS Control Plane), where UniFi Protect API keys are created. A key made there belongs to the console, and UniFi Access rejects it with a message that the key is associated with UniFi Protect. On newer consoles, the two pages look similar, so it is easy to pick the wrong one.
 {% endimportant %}
 
 {% include integrations/config_flow.md %}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change

On newer UniFi consoles, the UniFi Protect and UniFi Access integration pages look the same, so people create their API key on the console's **Integrations** page (the UniFi OS Control Plane, where UniFi Protect keys are created). The UniFi Access integration then rejects it with *"This API key is associated with UniFi Protect, not UniFi Access."*

This is a recurring setup question. It adds a note to the Prerequisites making clear the token must be created from inside the **UniFi Access** application (**Settings** > **Advanced** > **API Token**), and clarifies the first step to say "application" rather than "web interface".

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Addresses the recurring "wrong API key" reports: home-assistant/core#173512, home-assistant/core#170019, home-assistant/core#167389

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
