### PR TITLE
Fix invalid condition example using numeric_state for below comparison

### DIFF
--- a/source/_docs/automation/action.markdown
+++ b/source/_docs/automation/action.markdown
@@ -67,7 +67,7 @@ automation:
           entity_id: sun.sun
           attribute: elevation
           below: 4
-        - condition: state
+        - condition: numeric_state
           entity_id: sensor.office_illuminance
           below: 10
     - action: scene.turn_on


### PR DESCRIPTION
## Proposed change

The conditional actions example used a `state` condition with a `below:` parameter to check an illuminance sensor. The `state` condition does not support `below:`; numeric threshold comparisons require the `numeric_state` condition. This corrects the example to use `numeric_state`, matching the intent (it sits in an `or` block alongside a `numeric_state` elevation check).

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
