### PR TITLE
Fix broken anchor link to wake word detection on Android

### DIFF
--- a/source/voice_control/about_wake_word.markdown
+++ b/source/voice_control/about_wake_word.markdown
@@ -26,7 +26,7 @@ To avoid being limited to specific hardware, the wake word detection is done ins
 This means any device that streams audio can be turned into a voice satellite, even if it isn't powerful enough to run wake word detection locally. It also allows our developer community to experiment with wake word models without having to shrink the model to run on a low-powered voice satellite device.
 
 {% note %}
-**Exception for mobile devices**: Mobile devices like Android phones use microWakeWord for on-device wake word detection through the [Home Assistant Companion App](https://companion.home-assistant.io/). This preserves battery life and ensures wake word detection works even when network connectivity is unreliable or unavailable. Only after the wake word is detected does the device send audio to Home Assistant. Learn more about [Assist on Android](/voice_control/android/#using-wake-word-detection-on-android).
+**Exception for mobile devices**: Mobile devices like Android phones use microWakeWord for on-device wake word detection through the [Home Assistant Companion App](https://companion.home-assistant.io/). This preserves battery life and ensures wake word detection works even when network connectivity is unreliable or unavailable. Only after the wake word is detected does the device send audio to Home Assistant. Learn more about [Assist on Android](/voice_control/android/#about-wake-word-detection-on-android).
 {% endnote %}
 
 <p class='img'>


### PR DESCRIPTION
## Proposed change

The "Learn more about Assist on Android" link pointed to the anchor `#using-wake-word-detection-on-android`, which does not exist on the Android voice control page. This updates it to the existing section `#about-wake-word-detection-on-android`, the overview that explains on-device wake word detection on Android.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
