### PR TITLE
Use American English spelling

### DIFF
--- a/source/_integrations/bayesian.markdown
+++ b/source/_integrations/bayesian.markdown
@@ -134,7 +134,7 @@ When configuring these conditional probabilities, define the probability of the 
 
 ## Full examples
 
-These are a number of worked examples which you may find helpful for each of the observation types. Whilst these are YAML examples, UI configurations work in the same way, except that probabilities are expressed in percentages.
+These are a number of worked examples which you may find helpful for each of the observation types. While these are YAML examples, UI configurations work in the same way, except that probabilities are expressed in percentages.
 
 ### State
 

--- a/source/_integrations/deconz.markdown
+++ b/source/_integrations/deconz.markdown
@@ -330,7 +330,7 @@ The Payload consists of an event (`emergency`, `fire`, `invalid_code` or `panic`
 
 The following sensor types are supported:
 
-- Alarm signalling
+- Alarm signaling
 - Fire/Smoke detection
 - Open/Close detection
 - Presence detection

--- a/source/_integrations/geniushub.markdown
+++ b/source/_integrations/geniushub.markdown
@@ -113,7 +113,7 @@ Each such entity has a state attribute that will contain a list of any such issu
           {{ state_attr('sensor.geniushub_errors', 'error_list') }}
 ```
 
-This alert may be useful to see if the CH is being turned on whilst you're on a holiday!
+This alert may be useful to see if the CH is being turned on while you're on a holiday!
 
 ```yaml
 - alias: "GeniusHub CH State Change Alert"

--- a/source/_integrations/kira.markdown
+++ b/source/_integrations/kira.markdown
@@ -24,7 +24,7 @@ There is currently support for the following device types within Home Assistant:
 
 Some models (original Kira and Kira128) can be configured to act as either a sensor or as a remote. They are also able act as both when set to Standalone mode. The wireless models are hardware specific so the receiver can only be integrated as a sensor and the transmitter can only be integrated as a remote.
 
-If you are using two or more Kira devices for point to point IR transfer across your network they can continue to perform this function whilst also acting as a sensor or remote for Home Assistant.
+If you are using two or more Kira devices for point to point IR transfer across your network they can continue to perform this function while also acting as a sensor or remote for Home Assistant.
 
 ## Configuration
 

--- a/source/_integrations/motioneye.markdown
+++ b/source/_integrations/motioneye.markdown
@@ -279,7 +279,7 @@ Browser".
 
 ### Manually Configured Root Directories
 
-Whilst this integration allows drilling down into the media for each camera separately,
+While this integration allows drilling down into the media for each camera separately,
 underneath motionEye is using the directory structure to associate media items to each
 individual camera. Thus if multiple cameras are manually configured to share the same
 root directory, motionEye will return the _combination_ of the media items when any one


### PR DESCRIPTION
## Proposed change

Replaces a few British spellings in integration documentation with their American English equivalents, matching the site's writing style: `whilst` becomes `while` (in the bayesian, motioneye, kira, and geniushub pages) and `signalling` becomes `signaling` (in the deconz page).

Only prose and generic feature-list text was changed. Product names, device feature labels, API values, and example file paths that legitimately use British spelling were left untouched.

## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards