### PR TITLE
Fix grammar and terminology issues in integration docs

### DIFF
--- a/source/_integrations/airzone_cloud.markdown
+++ b/source/_integrations/airzone_cloud.markdown
@@ -39,7 +39,7 @@ These devices are Wi-Fi controllers that are normally connected to a single air 
 
 These devices are connected to ducted air conditioners, motorized grilles, and individual thermostats for every room (zone). Therefore, with a single ducted air conditioning system, the user can turn on and off the air conditioner and set different desired temperatures in each room.
 
-A typical Airzone HVAC system consists of a parent device (called *master zone* in Airzone terminology) and child devices (called *slave zones* in Airzone terminology). The [HVAC mode](/integrations/climate/#action-set-hvac-mode) can only be changed on the parent device. On child devices, you can only enable or disable the HVAC and adjust the desired temperature for that specific device.
+A typical Airzone HVAC system consists of a parent device and child devices. The [HVAC mode](/integrations/climate/#action-set-hvac-mode) can only be changed on the parent device. On child devices, you can only enable or disable the HVAC and adjust the desired temperature for that specific device.
 
 Note that multiple HVAC systems can be connected to the same Airzone web server. In this case, there will be one *parent zone* per HVAC system and there may also be *child zones* for each HVAC system.
 

--- a/source/_integrations/ambient_network.markdown
+++ b/source/_integrations/ambient_network.markdown
@@ -21,7 +21,7 @@ Similar to the [Ambient Weather Station](/integrations/ambient_station/)
 integration, this integration gathers sensor data from individual weather stations.
 However, in contrast to the [Ambient Weather Station](/integrations/ambient_station/)
 integration, which exclusively enables owners to fetch data solely from their owned stations, this
-integration directly pulls public data from <https://ambientweather.net> without requiring an API key,
+integration directly pulls public data from the [Ambient Weather Network](https://ambientweather.net) without requiring an API key,
 albeit with a reduced dataset (for example, excluding indoor sensors).
 
 {% include integrations/config_flow.md %}

--- a/source/_integrations/braviatv.markdown
+++ b/source/_integrations/braviatv.markdown
@@ -214,7 +214,7 @@ See [Using with Google Cast](#using-with-google-cast) section for more details.
 
 ### Power consumption ~15 W when the TV in standby mode while integration is enabled
 
-The Bravia TV is [local pulling integration](/blog/2016/02/12/classifying-the-internet-of-things/#polling-the-local-device). Even if the TV is turned off, its status is constantly polled to determine the current state, so the TV's network interface remains enabled. This is normal behavior. If you are concerned about this, you can disable polling for updates in the integration **System options** menu, but the TV status will no longer update automatically and you will have to force the {% term entity %} update by calling `homeassistant.update_entity` {% term action %} manually.
+The Bravia TV is [local polling integration](/blog/2016/02/12/classifying-the-internet-of-things/#polling-the-local-device). Even if the TV is turned off, its status is constantly polled to determine the current state, so the TV's network interface remains enabled. This is normal behavior. If you are concerned about this, you can disable polling for updates in the integration **System options** menu, but the TV status will no longer update automatically and you will have to force the {% term entity %} update by calling `homeassistant.update_entity` {% term action %} manually.
 
 Please note that this behavior can be caused not only by the integration, but also by some applications installed on the TV.
 

--- a/source/_integrations/motionblinds_ble.markdown
+++ b/source/_integrations/motionblinds_ble.markdown
@@ -50,7 +50,7 @@ The following entities are available for a Motionblinds Bluetooth device:
   -  Speed select: allows you to change the speed of the motor to low, medium, or high. Available for all blinds except curtain blinds and vertical blinds.
 - [Sensor](/integrations/sensor/) entities:
   -  Battery sensor: shows the battery percentage. The icon also reflects whether the motor is currently charging and/or whether the motor is wired and, therefore, does not have a battery.
-  Calibration sensor: shows whether the blind is still calibrated. The motor can move to an uncalibrated state when it has been moved to a different position while not powered. This sensor is available for curtain blinds and vertical blinds, as these can be moved while not powered.
+  -  Calibration sensor: shows whether the blind is still calibrated. The motor can move to an uncalibrated state when it has been moved to a different position while not powered. This sensor is available for curtain blinds and vertical blinds, as these can be moved while not powered.
   -  Connection sensor: shows whether the blind is connected, disconnected, connecting, or disconnecting.
   -  Signal strength sensor: shows the signal strength in dBm.
 

--- a/source/_integrations/notify.markdown
+++ b/source/_integrations/notify.markdown
@@ -65,7 +65,7 @@ With any of these integrations, the `message` data input in the automation edito
 
 Be aware that the `notify.notify` action is shorthand for the first notify action the system can find. It might not work as intended. Choose a specific action to make sure your message goes to the right place.
 
-Notifications can also be sent using [Notify groups](/integrations/group/#notify-groups). These allow you to send notification to multiple devices with a single call, or to update which device is notified by only changing it in a single place.
+Notifications can also be sent using [Notify groups](/integrations/group/#notify-groups). These allow you to send notifications to multiple devices with a single call, or to update which device is notified by only changing it in a single place.
 
 ### Test if it works
 

--- a/source/_integrations/nuki_matter.markdown
+++ b/source/_integrations/nuki_matter.markdown
@@ -22,7 +22,7 @@ works_with:
 
 ## Setting up your Nuki via Matter integrations requires Thread
 
-To use this integration, you need a Thread border router that supports Matter. For more information, refer to the [Thread documentation](/integrations/thread/). You can turn your Home Assistant installation into a Thread border router e.g. by using the Home Assistant [Connect ZBT-1](/connectzbt1/) or [ZBT-2](/connect/zbt-2/). For more information on setting this up, go to [Turning Home Assistant into a Thread border router section](/integrations/thread/#turning-home-assistant-into-a-thread-border-router)
+To use this integration, you need a Thread border router that supports Matter. For more information, refer to the [Thread documentation](/integrations/thread/). You can turn your Home Assistant installation into a Thread border router, for example, by using the Home Assistant [Connect ZBT-1](/connectzbt1/) or [ZBT-2](/connect/zbt-2/). For more information on setting this up, go to the [Turning Home Assistant into a Thread border router section](/integrations/thread/#turning-home-assistant-into-a-thread-border-router).
 
 For more information on setting up Matter with Nuki devices, refer to the [Nuki Matter setup guide](https://help.nuki.io/hc/en-001/articles/14596875392017-Setting-up-your-Matter-integration).
 

--- a/source/_integrations/tts.markdown
+++ b/source/_integrations/tts.markdown
@@ -29,7 +29,7 @@ Text-to-speech (TTS) enables Home Assistant to speak to you.
 
 {% include integrations/building_block_integration.md %}
 
-See all [TTS integrations](/integrations/#text-to-speech) using this building block for ways to use it in your automations. If you are using the Home Assistant voice assistant, [Assist](/voice_control/), Assist is using TTS when replying to you. Another way to use TTS is by using [TTS with Home Assistant Cloud](https://www.nabucasa.com/config/tts/). 
+See all [TTS integrations](/integrations/#text-to-speech) using this building block for ways to use it in your automations. If you are using the Home Assistant voice assistant [Assist](/voice_control/), it uses TTS when replying to you. Another way to use TTS is by using [TTS with Home Assistant Cloud](https://www.nabucasa.com/config/tts/).
 
 ## The state of a text-to-speech entity
 


### PR DESCRIPTION
## Proposed change

Fixes several small issues that surfaced on the lines touched by #45924 (the internal link normalization). This PR is stacked on that branch so the review diff stays focused; it will automatically retarget to `current` once #45924 merges.

Fixes: removes prohibited "master/slave" terminology on the Airzone Cloud page, corrects a "local pulling" to "local polling" typo (Bravia), restores a missing list marker (Motionblinds BLE), replaces "e.g." with plain wording and adds a missing period (Nuki Matter), corrects "notification" to "notifications" (Notify), rewrites an awkward sentence and drops trailing whitespace (TTS), and replaces a bare URL with a descriptive link (Ambient Weather Network).

## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards