### PR TITLE
Fix broken link to template sentence syntax documentation

### DIFF
--- a/source/_docs/automation/templating.markdown
+++ b/source/_docs/automation/templating.markdown
@@ -131,7 +131,7 @@ These are the properties available for a [Sentence trigger](/docs/automation/tri
 | `trigger.platform` | Hardcoded: `conversation`
 | `trigger.sentence` | Text of the sentence that was matched.
 | `trigger.slots`    | Object with matched slot values.
-| `trigger.details`  | Object with matched slot details by name, such as [wildcards](/docs/automation/trigger/#sentence-wildcards). Each detail contains: <ul><li>`name` - name of the slot</li><li>`text` - matched text</li><li>`value` - output value (see [lists](/docs/voice/intent-recognition/template-sentence-syntax/#lists))</li></ul>.
+| `trigger.details`  | Object with matched slot details by name, such as [wildcards](/docs/automation/trigger/#sentence-wildcards). Each detail contains: <ul><li>`name` - name of the slot</li><li>`text` - matched text</li><li>`value` - output value (see [lists](https://developers.home-assistant.io/docs/voice/intent-recognition/template-sentence-syntax/#lists))</li></ul>.
 | `trigger.device_id` | The device ID that captured the command, if any.
 | `trigger.satellite_id` | The entity ID of the satellite that captured the command, if any.
 


### PR DESCRIPTION
## Proposed change

The link to the template sentence syntax "lists" documentation used a site-relative path (`/docs/voice/intent-recognition/template-sentence-syntax/#lists`), but that page does not exist on this website and returns a 404. That documentation lives on the developer docs site. Every other reference to this page across the repository already points to `https://developers.home-assistant.io/docs/voice/intent-recognition/template-sentence-syntax/`. This updates the link to match.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
