### PR TITLE
Fix typos and grammar errors in integration documentation

### DIFF
--- a/source/_integrations/androidtv.markdown
+++ b/source/_integrations/androidtv.markdown
@@ -278,7 +278,7 @@ ________________
 Key|Description
 ---|-----------
 "BLUE"|Blue
-"GREEN"Green
+"GREEN"|Green
 "YELLOW"|Yellow
 "RED"|Red
 _____________

--- a/source/_integrations/bayesian.markdown
+++ b/source/_integrations/bayesian.markdown
@@ -147,7 +147,7 @@ binary_sensor:
   name: "in_bed"
   unique_id: "172b6ef1-e37e-4f04-8d64-891e84c02b43" # generated on https://www.uuidgenerator.net/
   prior: 0.25 # I spend 6 hours a day in bed 6hr/24hr is 0.25 
-  probability_threshold: 0.8 # I am going to be using this sensor to turn out the lights so I only want to to activate when I am sure
+  probability_threshold: 0.8 # I am going to be using this sensor to turn out the lights so I only want to activate when I am sure
   observations:
     - platform: "state"
       entity_id: "sensor.living_room_motion"

--- a/source/_integrations/enphase_envoy.markdown
+++ b/source/_integrations/enphase_envoy.markdown
@@ -257,7 +257,7 @@ When used with [multiphase CT phase data](#ct-aggregate-and-phase-data), disable
 
 #### Grid Balanced import/export sensor entities
 
-When the Envoy metered is equipped with a [total-consumption CT](#current-transformers) instead of a [net-consumption CT](#current-transformers), no grid import and export measurements are available. The Envoy calculates a balance of grid import and export in one of its endpoint reports. These balanced power and energy entities are available, disabled by default.
+When the Envoy Metered is equipped with a [total-consumption CT](#current-transformers) instead of a [net-consumption CT](#current-transformers), no grid import and export measurements are available. The Envoy calculates a balance of grid import and export in one of its endpoint reports. These balanced power and energy entities are available, disabled by default.
 
 The used endpoint is not in the official API documentation and data quality has varied / may vary with firmware evolutions.
 

--- a/source/_integrations/enphase_envoy.markdown
+++ b/source/_integrations/enphase_envoy.markdown
@@ -257,7 +257,7 @@ When used with [multiphase CT phase data](#ct-aggregate-and-phase-data), disable
 
 #### Grid Balanced import/export sensor entities
 
-When the Envoy metered is equipped with a a [total-consumption CT](#current-transformers) instead of a [net-consumption CT](#current-transformers), no grid import and export measurements are available. The Envoy calculates a balance of grid import and export in one of its endpoint reports. These balanced power and energy entities are available, disabled by default.
+When the Envoy metered is equipped with a [total-consumption CT](#current-transformers) instead of a [net-consumption CT](#current-transformers), no grid import and export measurements are available. The Envoy calculates a balance of grid import and export in one of its endpoint reports. These balanced power and energy entities are available, disabled by default.
 
 The used endpoint is not in the official API documentation and data quality has varied / may vary with firmware evolutions.
 

--- a/source/_integrations/frontier_silicon.markdown
+++ b/source/_integrations/frontier_silicon.markdown
@@ -15,7 +15,7 @@ ha_ssdp: true
 ha_config_flow: true
 ---
 
-This {% term integration %} provides support for Internet Radios based on the [Frontier Silicon chipset]. Some of the manufacturers which offer products based on these chips include: Hama, Medion, Slivercrest, Auna, Technisat, Revo, Pinnel, etc. These devices will be usually controlled by the OKTIV or UNDOK apps.
+This {% term integration %} provides support for Internet Radios based on the [Frontier Silicon chipset]. Some of the manufacturers which offer products based on these chips include: Hama, Medion, Silvercrest, Auna, Technisat, Revo, Pinell, etc. These devices will be usually controlled by the OKTIV or UNDOK apps.
 
 ## Supported models
 

--- a/source/_integrations/frontier_silicon.markdown
+++ b/source/_integrations/frontier_silicon.markdown
@@ -15,7 +15,7 @@ ha_ssdp: true
 ha_config_flow: true
 ---
 
-This {% term integration %} provides support for Internet Radios based on the [Frontier Silicon chipset]. Some of the manufacturers which offer products based on these chips include: Hama, Medion, Silvercrest, Auna, Technisat, Revo, Pinell, etc. These devices will be usually controlled by the OKTIV or UNDOK apps.
+This {% term integration %} provides support for Internet Radios based on the [Frontier Silicon chipset]. Some manufacturers that offer products based on these chips include Hama, Medion, Silvercrest, Auna, TechniSat, Revo, and Pinell. These devices are usually controlled with the OKTIV or UNDOK apps.
 
 ## Supported models
 

--- a/source/_integrations/profiler.markdown
+++ b/source/_integrations/profiler.markdown
@@ -104,7 +104,7 @@ The `profiler.start_log_object_sources` action starts logging the growth of obje
 | `scan_interval`        | yes      | The frequency between logging objects. Defaults to 30.0                |
 | `max_objects`          | yes      | The number of new objects to examine for source information. Defaults to 5 |
 
-Periodically log the growth of new objects in memory. This actions's primary use case is finding memory leaks.
+Periodically log the growth of new objects in memory. This action's primary use case is finding memory leaks.
 
 This action is similar to `start_log_objects` except that it is much more CPU intensive since it will attempt to locate the source of each new object up to `max_objects` each time it logs.
 

--- a/source/_integrations/profiler.markdown
+++ b/source/_integrations/profiler.markdown
@@ -81,7 +81,7 @@ The `profiler.start_log_objects` action starts logging the growth of objects in 
 
 | Data attribute | Optional | Description                                                 |
 | ---------------------- | -------- | ----------------------------------------------------------- |
-| `scan_interval`        | yes      | The the frequency between logging objects. Defaults to 30.0 |
+| `scan_interval`        | yes      | The frequency between logging objects. Defaults to 30.0 |
 
 Periodically log the growth of new objects in memory. This action's primary use case is finding memory leaks. This action can be run for long periods to find slow leaks. For finding fast leaks, `profiler.start_log_object_sources` is preferred; however, it is much more CPU intensive.
 
@@ -101,7 +101,7 @@ The `profiler.start_log_object_sources` action starts logging the growth of obje
 
 | Data attribute | Optional | Description                                                                |
 | ---------------------- | -------- | -------------------------------------------------------------------------- |
-| `scan_interval`        | yes      | The the frequency between logging objects. Defaults to 30.0                |
+| `scan_interval`        | yes      | The frequency between logging objects. Defaults to 30.0                |
 | `max_objects`          | yes      | The number of new objects to examine for source information. Defaults to 5 |
 
 Periodically log the growth of new objects in memory. This actions's primary use case is finding memory leaks.

--- a/source/_integrations/proxmoxve.markdown
+++ b/source/_integrations/proxmoxve.markdown
@@ -207,7 +207,7 @@ To create a token:
 ### Buttons not working
 
 If you want to use the `button` entities to perform actions on your node(s), additional privileges may be required:
-- For actions related to power, such as start, stop or reboot, the Proxmox VE user must have the power-management privilege `VM.PowerMgmt`, or role `PVEVMUser`.
+- For actions related to power, such as start, stop, or reboot, the Proxmox VE user must have the power-management privilege `VM.PowerMgmt`, or role `PVEVMUser`.
 - To create snapshots, the privilege `VM.Snapshot` is required, or role `PVEVMAdmin`.
 If monitoring works (e.g. sensors provide relevant information) but button presses fail, assign a more permissive role or create a custom role and try again.
 

--- a/source/_integrations/proxmoxve.markdown
+++ b/source/_integrations/proxmoxve.markdown
@@ -207,7 +207,7 @@ To create a token:
 ### Buttons not working
 
 If you want to use the `button` entities to perform actions on your node(s), additional privileges may be required:
-- For actions related to power, such as start, stop or reboot, the Proxmox VE user must have the power-management privilege `VM.PowerManagemt`, or role `PVEVMUser`.
+- For actions related to power, such as start, stop or reboot, the Proxmox VE user must have the power-management privilege `VM.PowerMgmt`, or role `PVEVMUser`.
 - To create snapshots, the privilege `VM.Snapshot` is required, or role `PVEVMAdmin`.
 If monitoring works (e.g. sensors provide relevant information) but button presses fail, assign a more permissive role or create a custom role and try again.
 

--- a/source/_integrations/rfxtrx.markdown
+++ b/source/_integrations/rfxtrx.markdown
@@ -178,7 +178,7 @@ Some protocols, like `undecoded`, cannot be enabled in non-volatile memory and m
 To configure device options, select a device from the list under *Select device to configure*. After pressing *Submit* a window with device options are presented based on the device type.
 
 {% important %}
-If a device is missing from the list, close the options window and either make sure the device sents a command or manually re-add the device by event code.
+If a device is missing from the list, close the options window and either make sure the device sends a command or manually re-add the device by event code.
 {% endimportant %}
 
 #### Off delay

--- a/source/_integrations/rfxtrx.markdown
+++ b/source/_integrations/rfxtrx.markdown
@@ -175,7 +175,7 @@ Some protocols, like `undecoded`, cannot be enabled in non-volatile memory and m
 
 ### Configure device options
 
-To configure device options, select a device from the list under *Select device to configure*. After pressing *Submit* a window with device options are presented based on the device type.
+To configure device options, select a device from the list under *Select device to configure*. After pressing *Submit*, a window with device options is presented based on the device type.
 
 {% important %}
 If a device is missing from the list, close the options window and either make sure the device sends a command or manually re-add the device by event code.

--- a/source/_integrations/roku.markdown
+++ b/source/_integrations/roku.markdown
@@ -108,7 +108,7 @@ The following commands are currently supported depending on device type and manu
 - volume_mute
 - volume_up
 
-Strings can be be typed by using the command `Lit_STRING` (e.g. `Lit_example` will type "example"). Punctuation and spaces are allowed in the string.
+Strings can be typed by using the command `Lit_STRING` (e.g. `Lit_example` will type "example"). Punctuation and spaces are allowed in the string.
 
 ##### Example
 

--- a/source/_integrations/siren.mqtt.markdown
+++ b/source/_integrations/siren.mqtt.markdown
@@ -81,7 +81,7 @@ command_off_template:
   type: template
 command_topic:
   description: >
-    The MQTT topic to publish commands to change the siren state. Without command templates, a default JSON payload like `{"state":"ON", "tone": "bell", "duration": 10, "volume_level": 0.5 }` is published. When the siren turn on action is performed, the startup parameters will be added to the JSON payload. The `state` value of the JSON payload will be set to the the `payload_on` or `payload_off` configured payload.
+    The MQTT topic to publish commands to change the siren state. Without command templates, a default JSON payload like `{"state":"ON", "tone": "bell", "duration": 10, "volume_level": 0.5 }` is published. When the siren turn on action is performed, the startup parameters will be added to the JSON payload. The `state` value of the JSON payload will be set to the `payload_on` or `payload_off` configured payload.
   required: false
   type: string
 default_entity_id:

--- a/source/_integrations/synology_dsm.markdown
+++ b/source/_integrations/synology_dsm.markdown
@@ -191,4 +191,4 @@ In any case, when reporting an issue, please enable [debug logging](/docs/config
 
 {% include integrations/remove_device_service.md %}
 
-If you don't use the separate created user anymore (_see [Separate User Configuration](#separate-user-configuration) above_), then remove it from the NAS under to **Control Panel** > **User & Group** > **User**. Don't forget to backup any data from the users home directory, if you want to keep them (_eq. Home Assistant backups_)
+If you don't use the separate created user anymore (_see [Separate User Configuration](#separate-user-configuration) above_), then remove it from the NAS under **Control Panel** > **User & Group** > **User**. Don't forget to back up any data from the user's home directory, if you want to keep it (_for example, Home Assistant backups_).

--- a/source/_integrations/unifi.markdown
+++ b/source/_integrations/unifi.markdown
@@ -152,7 +152,7 @@ This platform allows you to detect presence by looking at devices connected to a
 
 ### Troubleshooting and Time Synchronization
 
-If tracked devices continue to show "Home" when not connected/present and show connected in the UniFi Controller, disable 802.11r Fast Roaming.  When enabled, it has been observed on the various UniFi Controller versions, failure to declare disconnected clients.
+If tracked devices continue to show "Home" when not connected/present and show connected in the UniFi Controller, disable 802.11r Fast Roaming. When enabled, various UniFi Controller versions have been observed to fail to declare clients disconnected.
 
 Presence detection is not compatible with Client MAC Address Randomization, enabled by default on most modern SmartPhones. This feature will need to be disabled within the client device settings, usually under the settings for the specific network.
 

--- a/source/_integrations/unifi.markdown
+++ b/source/_integrations/unifi.markdown
@@ -140,7 +140,7 @@ Use the **Power cycle PoE** button entity to power cycle one specific PoE port t
 Use the **Restart UniFi device** button entity to restart the entire UniFi device. In case the device is a PoE switch, the PoE supply is not affected.
 
 ### WLAN regenerate password
-Use the **WLAN regenerate password** button entity to generate and apply a new password to the specified WLAN (Wireless Local Area Network). Use the **WLAN regenerate password** button entity to generate and apply a new password to the specified WLAN (Wireless Local Area Network). **It will be randomly generated with 20 characters, consisting of lowercase letters, uppercase letters, and digits.**
+Use the **WLAN regenerate password** button entity to generate and apply a new password to the specified WLAN (Wireless Local Area Network). **It will be randomly generated with 20 characters, consisting of lowercase letters, uppercase letters, and digits.**
 
 ## Image
 
@@ -152,7 +152,7 @@ This platform allows you to detect presence by looking at devices connected to a
 
 ### Troubleshooting and Time Synchronization
 
-If tracked devices continue to show "Home" when not connect/present and show connected in the UniFi Controller, disable 802.11r Fast Roaming.  When enabled, it has been observed on the various UniFi Controller versions, failure to declare disconnected clients.
+If tracked devices continue to show "Home" when not connected/present and show connected in the UniFi Controller, disable 802.11r Fast Roaming.  When enabled, it has been observed on the various UniFi Controller versions, failure to declare disconnected clients.
 
 Presence detection is not compatible with Client MAC Address Randomization, enabled by default on most modern SmartPhones. This feature will need to be disabled within the client device settings, usually under the settings for the specific network.
 


### PR DESCRIPTION
## Proposed change

Corrects a batch of clear typos and grammar errors across several integration pages. These are all small correctness fixes:

- `androidtv`: fixed a broken table cell (`"GREEN"Green` was missing the column separator).
- `unifi`: removed a fully duplicated sentence and fixed `not connect/present` to `not connected/present`.
- `synology_dsm`: removed a stray `to`, fixed `users` to `user's`, `backup` (verb) to `back up`, and `eq.` to `for example`.
- `proxmoxve`: corrected the Proxmox privilege name `VM.PowerManagemt` to `VM.PowerMgmt`.
- `rfxtrx`: `sents` to `sends`.
- `frontier_silicon`: brand spellings `Slivercrest` to `Silvercrest` and `Pinnel` to `Pinell` (both contradicted spellings used elsewhere on the same page).
- `roku`, `siren.mqtt`, `enphase_envoy`, `profiler`, `bayesian`: removed doubled words (`be be`, `the the`, `a a`, `The the`, `to to`).

## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards