### PR TITLE
Fix broken step numbering in Windows VMware install guide

### DIFF
--- a/source/_includes/installation/operating_system.md
+++ b/source/_includes/installation/operating_system.md
@@ -456,15 +456,15 @@ Minimum recommended assignments:
 
       11. In Windows Explorer, go to the storage location of your newly created VM, for example under `C:\home-assistant`.
       12. Delete the `home-assistant.vmdk` file.
-      3. In the `Downloads` folder, find the `haos_ova_xx.x.vmdk` file. 
+      13. In the `Downloads` folder, find the `haos_ova_xx.x.vmdk` file.
          - If you haven't unzipped the archive, unzip it.
          - Within the folder, find the `.vmdk` file and rename it to `home-assistant.vmdk`.
          - Paste the file (not the unzipped folder) into the `C:\home-assistant` folder.
-      4. Right-click the `.vmx` file and select **Open with** > **Notepad**.
-      5. Under `.encoding`, add a line. Enter `firmware = "efi"`.
-      6. Now continue with the next step to start your VM. 
+      14. Right-click the `.vmx` file and select **Open with** > **Notepad**.
+      15. Under `.encoding`, add a line. Enter `firmware = "efi"`.
+      16. Now continue with the next step to start your VM.
          - If you see a message about side channel mitigations, select **OK**.
-         - If you see a message stating that the `.vmdk` file could not be found, in step 3, you likely pasted the folder, not the file. Repeat step 3.
+         - If you see a message stating that the `.vmdk` file could not be found, in step 13, you likely pasted the folder, not the file. Repeat step 13.
 
 
 {% elsif page.installation_type == 'alternative' %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

In the Windows VMware Workstation installation steps, the list continued past the **Edit the VM settings** heading as steps 11 and 12, then reset to 3 through 6 instead of continuing 13 through 16. The troubleshooting notes also referred to "step 3", which pointed readers at the wrong step. This renumbers the steps sequentially and updates the references so people following along land on the correct step.

This content lives in the shared `operating_system.md` include, so it affects the Windows VMware section of the installation guides.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards