### PR TITLE
Replace deprecated "service call" terminology with "action"

### DIFF
--- a/source/_integrations/fish_audio.markdown
+++ b/source/_integrations/fish_audio.markdown
@@ -70,7 +70,7 @@ Currently supported languages include:
 
 The `tts.speak` service allows you to use Fish Audio voices in your automations and scripts. Select the `tts.fish_audio` entity, choose a media player, and enter your message.
 
-Example of a `tts.speak` service call in YAML:
+Example of a `tts.speak` action in YAML:
 
 ```yaml
 actions:

--- a/source/_integrations/google_cloud.markdown
+++ b/source/_integrations/google_cloud.markdown
@@ -116,7 +116,7 @@ The `tts.speak` action is the modern way to use Google Cloud TTS action. Add the
 
 For more options about `speak`, see the Speak section on the main [TTS](/integrations/tts/#action-speak) building block page.
 
-A `tts.speak` service call can look like:
+A `tts.speak` action can look like:
 
 ```yaml
 action: tts.speak

--- a/source/_integrations/google_mail.markdown
+++ b/source/_integrations/google_mail.markdown
@@ -71,7 +71,7 @@ The following attributes can be placed inside the `data` key of the action for e
 
 ### Examples
 
-This is the full service call to send an email:
+This is the full action to send an email:
 
 ```yaml
 action: notify.example_gmail_com

--- a/source/_integrations/input_button.markdown
+++ b/source/_integrations/input_button.markdown
@@ -61,7 +61,7 @@ The `input_button` entity is stateless, as in, it cannot have a state like the
 
 Every input button entity does keep track of the timestamp of when the last time
 the input button entity has been pressed in the Home Assistant UI or pressed via
-a service call.
+an action.
 
 Because the state of a input button entity in Home Assistant is a timestamp, it
 means we can use it in our automations. For example:

--- a/source/_integrations/manual.markdown
+++ b/source/_integrations/manual.markdown
@@ -109,7 +109,7 @@ The `manual_alarm_bad_code_attempt` event is fired when an attempt to change the
 
 - **entity_id** (string): The entity ID of the alarm control panel (for example, `alarm_control_panel.my_alarm`).
 - **target_state** (string): The attempted target state (for example, `disarmed`, `armed_away`, `armed_home`).
-- **user_id** (string): The user ID who initiated the service call (if available).
+- **user_id** (string): The user ID who initiated the action (if available).
 
 Example automation trigger:
 

--- a/source/_integrations/openuv.markdown
+++ b/source/_integrations/openuv.markdown
@@ -183,7 +183,7 @@ provided by OpenUV. So, this strategy is followed:
 1. Any `HTTP 403` response will create a persistent notification asking you to
    re-authenticate the OpenUV integration.
 2. In the case of an overrun API call limit, once the `homeassistant.update_entity`
-   service call is again successful, existing re-authentication notifications will
+   action is again successful, existing re-authentication notifications will
    automatically be removed.
 
 If you receive a re-authentication notification and are certain that your key has merely


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Home Assistant renamed services and service calls to actions. Several integration pages still referred to a "service call", in some cases right next to text and YAML examples that already use the modern "action" wording. This updates those leftover references so the terminology is consistent.

Pages updated: `fish_audio`, `google_cloud`, `google_mail`, `input_button`, `manual`, `openuv`.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards