### PR TITLE
Add Litter-Robot 5 entities to Whisker integration docs

### DIFF
--- a/source/_integrations/litterrobot.markdown
+++ b/source/_integrations/litterrobot.markdown
@@ -60,12 +60,19 @@ Password:
 | Panel lockout                 | `switch`        | When turned on, disables the buttons on the unit to prevent changes to settings.                            |
 | Last seen                     | `sensor`        | Displays the time the unit was last seen / reported an update.                                              |
 | Litter level                  | `sensor`        | Displays the litter level, only for Litter-Robot 4.                                                         |
+| Next filter replacement       | `sensor`        | Displays the date the filter should next be replaced, only for Litter-Robot 5.                              |
 | Pet weight                    | `sensor`        | Displays the last measured pet weight, only for Litter-Robot 4.                                             |
+| Scoops saved                  | `sensor`        | Displays the total scoops of litter saved, only for Litter-Robot 5.                                         |
 | Sleep mode start time         | `sensor`        | When sleep mode is enabled, displays the current or next sleep mode start time.                             |
 | Sleep mode end time           | `sensor`        | When sleep mode is enabled, displays the current or last sleep mode end time.                               |
 | Status code                   | `sensor`        | Displays the status code (Clean Cycle in Progress, Ready, Drawer Full, etc.).                               |
 | Total cycles                  | `sensor`        | Displays the total cycles.                                                                                  |
 | Waste drawer                  | `sensor`        | Displays the current waste drawer level.                                                                    |
+| Bonnet removed                | `binary_sensor` | Indicates whether the bonnet is removed, only for Litter-Robot 5.                                           |
+| Drawer removed                | `binary_sensor` | Indicates whether the waste drawer is removed, only for Litter-Robot 5.                                     |
+| Hopper connected              | `binary_sensor` | Indicates whether a LitterHopper is connected, only for Litter-Robot 5.                                     |
+| Laser dirty                   | `binary_sensor` | Indicates whether the cat detection laser is dirty, only for Litter-Robot 5.                                |
+| Online                        | `binary_sensor` | Indicates whether the unit is connected to Whisker, only for Litter-Robot 5.                                |
 | Power status                  | `binary_sensor` | Indicates whether power is currently connected.                                                             |
 | Sleep mode                    | `binary_sensor` | Indicates whether sleep mode is enabled.                                                                    |
 | Sleeping                      | `binary_sensor` | Indicates whether sleep mode is currently active.                                                           |
@@ -73,6 +80,7 @@ Password:
 | Globe brightness              | `select`        | View and select the brightness level for the globe light, only for Litter-Robot 4.                          |
 | Globe light                   | `select`        | View and select the globe light setting, only for Litter-Robot 4.                                           |
 | Panel brightness              | `select`        | View and select the panel brightness, only for Litter-Robot 4.                                              |
+| Change filter                 | `button`        | Button to indicate the filter was changed and reset the replacement date, only for Litter-Robot 5.          |
 | Reset                         | `button`        | Button to reset the robot, clearing any errors and potentially triggering a cycle, only for Litter-Robot 4. |
 | Reset waste drawer            | `button`        | Button to reset the waste drawer level to 0%, only for Litter-Robot 3.                                      |
 | Firmware                      | `update`        | View and update to the latest firmware, only for Litter-Robot 4.                                            |

--- a/source/_integrations/litterrobot.markdown
+++ b/source/_integrations/litterrobot.markdown
@@ -60,9 +60,9 @@ Password:
 | Panel lockout                 | `switch`        | When turned on, disables the buttons on the unit to prevent changes to settings.                            |
 | Last seen                     | `sensor`        | Displays the time the unit was last seen / reported an update.                                              |
 | Litter level                  | `sensor`        | Displays the litter level, only for Litter-Robot 4.                                                         |
-| Next filter replacement       | `sensor`        | Displays the date the filter should next be replaced, only for Litter-Robot 5.                              |
+| Next filter replacement       | `sensor`        | Displays the next filter replacement date, only for Litter-Robot 5.                                         |
 | Pet weight                    | `sensor`        | Displays the last measured pet weight, only for Litter-Robot 4.                                             |
-| Scoops saved                  | `sensor`        | Displays the total scoops of litter saved, only for Litter-Robot 5.                                         |
+| Scoops saved                  | `sensor`        | Displays the total number of scoops of litter saved, only for Litter-Robot 5.                               |
 | Sleep mode start time         | `sensor`        | When sleep mode is enabled, displays the current or next sleep mode start time.                             |
 | Sleep mode end time           | `sensor`        | When sleep mode is enabled, displays the current or last sleep mode end time.                               |
 | Status code                   | `sensor`        | Displays the status code (Clean Cycle in Progress, Ready, Drawer Full, etc.).                               |
