### PR TITLE
Add Yoto binary sensors documentation

### DIFF
--- a/source/_integrations/yoto.markdown
+++ b/source/_integrations/yoto.markdown
@@ -2,7 +2,7 @@
 title: Yoto
 description: Instructions on how to integrate Yoto players with Home Assistant.
 ha_category:
-  - Binary sensor
+  - Binary Sensor
   - Media Player
   - Time
 ha_iot_class: Cloud Push

--- a/source/_integrations/yoto.markdown
+++ b/source/_integrations/yoto.markdown
@@ -2,6 +2,7 @@
 title: Yoto
 description: Instructions on how to integrate Yoto players with Home Assistant.
 ha_category:
+  - Binary sensor
   - Media Player
   - Time
 ha_iot_class: Cloud Push
@@ -13,6 +14,7 @@ ha_codeowners:
   - '@piitaya'
 ha_domain: yoto
 ha_platforms:
+  - binary_sensor
   - media_player
   - time
 ha_integration_type: hub
@@ -104,6 +106,14 @@ Yoto players can switch between a day display and a night display. Each player p
 
 - **Day mode start**: The time the player switches to day mode.
 - **Night mode start**: The time the player switches to night mode.
+
+### Binary sensors
+
+Each Yoto player also provides several binary sensors:
+
+- **Charging**: whether the player's battery is charging.
+- **Headphones**: whether headphones are connected to the player.
+- **Bluetooth audio**: whether a Bluetooth audio device is connected to the player.
 
 ## Data updates
 


### PR DESCRIPTION
## Proposed change

Documents the new binary sensor platform for the Yoto integration. Each player exposes charging, headphones, and Bluetooth audio binary sensors. Adds a **Binary sensors** section under **Supported functionality** and lists `binary_sensor` in the platforms and `Binary sensor` in the categories.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/173612
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
