### PR TITLE
Add Yoto day and night mode time entities documentation

### DIFF
--- a/source/_integrations/yoto.markdown
+++ b/source/_integrations/yoto.markdown
@@ -100,10 +100,10 @@ data:
 
 ### Day and night mode
 
-Yoto players can switch between a day display and a night display. Two time entities let you set when each one starts:
+Yoto players can switch between a day display and a night display. Each player provides two time entities that let you set when each mode starts:
 
-- **Day mode start**: the time the player switches to day mode.
-- **Night mode start**: the time the player switches to night mode.
+- **Day mode start**: The time the player switches to day mode.
+- **Night mode start**: The time the player switches to night mode.
 
 ## Data updates
 

--- a/source/_integrations/yoto.markdown
+++ b/source/_integrations/yoto.markdown
@@ -3,6 +3,7 @@ title: Yoto
 description: Instructions on how to integrate Yoto players with Home Assistant.
 ha_category:
   - Media Player
+  - Time
 ha_iot_class: Cloud Push
 ha_release: 2026.6
 ha_quality_scale: bronze
@@ -13,6 +14,7 @@ ha_codeowners:
 ha_domain: yoto
 ha_platforms:
   - media_player
+  - time
 ha_integration_type: hub
 ha_dhcp: true
 ---
@@ -63,6 +65,8 @@ During setup, Home Assistant opens the Yoto authorization page so you can grant 
 
 ## Supported functionality
 
+### Media player
+
 The integration provides one media player entity per Yoto player. Each entity supports:
 
 - Play, pause, and stop
@@ -93,6 +97,13 @@ data:
   media_content_type: "music"
   media_content_id: "yoto://card/abc123/01/02"
 ```
+
+### Day and night mode
+
+Yoto players can switch between a day display and a night display. Two time entities let you set when each one starts:
+
+- **Day mode start**: the time the player switches to day mode.
+- **Night mode start**: the time the player switches to night mode.
 
 ## Data updates
 


### PR DESCRIPTION
## Proposed change

Documents the new time platform for the Yoto integration. Each player gets two config time entities, **Day mode start** and **Night mode start**, to set when it switches between its day and night display. Adds a **Day and night mode** section under **Supported functionality**, with `time` in the platforms and `Time` in the categories.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/173617
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
