### PR TITLE
Remove Sweden from Verisure limitations list

### DIFF
--- a/source/_integrations/verisure.markdown
+++ b/source/_integrations/verisure.markdown
@@ -93,7 +93,6 @@ Some users have reported that this integration currently doesn't work in the fol
 - Ireland
 - Italy
 - Spain
-- Sweden
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Proposed change

Removes Sweden from the "Limitations and known issues" section of the Verisure integration documentation. Sweden is the home country of the upstream [`python-verisure`](https://github.com/persandstrom/python-verisure) maintainer, and I can personally verify the integration works there. The only historical issue filed for Sweden ([#111](https://github.com/persandstrom/python-verisure/issues/111)) was closed the same day it was opened and predates the 2023 migration to the GraphQL API ([home-assistant/core#89318](https://github.com/home-assistant/core/pull/89318)). There are no issues filed against the current API for Sweden.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: N/A
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: N/A

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards