### PR TITLE
Replace bare URLs with descriptive links

### DIFF
--- a/source/_integrations/agent_dvr.markdown
+++ b/source/_integrations/agent_dvr.markdown
@@ -65,7 +65,7 @@ Data attribute | Optional | Description
 
 ## Iframe
 
-- Using the Webpage Card you can embed the Agent DVR viewer directly in Home Assistant. Just point it to <https://www.ispyconnect.com/app/>
+- Using the Webpage Card you can embed the Agent DVR viewer directly in Home Assistant. Just point it to [the Agent DVR web app](https://www.ispyconnect.com/app/)
 
 <p class='img'>
 <img src='/images/screenshots/agent_dvr.jpg' />

--- a/source/_integrations/amberelectric.markdown
+++ b/source/_integrations/amberelectric.markdown
@@ -24,7 +24,7 @@ Using the **Amber Electric** {% term integration %}, customers can go a step fur
 
 To use this {% term integration %}, you will need to generate an API key.
 
-1. Login to your Amber account at: <https://app.amber.com.au>
+1. Log in to your [Amber account](https://app.amber.com.au)
 2. Click _Settings_
 3. Enable _Developer Mode_
 4. Click _Generate API Key_

--- a/source/_integrations/concord232.markdown
+++ b/source/_integrations/concord232.markdown
@@ -16,7 +16,7 @@ ha_quality_scale: legacy
 
 The **Concord232** {% term integration %} provides integration with GE, Interlogix (and other brands) alarm panels that support the RS-232 Automation Control Panel interface module (or have it built in). Supported panels include Concord 4.
 
-To use this platform, you will need to have the external concord232 client and server installed. The server must be running on the device which is connected to the automation module's serial port. The client must be installed on the machine running Home Assistant. These may often be the same machine, but do not have to be. For additional details in setting up and testing the client and server, see <https://github.com/JasonCarter80/concord232>.
+To use this platform, you will need to have the external concord232 client and server installed. The server must be running on the device which is connected to the automation module's serial port. The client must be installed on the machine running Home Assistant. These may often be the same machine, but do not have to be. For additional details in setting up and testing the client and server, see the [concord232 project on GitHub](https://github.com/JasonCarter80/concord232).
 
 There is currently support for the following device types within Home Assistant:
 

--- a/source/_integrations/deconz.markdown
+++ b/source/_integrations/deconz.markdown
@@ -385,7 +385,7 @@ Switches aren't exposed as ordinary entities, see the [deCONZ main integration](
 
 #### deCONZ Daylight Sensor
 
-The deCONZ Daylight sensor is a special sensor built into the deCONZ software since version 2.05.12. It is represented in Home Assistant as a sensor called sensor.daylight. The sensor's state value is a string corresponding to the phase of daylight (descriptions below taken from <https://github.com/mourner/suncalc>, on which the deCONZ implementation is based):
+The deCONZ Daylight sensor is a special sensor built into the deCONZ software since version 2.05.12. It is represented in Home Assistant as a sensor called sensor.daylight. The sensor's state value is a string corresponding to the phase of daylight (descriptions below taken from [SunCalc](https://github.com/mourner/suncalc), on which the deCONZ implementation is based):
 
 | Sensor State  | Description                                                              |
 | ------------- | ------------------------------------------------------------------------ |

--- a/source/_integrations/delijn.markdown
+++ b/source/_integrations/delijn.markdown
@@ -81,4 +81,4 @@ sensor:
 
 ## Custom dashboard card
 
-Works best with the following custom dashboard card: <https://github.com/bollewolle/delijn-card>
+Works best with the following custom dashboard card: [delijn-card](https://github.com/bollewolle/delijn-card)

--- a/source/_integrations/kwb.markdown
+++ b/source/_integrations/kwb.markdown
@@ -19,7 +19,7 @@ The **KWB Easyfire** {% term integration %} integrates the sensors of KWB Easyfi
 
 Direct connection via serial (RS485) or via telnet terminal server is supported. The serial cable has to be attached to the control unit port 25 (which is normally used for detached control terminals).
 
-Since this serial protocol is proprietary and closed, only most temperature sensors and a few control relays are supported, the rest is still WIP (see <https://www.mikrocontroller.net/topic/274137>).
+Since this serial protocol is proprietary and closed, only most temperature sensors and a few control relays are supported, the rest is still WIP (see [this mikrocontroller.net forum thread](https://www.mikrocontroller.net/topic/274137)).
 
 To enable the KWB Easyfire {% term integration %}, add it to your {% term "`configuration.yaml`" %} file.
 {% include integrations/restart_ha_after_config_inclusion.md %}


### PR DESCRIPTION
## Proposed change

Converts bare URLs in the body text of several integration pages into Markdown links with descriptive link text. This follows the documentation style (no bare URLs in body text) and improves readability, accessibility, and SEO through meaningful link text.

Pages updated: agent_dvr, amberelectric, concord232, deconz, delijn, and kwb. On the amberelectric page, `Login` was also corrected to `Log in to` on the same line.

Bare URLs that are intentional (placeholder example URLs to enter, Slack message link syntax, reference tables, and configuration value descriptions) were left untouched.

## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards