### PR TITLE
Drop stale Raspberry Pi 3 mention from the install guide

### DIFF
--- a/source/installation/raspberrypi.markdown
+++ b/source/installation/raspberrypi.markdown
@@ -38,7 +38,7 @@ This guide shows how to install the {% term "Home Assistant Operating System" %}
 3. Choose the operating system type:
    - Select **Other specific-purpose OS** > **Home automation** > **Home Assistant**.
     ![Choose the operating system type: Other specific-purpose OS](/images/installation/rpi-ha-1.webp)
-4. Choose the Home Assistant OS that matches your hardware (RPi&nbsp;3, RPi&nbsp;4, or RPi&nbsp;5).
+4. Choose the Home Assistant OS that matches your hardware (RPi&nbsp;4 or RPi&nbsp;5).
     ![Choose the Home Assistant OS](/images/installation/rpi-ha-2.webp)
 5. Choose the storage:
    1. Insert the SD card into the computer. Note: the contents of the card will be overwritten.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

The Raspberry Pi installation guide told readers to pick the Home Assistant OS image matching "RPi 3, RPi 4, or RPi 5" in the imager. That mention of the Pi 3 is stale: the guide only offers Pi 4 and Pi 5 download images, recommends Pi 4 or Pi 5 hardware, and requires at least 2 GB of RAM, which the Pi 3 does not provide. Removed the Pi 3 from that step so it matches the rest of the page.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards