### PR TITLE
Normalize internal links to root-relative paths site-wide

### DIFF
--- a/source/_docs/automation/troubleshooting.markdown
+++ b/source/_docs/automation/troubleshooting.markdown
@@ -90,6 +90,6 @@ trace:
 If your automation uses [templates](/docs/templating/) in any part, you can do the following to make sure it works as expected:
 
 1. Go to {% my developer_template title="**Settings** > **Developer tools** > **Template**" %} tab.
-2. Create all variables (sources) required for your template as described at the end of [this](https://www.home-assistant.io/docs/templating/where-to-use/#processing-incoming-data) paragraph.
+2. Create all variables (sources) required for your template as described at the end of [this](/docs/templating/where-to-use/#processing-incoming-data) paragraph.
 3. Copy your template code and paste it in Template editor straight after your variables.
 4. If necessary, change your sources' value and check if the template works as you want and does not generate any errors.

--- a/source/_includes/installation/container.md
+++ b/source/_includes/installation/container.md
@@ -4,7 +4,7 @@
 These below instructions are for an installation of {% term "Home Assistant Container" %} running in your own container environment, which you manage yourself. Any [OCI](https://opencontainers.org/) compatible runtime can be used, however this guide will focus on installing it with Docker.
 
 {% note %}
-This installation type **does not have access to apps**. If you want to use apps, you need to use another installation type. The recommended type is {% term "Home Assistant Operating System" %}. Checkout the [overview table of installation types](https://www.home-assistant.io/installation/#about-installation-types) to see the differences.
+This installation type **does not have access to apps**. If you want to use apps, you need to use another installation type. The recommended type is {% term "Home Assistant Operating System" %}. Checkout the [overview table of installation types](/installation/#about-installation-types) to see the differences.
 {% endnote %}
 
 {% important %}

--- a/source/common-tasks/os.markdown
+++ b/source/common-tasks/os.markdown
@@ -43,7 +43,7 @@ Updates of the {% term "Home Assistant Operating System" %} are independent of o
 
 - [Backup your installation](/common-tasks/general/#backups).
   - Make sure the backup is stored on a [backup location](/common-tasks/general/#defining-backup-locations) outside of the device where Home Assistant is installed.
-    - For example, if Home Assistant is installed on [Home Assistant Green](https://www.home-assistant.io/green), make sure it is stored on [Home Assistant Cloud](/common-tasks/general/#about-the-backup-storage-on-home-assistant-cloud) or another location.
+    - For example, if Home Assistant is installed on [Home Assistant Green](/green), make sure it is stored on [Home Assistant Cloud](/common-tasks/general/#about-the-backup-storage-on-home-assistant-cloud) or another location.
   - So that you can [restore from that backup](/common-tasks/general/#restoring-a-backup) in case there is an issue with the system.
 
 #### To update the Home Assistant Operating System

--- a/source/installation/troubleshooting.markdown
+++ b/source/installation/troubleshooting.markdown
@@ -41,7 +41,7 @@ To resolve this issue, try the following steps:
 7. If you still can’t reach Home Assistant, connect keyboard and monitor to the device Home Assistant is running on to access the console and see where Home Assistant gets stuck.
    - If you are using a Home Assistant Green, follow these steps [to access the console](https://support.nabucasa.com/hc/articles/25153288092829).
    - If you are using a Home Assistant Yellow, follow these steps [to access the console from Windows](https://support.nabucasa.com/hc/articles/25454894609693), or [to access the console from Linux or macOS](https://support.nabucasa.com/hc/articles/25454972435357).
-8. [Reach out to our community for help](https://www.home-assistant.io/help/).
+8. [Reach out to our community for help](/help/).
 
 ## "Error installing Home Assistant"
 
@@ -60,7 +60,7 @@ You are in the onboarding procedure, but you get the message **Error installing 
        - github.com: to update metadata of the Home Assistant app store.
        - ghcr.io: the GitHub container registry to fetch new Home Assistant updates.
 2. After changing your network environment, wait a few minutes. Home Assistant will try to reconnect.
-3. [Reach out to our community for help](https://www.home-assistant.io/help/).
+3. [Reach out to our community for help](/help/).
 
 ## Stuck at "Preparing Home Assistant"
 
@@ -81,4 +81,4 @@ You are in the onboarding procedure, but the process seems stuck at the step **P
        - github.com: to update metadata of the Home Assistant app store.
        - ghcr.io: the GitHub container registry to fetch new Home Assistant updates.
 3. After changing your network environment, wait a few minutes. Home Assistant will try to reconnect.
-4. [Reach out to our community for help](https://www.home-assistant.io/help/).
+4. [Reach out to our community for help](/help/).

--- a/source/more-info/nest-auth-deprecation.markdown
+++ b/source/more-info/nest-auth-deprecation.markdown
@@ -10,19 +10,19 @@ for announcement details.
 
 ## New Users
 
-New users may sign up using *Web Auth* without issue. Follow the [documentation](https://www.home-assistant.io/integrations/nest/) which has been updated to use *Web Auth* and a *My Home Assistant* redirect URL using Home Assistant `2022.6` or newer.
+New users may sign up using *Web Auth* without issue. Follow the [documentation](/integrations/nest/) which has been updated to use *Web Auth* and a *My Home Assistant* redirect URL using Home Assistant `2022.6` or newer.
 
 ## Existing Users: App Auth
 
-If you previously successfully configured Nest and Home Assistant with *App Auth* then follow the instructions for [Deprecated App Auth Credentials](https://www.home-assistant.io/integrations/nest/#deprecated-app-auth-credentials).
+If you previously successfully configured Nest and Home Assistant with *App Auth* then follow the instructions for [Deprecated App Auth Credentials](/integrations/nest/#deprecated-app-auth-credentials).
 
-Nest is now configured entirely from the UI using [Application Credentials](https://www.home-assistant.io/integrations/application_credentials/) and the configuration flow will walk you through the steps of creating new credentials the right way.
+Nest is now configured entirely from the UI using [Application Credentials](/integrations/application_credentials/) and the configuration flow will walk you through the steps of creating new credentials the right way.
 
 You will need to upgrade to *Web Auth* before October to avoid interruption.
 
 ## Existing Users: Web Auth
 
-Users who signed up using *Web Auth* are not affected by the App Auth deprecation. However, as of `2022.6` the *My Home Assistant* URL is now the default redirect URL and may need to be updated in the Google Cloud Console to avoid a `redirect_uri_mismatch` ([more info](https://www.home-assistant.io/integrations/nest/#troubleshooting)).
+Users who signed up using *Web Auth* are not affected by the App Auth deprecation. However, as of `2022.6` the *My Home Assistant* URL is now the default redirect URL and may need to be updated in the Google Cloud Console to avoid a `redirect_uri_mismatch` ([more info](/integrations/nest/#troubleshooting)).
 
 # Background
 

--- a/source/more-info/statistics.markdown
+++ b/source/more-info/statistics.markdown
@@ -5,7 +5,7 @@ description: "More information on if your expected data source is not listed."
 
 You're configuring a statistic but you couldn't find your source in the dropdown?
 
-Check that it hasn't been excluded in the [Recorder](https://www.home-assistant.io/integrations/recorder/) configuration.
+Check that it hasn't been excluded in the [Recorder](/integrations/recorder/) configuration.
 
 Make sure the entity uses the same unit as the already selected sensors for that statistics graph. Because the graph uses a single Y axis, you cannot mix units (for example, °C and %, or kW and W) in the same graph.
 

--- a/source/more-info/unsupported/system_architecture.markdown
+++ b/source/more-info/unsupported/system_architecture.markdown
@@ -7,7 +7,7 @@ description: "More information on why System Architecture marks the installation
 
 Supervisor considers `i386`, `armhf`, and `armv7` (all 32-bit system architectures)
 as unsupported. Home Assistant announced the sunset of these architectures in May 2025
-(see [this blog post for more information](https://www.home-assistant.io/blog/2025/05/22/deprecating-core-and-supervised-installation-methods-and-32-bit-systems/)).
+(see [this blog post for more information](/blog/2025/05/22/deprecating-core-and-supervised-installation-methods-and-32-bit-systems/)).
 On these system architectures, the Supervisor stops refreshing its update
 information. This means you will no longer receive updates for any component,
 including Home Assistant Core or app (formerly known as add-ons) updates.
@@ -21,7 +21,7 @@ continue to receive software updates, including security updates.
 1. To migrate to a supported architecture, [create a full backup](/common-tasks/general/#backups)
 and download it.
 2. Install Home Assistant OS on supported 64-bit hardware. 
-   - Use the [restore from backup feature during onboarding](https://www.home-assistant.io/getting-started/onboarding/) (Option 2).
+   - Use the [restore from backup feature during onboarding](/getting-started/onboarding/) (Option 2).
    - If you use a Raspberry Pi 3 or Raspberry Pi 4, you can install the 64-bit variants
 of Home Assistant OS. 
-      - See the [Raspberry Pi installation documentation](https://www.home-assistant.io/installation/raspberrypi/) for detailed instructions.
+      - See the [Raspberry Pi installation documentation](/installation/raspberrypi/) for detailed instructions.


### PR DESCRIPTION
## Proposed change

Extends the internal-link normalization from #45924 to documentation pages outside `source/_integrations`. Internal links now use root-relative paths (`/path/`) instead of the full `https://www.home-assistant.io/` domain, matching the convention used across the rest of the site.

The intentional full-URL NFC example on the URL-based tag page is left untouched, since that page demonstrates the absolute `https://www.home-assistant.io/tag/{tag}` format.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards