### PR TITLE
Fix broken relative link to configuration troubleshooting page

### DIFF
--- a/source/_docs/configuration.markdown
+++ b/source/_docs/configuration.markdown
@@ -12,7 +12,7 @@ related:
     title: Reloading the YAML configuration from developer tools
   - docs: /common-tasks/os/#configuring-access-to-files
     title: Configuring file access on the Operating System
-  - docs: docs/configuration/troubleshooting/
+  - docs: /docs/configuration/troubleshooting/
     title: Troubleshooting the configuration
 ---
 


### PR DESCRIPTION
## Proposed change

The `related` entry linking to the configuration troubleshooting page was missing its leading slash, making it a relative link that resolves incorrectly. Every other entry in the same `related` block uses an absolute path. This fixes the link to `/docs/configuration/troubleshooting/`.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