@@ -72,7 +72,7 @@ Password:
 | Drawer removed                | `binary_sensor` | Indicates whether the waste drawer is removed, only for Litter-Robot 5.                                     |
 | Hopper connected              | `binary_sensor` | Indicates whether a LitterHopper is connected, only for Litter-Robot 5.                                     |
 | Laser dirty                   | `binary_sensor` | Indicates whether the cat detection laser is dirty, only for Litter-Robot 5.                                |
-| Online                        | `binary_sensor` | Indicates whether the unit is connected to Whisker, only for Litter-Robot 5.                                |
+| Online                        | `binary_sensor` | Indicates whether the unit is connected to the Whisker cloud, only for Litter-Robot 5.                      |
 | Power status                  | `binary_sensor` | Indicates whether power is currently connected.                                                             |
 | Sleep mode                    | `binary_sensor` | Indicates whether sleep mode is enabled.                                                                    |
 | Sleeping                      | `binary_sensor` | Indicates whether sleep mode is currently active.                                                           |

--- a/source/_integrations/litterrobot.markdown
+++ b/source/_integrations/litterrobot.markdown
@@ -59,9 +59,9 @@ Password:
 | Night light mode              | `switch`        | When turned on, automatically turns on the night light in darker settings, only for Litter-Robot 3.         |
 | Panel lockout                 | `switch`        | When turned on, disables the buttons on the unit to prevent changes to settings.                            |
 | Last seen                     | `sensor`        | Displays the time the unit was last seen / reported an update.                                              |
-| Litter level                  | `sensor`        | Displays the litter level, only for Litter-Robot 4.                                                         |
+| Litter level                  | `sensor`        | Displays the litter level, only for Litter-Robot 4 and 5.                                                   |
 | Next filter replacement       | `sensor`        | Displays the next filter replacement date, only for Litter-Robot 5.                                         |
-| Pet weight                    | `sensor`        | Displays the last measured pet weight, only for Litter-Robot 4.                                             |
+| Pet weight                    | `sensor`        | Displays the last measured pet weight, only for Litter-Robot 4 and 5.                                       |
 | Scoops saved                  | `sensor`        | Displays the total number of scoops of litter saved, only for Litter-Robot 5.                               |
 | Sleep mode start time         | `sensor`        | When sleep mode is enabled, displays the current or next sleep mode start time.                             |
 | Sleep mode end time           | `sensor`        | When sleep mode is enabled, displays the current or last sleep mode end time.                               |
@@ -77,12 +77,12 @@ Password:
 | Sleep mode                    | `binary_sensor` | Indicates whether sleep mode is enabled.                                                                    |
 | Sleeping                      | `binary_sensor` | Indicates whether sleep mode is currently active.                                                           |
 | Clean cycle wait time minutes | `select`        | View and select the clean cycle wait time.                                                                  |
-| Globe brightness              | `select`        | View and select the brightness level for the globe light, only for Litter-Robot 4.                          |
-| Globe light                   | `select`        | View and select the globe light setting, only for Litter-Robot 4.                                           |
-| Panel brightness              | `select`        | View and select the panel brightness, only for Litter-Robot 4.                                              |
+| Globe brightness              | `select`        | View and select the brightness level for the globe light, only for Litter-Robot 4 and 5.                    |
+| Globe light                   | `select`        | View and select the globe light setting, only for Litter-Robot 4 and 5.                                     |
+| Panel brightness              | `select`        | View and select the panel brightness, only for Litter-Robot 4 and 5.                                        |
 | Change filter                 | `button`        | Button to indicate the filter was changed and reset the replacement date, only for Litter-Robot 5.          |
-| Reset                         | `button`        | Button to reset the robot, clearing any errors and potentially triggering a cycle, only for Litter-Robot 4. |
-| Reset waste drawer            | `button`        | Button to reset the waste drawer level to 0%, only for Litter-Robot 3.                                      |
+| Reset                         | `button`        | Button to reset the robot, clearing errors and potentially cycling, only for Litter-Robot 4 and 5.          |
+| Reset waste drawer            | `button`        | Button to reset the waste drawer level to 0%, only for Litter-Robot 3 and 5.                                |
 | Firmware                      | `update`        | View and update to the latest firmware, only for Litter-Robot 4.                                            |
 
 ### Feeder-Robot


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change

Document the Litter-Robot 5 entities added to the Whisker integration in home-assistant/core#165879: the bonnet removed, drawer removed, hopper connected, laser dirty, and online binary sensors; the next filter replacement and scoops saved sensors; and the change filter button.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: home-assistant/core#165879
- Link to parent pull request in the Brands repository: N/A
- This PR fixes or closes issue: N/A

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
