### PR TITLE
Fix broken action anchor links in integration docs

### DIFF
--- a/source/_integrations/abode.markdown
+++ b/source/_integrations/abode.markdown
@@ -38,7 +38,7 @@ There is currently support for the following {% term device %} types within Home
 
 - **Alarm control panel**: Reports on the current alarm status and can be used to arm and disarm the system.
 - **Binary sensor**: Reports on `Quick Actions`, `Door Contacts`, `Connectivity` {% term sensors %} (remotes, keypads, and status indicators), `Moisture` sensors, and `Motion` or `Occupancy` sensors.
-- **Camera**: Reports on `Camera` devices and will download and show the latest captured still image. Can be turned off and on using the [`camera.turn_off`](/integrations/camera/#action-turn_off) and [`camera.turn_on`](/integrations/camera/#action-turn_on) {% term actions %}.
+- **Camera**: Reports on `Camera` devices and will download and show the latest captured still image. Can be turned off and on using the [`camera.turn_off`](/integrations/camera/#action-turn-off) and [`camera.turn_on`](/integrations/camera/#action-turn-on) {% term actions %}.
 - **Cover**: Reports on `Secure Barriers` and can be used to open and close the cover.
 - **Lock**: Reports on `Door Locks` and can be used to lock and unlock the door.
 - **Light**: Reports on `Dimmer` lights and can be used to dim or turn the light on and off.

--- a/source/_integrations/airzone_cloud.markdown
+++ b/source/_integrations/airzone_cloud.markdown
@@ -39,7 +39,7 @@ These devices are Wi-Fi controllers that are normally connected to a single air 
 
 These devices are connected to ducted air conditioners, motorized grilles, and individual thermostats for every room (zone). Therefore, with a single ducted air conditioning system, the user can turn on and off the air conditioner and set different desired temperatures in each room.
 
-A typical Airzone HVAC system consists of a parent device (called *master zone* in Airzone terminology) and child devices (called *slave zones* in Airzone terminology). The [HVAC mode](/integrations/climate/#action-climateset_hvac_mode) can only be changed on the parent device. On child devices, you can only enable or disable the HVAC and adjust the desired temperature for that specific device.
+A typical Airzone HVAC system consists of a parent device (called *master zone* in Airzone terminology) and child devices (called *slave zones* in Airzone terminology). The [HVAC mode](/integrations/climate/#action-set-hvac-mode) can only be changed on the parent device. On child devices, you can only enable or disable the HVAC and adjust the desired temperature for that specific device.
 
 Note that multiple HVAC systems can be connected to the same Airzone web server. In this case, there will be one *parent zone* per HVAC system and there may also be *child zones* for each HVAC system.
 

--- a/source/_integrations/atag.markdown
+++ b/source/_integrations/atag.markdown
@@ -46,11 +46,11 @@ The `Atag` climate platform provides current and target temperature information 
 
 This integration supports the following actions (see [Climate](/integrations/climate/)).
 
-- [`set_temperature`](/integrations/climate/#action-climateset_temperature)
-- [`set_hvac_mode`](/integrations/climate/#action-climateset_hvac_mode)
+- [`set_temperature`](/integrations/climate/#action-set-temperature)
+- [`set_hvac_mode`](/integrations/climate/#action-set-hvac-mode)
   - `heat` for thermostat mode
   - `auto` for weather-based mode
-- [`set_preset_mode`](/integrations/climate/#action-climateset_preset_mode)
+- [`set_preset_mode`](/integrations/climate/#action-set-preset-mode)
   - `Manual` enable manual operation
   - `Auto` enable schedule based operation
   - `Extend` delay the next scheduled temperature update by the default extend period

--- a/source/_integrations/blink.markdown
+++ b/source/_integrations/blink.markdown
@@ -129,7 +129,7 @@ sequence:
 
 ### Arm Blink when away
 
-This example automation will arm your blink sync module to detect motion on any of your blink cameras that have motion detection enabled.  By default, Blink enables motion detection on all cameras so, unless you've changed anything in your app, you're all set.  If you want to manually enable motion detection for individual cameras, you can utilize the [appropriate camera action](/integrations/camera#action-enable_motion_detection) but please note that motion will only be captured if the sync module is armed.
+This example automation will arm your blink sync module to detect motion on any of your blink cameras that have motion detection enabled.  By default, Blink enables motion detection on all cameras so, unless you've changed anything in your app, you're all set.  If you want to manually enable motion detection for individual cameras, you can utilize the [appropriate camera action](/integrations/camera/#action-enable-motion-detection) but please note that motion will only be captured if the sync module is armed.
 
 Here, this example assumes your blink module is named `My Sync Module` and that you have [device trackers](/integrations/device_tracker) set up for presence detection.
 

--- a/source/_integrations/daikin.markdown
+++ b/source/_integrations/daikin.markdown
@@ -59,12 +59,12 @@ If this situation applies to you, you may need to adjust your firewall(s) accord
 
 The `daikin` climate platform integrates Daikin air conditioning systems into Home Assistant, enabling control of setting the following parameters:
 
-- [**set_hvac_mode**](/integrations/climate/#action-climateset_hvac_mode) (`off`, `heat`, `cool`, `heat_cool`, or `fan_only`)
-- [**target temperature**](/integrations/climate#action-climateset_temperature)
-- [**turn on/off**](/integrations/climate#action-climateturn_on)
-- [**fan mode**](/integrations/climate#action-climateset_fan_mode) (speed)
-- [**swing mode**](/integrations/climate#action-climateset_swing_mode)
-- [**set_preset_mode**](/integrations/climate#action-climateset_preset_mode) (away, none)
+- [**set_hvac_mode**](/integrations/climate/#action-set-hvac-mode) (`off`, `heat`, `cool`, `heat_cool`, or `fan_only`)
+- [**target temperature**](/integrations/climate/#action-set-temperature)
+- [**turn on/off**](/integrations/climate/#action-turn-on)
+- [**fan mode**](/integrations/climate/#action-set-fan-mode) (speed)
+- [**swing mode**](/integrations/climate/#action-set-swing-mode)
+- [**set_preset_mode**](/integrations/climate/#action-set-preset-mode) (away, none)
 
 Current inside temperature is displayed.
 

--- a/source/_integrations/esphome.markdown
+++ b/source/_integrations/esphome.markdown
@@ -224,7 +224,7 @@ If you want the device to send logs without requiring you to be actively monitor
 
 2. To adjust the logging level, there are two options:
     - enable [debug logging](/docs/configuration/troubleshooting/#debug-logs-and-diagnostics),
-    - or use the [Developer tools](/docs/tools/dev-tools/#actions-tab) to call the [`logger.set_level`](/integrations/logger/#action-set_level) action to specify the desired level:
+    - or use the [Developer tools](/docs/tools/dev-tools/#actions-tab) to call the [`logger.set_level`](/integrations/logger/#action-set-level) action to specify the desired level:
 
       ```yaml
       action: logger.set_level

--- a/source/_integrations/fujitsu_fglair.markdown
+++ b/source/_integrations/fujitsu_fglair.markdown
@@ -37,11 +37,11 @@ To configure this integration, you will need the credentials (login and password
 
 This integration supports the following functionalities (if the devices support them):
 
-- [`set_hvac_mode`](/integrations/climate/#action-climateset_hvac_mode)
-- [`target temperature`](/integrations/climate#action-climateset_temperature)
-- [`turn on/off`](/integrations/climate#action-climateturn_on)
-- [`fan mode`](/integrations/climate#action-climateset_fan_mode)
-- [`swing mode`](/integrations/climate#action-climateset_swing_mode)
+- [`set_hvac_mode`](/integrations/climate/#action-set-hvac-mode)
+- [`target temperature`](/integrations/climate/#action-set-temperature)
+- [`turn on/off`](/integrations/climate/#action-turn-on)
+- [`fan mode`](/integrations/climate/#action-set-fan-mode)
+- [`swing mode`](/integrations/climate/#action-set-swing-mode)
 
 ## Outside temperature
 

--- a/source/_integrations/gree.markdown
+++ b/source/_integrations/gree.markdown
@@ -47,12 +47,12 @@ Any Gree Smart device working with the Gree+ app should be supported, including 
 
 The `gree` climate platform integrates Gree HVAC systems into Home Assistant, enabling control of setting the following parameters:
 
-- [`set_hvac_mode`](/integrations/climate/#action-climateset_hvac_mode)
-- [`target temperature`](/integrations/climate#action-climateset_temperature)
-- [`turn on/off`](/integrations/climate#action-climateturn_on)
-- [`fan mode`](/integrations/climate#action-climateset_fan_mode)
-- [`swing mode`](/integrations/climate#action-climateset_swing_mode)
-- [`set_preset_mode`](/integrations/climate#action-climateset_preset_mode)
+- [`set_hvac_mode`](/integrations/climate/#action-set-hvac-mode)
+- [`target temperature`](/integrations/climate/#action-set-temperature)
+- [`turn on/off`](/integrations/climate/#action-turn-on)
+- [`fan mode`](/integrations/climate/#action-set-fan-mode)
+- [`swing mode`](/integrations/climate/#action-set-swing-mode)
+- [`set_preset_mode`](/integrations/climate/#action-set-preset-mode)
 
 {% note %}
 Preset mode **Away** represents Gree's "8°C heating mode."

--- a/source/_integrations/habitica.markdown
+++ b/source/_integrations/habitica.markdown
@@ -135,7 +135,7 @@ The following {% term calendars %} will be created:
 
 ## Button controls for class skills
 
-If you've unlocked the class system, button controls for casting player and party skills will become available, depending on the class you've selected. For task skills see [action `habitica.cast_skill`](#action-habiticacast_skill)
+If you've unlocked the class system, button controls for casting player and party skills will become available, depending on the class you've selected. For task skills see [action `habitica.cast_skill`](#action-cast-skill)
 
 ### Mage
 

--- a/source/_integrations/moehlenhoff_alpha2.markdown
+++ b/source/_integrations/moehlenhoff_alpha2.markdown
@@ -46,11 +46,11 @@ changes.
 
 This integration supports the following actions (see [Climate](/integrations/climate/)).
 
-- [`set_temperature`](/integrations/climate/#action-climateset_temperature)
-- [`set_hvac_mode`](/integrations/climate/#action-climateset_hvac_mode)
+- [`set_temperature`](/integrations/climate/#action-set-temperature)
+- [`set_hvac_mode`](/integrations/climate/#action-set-hvac-mode)
   - `heat` for heating mode
   - `cool` for cooling mode
-- [`set_preset_mode`](/integrations/climate/#action-climateset_preset_mode)
+- [`set_preset_mode`](/integrations/climate/#action-set-preset-mode)
   - `auto` enable schedule based operation
   - `day` enable day mode
   - `night` enable night mode

--- a/source/_integrations/music_assistant.markdown
+++ b/source/_integrations/music_assistant.markdown
@@ -76,7 +76,7 @@ If a player provider supports player options, the Music Assistant integration ex
 
 ### Action `music_assistant.play_media`
 
-Play media on a Music Assistant player with more fine-grained control options. This action is more powerful than the [`media_player.play_media`](/integrations/media_player/#action-media_playerplay_media) action because it allows multiple items to be added to the queue at once, it allows more specific control of the media item to be played (e.g. a track from a specific album can be specified) and Music Assistant's radio mode (where the queue is filled with similar tracks to that enqueued) can be enabled.
+Play media on a Music Assistant player with more fine-grained control options. This action is more powerful than the [`media_player.play_media`](/integrations/media_player/#action-play-media) action because it allows multiple items to be added to the queue at once, it allows more specific control of the media item to be played (e.g. a track from a specific album can be specified) and Music Assistant's radio mode (where the queue is filled with similar tracks to that enqueued) can be enabled.
 
 - **Data attribute**: `media_id`
   - **Optional**: No.

--- a/source/_integrations/nordpool.markdown
+++ b/source/_integrations/nordpool.markdown
@@ -57,7 +57,7 @@ All prices are displayed as `[Currency]/kWh`.
 Data is polled from the **Nord Pool** API on an hourly basis, exactly on the hour, to ensure the price sensors are displaying the correct price.
 
 If polling cannot happen because of no connectivity or a malfunctioning API, it will wait a retry a few times before failing.
-The user can use the [`homeassistant.update_entity`](homeassistant#action-homeassistantupdate_entity) action to manually try again later, in the case the user has solved the connectivity issue.
+The user can use the [`homeassistant.update_entity`](/integrations/homeassistant/#action-update-entity) action to manually try again later, in the case the user has solved the connectivity issue.
 
 ## Troubleshooting
 

--- a/source/_integrations/palazzetti.markdown
+++ b/source/_integrations/palazzetti.markdown
@@ -50,11 +50,11 @@ the fan speed.
 
 This integration supports the following actions (see [Climate](/integrations/climate/)).
 
-- [`set_temperature`](/integrations/climate/#action-climateset_temperature)
-- [`set_hvac_mode`](/integrations/climate/#action-climateset_hvac_mode)
+- [`set_temperature`](/integrations/climate/#action-set-temperature)
+- [`set_hvac_mode`](/integrations/climate/#action-set-hvac-mode)
   - `heat` for heating mode
   - `off` to turn the stove off
-- [`set_fan_mode`](/integrations/climate/#action-climateset_fan_mode)
+- [`set_fan_mode`](/integrations/climate/#action-set-fan-mode)
   - `0` to `5` increasing fan speeds
   - `High` the highest available fan speed
   - `Auto` let the stove set the optimal fan speed

--- a/source/_integrations/sensibo.markdown
+++ b/source/_integrations/sensibo.markdown
@@ -401,7 +401,7 @@ automation:
 Data is {% term polling polled %} from the **Sensibo** API once every minute for all devices.
 
 If {% term polling %} cannot happen because of no connectivity or a malfunctioning API, it will retry a few times before failing.
-The user can use the [`homeassistant.update_entity`](homeassistant#action-homeassistantupdate_entity) action to manually try again later, in the case the user has solved the connectivity issue.
+The user can use the [`homeassistant.update_entity`](/integrations/homeassistant/#action-update-entity) action to manually try again later, in the case the user has solved the connectivity issue.
 
 ## Troubleshooting
 

--- a/source/_integrations/solaredge.markdown
+++ b/source/_integrations/solaredge.markdown
@@ -210,7 +210,7 @@ mode: single
 Specifically for the module statistics:
 
 - The integration intentionally doesn't create any entities/sensors for module data. All data is only available in statistics. This is because data is often delayed by a couple of hours.
-- The statistics are intentionally updated infrequently (every 12 hours). If you want more frequent updates, you can call the [`homeassistant.reload_config_entry`](/integrations/homeassistant/#action-homeassistantreload_config_entry) action from an automation.
+- The statistics are intentionally updated infrequently (every 12 hours). If you want more frequent updates, you can call the [`homeassistant.reload_config_entry`](/integrations/homeassistant/#action-reload-config-entry) action from an automation.
 - The API provides data at a 15-minute interval, but Home Assistant long-term statistics are limited to a 1-hour interval. The integration aggregates the 15-minute data into hourly statistics.
 
 ## Removing the integration

--- a/source/_integrations/spotify.markdown
+++ b/source/_integrations/spotify.markdown
@@ -136,7 +136,7 @@ The Spotify API cannot initiate playback to a device not already known to the Sp
 ## Playing Spotify playlists
 
 You can send playlists to Spotify using the `"media_content_type": "playlist"`, which is part of the
-[media_player.play_media](/integrations/media_player/#action-media_playerplay_media) action, for example:
+[media_player.play_media](/integrations/media_player/#action-play-media) action, for example:
 
 ```yaml
 # Example script to play playlist

--- a/source/_integrations/unifiprotect.markdown
+++ b/source/_integrations/unifiprotect.markdown
@@ -520,7 +520,7 @@ actions:
     action: notify.mobile_app_your_device # Replace with your notification target
 ```
 
-You can obtain the `nfc_id` using the [Action unifiprotect.get_user_keyring_info](#action-unifiprotectget_user_keyring_info).
+You can obtain the `nfc_id` using the [Action unifiprotect.get_user_keyring_info](#action-get-user-keyring-info).
 
 {% warning %}
 When processing NFC scans, always validate the scanned ID. Unknown NFC cards also trigger the scan event. Additionally, this event was developed using third-party cards, as the developer did not have access to official UniFi cards at the time. With third-party cards, the scan relies on the card's serial number. While this approach is not uncommon, it is essential to note that the card's serial number is generally not considered a secure identifier and can be duplicated relatively easily. When the device becomes unavailable and becomes available again in Home Assistant, repeated event processing can occur. The state change is not an issue with the integration but should be considered, mainly if the device is used for actions such as unlocking doors.
@@ -535,7 +535,7 @@ When processing NFC scans, always validate the scanned ID. Unknown NFC cards als
   - **ulp_id**: The ID used to identify the person. If no fingerprint match is found, the `ulp_id` will be empty and the `event_type` will be `not_identified`.
 - **Description**: This event is triggered when a fingerprint is scanned by a compatible device. If the fingerprint is recognized, it provides a `ulp_id`, which represents the internal user ID. If the fingerprint is not recognized, the `event_type` will be set to `not_identified`, and no `ulp_id` will be provided.
 
-You can obtain the `ulp_id` using the [Action unifiprotect.get_user_keyring_info](#action-unifiprotectget_user_keyring_info).
+You can obtain the `ulp_id` using the [Action unifiprotect.get_user_keyring_info](#action-get-user-keyring-info).
 
 #### Example G4 Doorbell Fingerprint Identified Automation
 

--- a/source/_integrations/vicare.markdown
+++ b/source/_integrations/vicare.markdown
@@ -116,7 +116,7 @@ The following actions of the [water_heater integration](/integrations/water_heat
 
 ### Action: Set ViCare mode
 
-The `vicare.set_vicare_mode` action sets the mode for the climate device as defined by Viessmann (see [set_hvac_mode](#action-climateset_hvac_mode) for a mapping to Home Assistant Climate modes). This allows more fine-grained control of the heating modes.
+The `vicare.set_vicare_mode` action sets the mode for the climate device as defined by Viessmann (see [set_hvac_mode](#action-set-hvac-mode) for a mapping to Home Assistant Climate modes). This allows more fine-grained control of the heating modes.
 
 | Data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |

--- a/source/_integrations/whirlpool.markdown
+++ b/source/_integrations/whirlpool.markdown
@@ -83,11 +83,11 @@ The `whirlpool` climate platform integrates Whirlpool air conditioning systems i
 
 The following actions are also available:
 
-- [**set_hvac_mode**](/integrations/climate/#action-climateset_hvac_mode) (`off`, `heat`, `cool`, `fan_only`)
-- [**target temperature**](/integrations/climate#action-climateset_temperature)
-- [**turn on/off**](/integrations/climate#action-climateturn_on)
-- [**fan mode**](/integrations/climate#action-climateset_fan_mode) (`low`, `medium`, `high`)
-- [**swing mode**](/integrations/climate#action-climateset_swing_mode) (`off`, `horizontal`)
+- [**set_hvac_mode**](/integrations/climate/#action-set-hvac-mode) (`off`, `heat`, `cool`, `fan_only`)
+- [**target temperature**](/integrations/climate/#action-set-temperature)
+- [**turn on/off**](/integrations/climate/#action-turn-on)
+- [**fan mode**](/integrations/climate/#action-set-fan-mode) (`low`, `medium`, `high`)
+- [**swing mode**](/integrations/climate/#action-set-swing-mode) (`off`, `horizontal`)
 
 ### Select
 

--- a/source/_integrations/yeelight.markdown
+++ b/source/_integrations/yeelight.markdown
@@ -263,7 +263,7 @@ The `yeelight.set_color_temp_scene` action changes the light to the specified co
 
 ### Action: Set color flow scene
 
-The `yeelight.set_color_flow_scene` action starts a color flow. Difference between this and [yeelight.start_flow](#action-yeelightstart_flow), this action uses a different Yeelight API call. If the light was off, it will be turned on. There might be some firmware differences in handling complex flows, etc.
+The `yeelight.set_color_flow_scene` action starts a color flow. Difference between this and [yeelight.start_flow](#action-start-flow), this action uses a different Yeelight API call. If the light was off, it will be turned on. There might be some firmware differences in handling complex flows, etc.
 
 | Data attribute    | Optional | Description                                                                                 |
 |---------------------------|----------|---------------------------------------------------------------------------------------------|


### PR DESCRIPTION
## Proposed change

Several integration pages linked to action sections using an outdated anchor format (for example `#action-climateset_temperature`). The target pages (climate, camera, media_player, logger, homeassistant) use the `### Action: Set temperature` heading style, which produces anchors like `#action-set-temperature`. These links were therefore broken and did not scroll to the intended section.

This corrects those anchors across 20 integration pages. Two of them also used a full `https://www.home-assistant.io/...` URL for an internal page, which I changed to a repo-relative link.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards