### PR TITLE
Use lowercase booleans in YAML examples

### DIFF
--- a/source/_integrations/alarmdecoder.markdown
+++ b/source/_integrations/alarmdecoder.markdown
@@ -130,7 +130,7 @@ Using a combination of the available {% term actions %} and attributes, you can 
         - condition: state
           entity_id: alarm_control_panel.alarm_panel
           attribute: chime
-          state: False
+          state: false
         - action: alarmdecoder.alarm_toggle_chime
           target:
             entity_id: alarm_control_panel.alarm_panel
@@ -140,7 +140,7 @@ Using a combination of the available {% term actions %} and attributes, you can 
         - condition: state
           entity_id: alarm_control_panel.alarm_panel
           attribute: chime
-          state: True
+          state: true
         - action: alarmdecoder.alarm_toggle_chime
           target:
             entity_id: alarm_control_panel.alarm_panel

--- a/source/_integrations/discord.markdown
+++ b/source/_integrations/discord.markdown
@@ -137,9 +137,9 @@ To include messages with embedding, use these attributes underneath the `embed` 
     target: ["1234567890", "0987654321"]
     data:
       verify_ssl: false
-      urls: 
-      - "https://example.com/image.jpg"
-      - "https://example.com/video.mp4"
+      urls:
+        - "https://example.com/image.jpg"
+        - "https://example.com/video.mp4"
 ```
 
 Note that `verify_ssl` defaults to `True`, and that any remote hosts will need to be in your [`allowlist_external_urls`](/integrations/homeassistant/#allowlist_external_urls) list. Discord limits attachment size to 8MB, so anything exceeding this will be skipped and noted in the error log.

--- a/source/_integrations/discord.markdown
+++ b/source/_integrations/discord.markdown
@@ -136,7 +136,7 @@ To include messages with embedding, use these attributes underneath the `embed` 
     message: "A message from Home Assistant"
     target: ["1234567890", "0987654321"]
     data:
-      verify_ssl: False
+      verify_ssl: false
       urls: 
       - "https://example.com/image.jpg"
       - "https://example.com/video.mp4"

--- a/source/_integrations/elkm1.markdown
+++ b/source/_integrations/elkm1.markdown
@@ -193,7 +193,7 @@ auto_configure:
   description: Auto configure `area`, `counter`, `keypad`, `output`, `setting`, `task`, `thermostat`, `plc`, and `zone` by only adding elements that ElkM1 reports on the initial sync.
   required: false
   type: boolean
-  default: False
+  default: false
 area:
   description: Elk areas to include in Home Assistant.
   required: false

--- a/source/_integrations/firmata.markdown
+++ b/source/_integrations/firmata.markdown
@@ -95,12 +95,12 @@ switches:
     initial:
       description: The initial output of the pin after initialization. Note that this is inverted if `negate` is enabled.
       required: false
-      default: False
+      default: false
       type: boolean
     negate:
       description: Flips the output of the digital pin
       required: false
-      default: False
+      default: false
       type: boolean
 lights:
   description: PWM/Analog outputs to configure
@@ -154,7 +154,7 @@ binary_sensors:
     negate:
       description: Flips the input of the digital or analog pin
       required: false
-      default: False
+      default: false
       type: boolean
 sensors:
   description: Analog input to configure

--- a/source/_integrations/generic_hygrostat.markdown
+++ b/source/_integrations/generic_hygrostat.markdown
@@ -141,6 +141,6 @@ generic_hygrostat:
       minutes: 3
     initial_state: true
     away_humidity: 35
-    away_fixed: True
+    away_fixed: true
     sensor_stale_duration: 00:15:00
 ```

--- a/source/_integrations/homekit.markdown
+++ b/source/_integrations/homekit.markdown
@@ -74,7 +74,7 @@ homekit:
       switch.bedroom_outlet:
         type: outlet
       camera.back_porch:
-        support_audio: True
+        support_audio: true
       sensor.some_co_sensor:
         co_threshold: 1000
       sensor.some_co2_sensor:

--- a/source/_integrations/homematicip_cloud.markdown
+++ b/source/_integrations/homematicip_cloud.markdown
@@ -318,7 +318,7 @@ Dump the configuration of the Homematic IP Access Point(s).
 actions:
   - action: homematicip_cloud.dump_hap_config
     data:
-      anonymize: True
+      anonymize: true
 ```
 
 Reset energy counter of measuring actuators.
@@ -338,7 +338,7 @@ Enable (or disable) Cooling mode for the entire home. Disabling Cooling mode wil
 actions:
   - action: homematicip_cloud.set_home_cooling_mode
     data:
-      cooling: True
+      cooling: true
       accesspoint_id: 3014xxxxxxxxxxxxxxxxxxxx
 ```
 

--- a/source/_integrations/imap.markdown
+++ b/source/_integrations/imap.markdown
@@ -437,7 +437,7 @@ template:
         event_type: "imap_content"
         id: "custom_event"
         event_data:
-          custom: True
+          custom: true
     sensor:
       - name: event filtered by template
         state: '{{ trigger.event.data["subject"] }}'

--- a/source/_integrations/nilu.markdown
+++ b/source/_integrations/nilu.markdown
@@ -142,7 +142,7 @@ Example where the sensors are also added to the map.
 # Additionally adds the sensors to the map.
 air_quality:
   - platform: nilu
-    show_on_map: True
+    show_on_map: true
 ```
 
 Example of a specific station.

--- a/source/_integrations/notify.rest.markdown
+++ b/source/_integrations/notify.rest.markdown
@@ -38,7 +38,7 @@ verify_ssl:
   description: Verify the SSL certificate of the endpoint.
   required: false
   type: boolean
-  default: True
+  default: true
 authentication:
   description:  Type of the HTTP authentication. `basic` or `digest`.
   required: false

--- a/source/_integrations/quantum_gateway.markdown
+++ b/source/_integrations/quantum_gateway.markdown
@@ -48,7 +48,7 @@ ssl:
   description: Use HTTPS when connecting to gateway. New firmware may require HTTPS while older may require this to be False.
   required: false
   type: boolean
-  default: True
+  default: true
 {% endconfiguration %}
 
 See the [device tracker integration page](/integrations/device_tracker/) for instructions how to configure the people to be tracked.

--- a/source/_integrations/rest.markdown
+++ b/source/_integrations/rest.markdown
@@ -135,7 +135,7 @@ verify_ssl:
   description: Whether to verify the SSL certificate of the endpoint.
   required: false
   type: boolean
-  default: True
+  default: true
 ssl_cipher_list:
   description: The list of SSL ciphers to be accepted from this endpoint. `python_default` (_default_), `modern` or `intermediate` (_inspired by [Mozilla Security/Server Side TLS](https://wiki.mozilla.org/Security/Server_Side_TLS)_).
   required: false

--- a/source/_integrations/rflink.markdown
+++ b/source/_integrations/rflink.markdown
@@ -410,7 +410,7 @@ devices:
         fire_event:
           description: Fire a `button_pressed` event if this device is turned on or off.
           required: false
-          default: False
+          default: false
           type: boolean
         signal_repetitions:
           description: The number of times every RFLink command should repeat.
@@ -578,7 +578,7 @@ device_defaults:
     fire_event:
       description: Set default `fire_event` for RFLink switch devices (see below).
       required: false
-      default: False
+      default: false
       type: boolean
     signal_repetitions:
       description: Set default `signal_repetitions` for RFLink switch devices (see below).
@@ -876,7 +876,7 @@ device_defaults:
     fire_event:
       description: Set default `fire_event` for RFLink switch devices (see below).
       required: false
-      default: False
+      default: false
       type: boolean
     signal_repetitions:
       description: Set default `signal_repetitions` for RFLink switch devices (see below).

--- a/source/_integrations/scrape.markdown
+++ b/source/_integrations/scrape.markdown
@@ -73,7 +73,7 @@ verify_ssl:
   description: Verify the SSL certificate of the endpoint.
   required: false
   type: boolean
-  default: True
+  default: true
 timeout:
   description: Defines max time to wait data from the endpoint.
   required: false

--- a/source/_integrations/sensor.rest.markdown
+++ b/source/_integrations/sensor.rest.markdown
@@ -154,7 +154,7 @@ verify_ssl:
   description: Verify the SSL certificate of the endpoint.
   required: false
   type: boolean
-  default: True
+  default: true
 {% endconfiguration %}
 
 {% important %}

--- a/source/_integrations/serial.markdown
+++ b/source/_integrations/serial.markdown
@@ -65,17 +65,17 @@ stopbits:
 xonxoff:
   description: Enable software flow control.
   required: false
-  default: False
+  default: false
   type: boolean
 rtscts:
   description: Enable hardware (RTS/CTS) flow control.
   required: false
-  default: False
+  default: false
   type: boolean
 dsrdtr:
   description: Enable hardware (DSR/DTR) flow control.
   required: false
-  default: False
+  default: false
   type: boolean
 value_template:
   description: "Defines a [template](/docs/templating/where-to-use/#processing-incoming-data) to extract a value from the serial line."

--- a/source/_integrations/stookwijzer.markdown
+++ b/source/_integrations/stookwijzer.markdown
@@ -58,16 +58,16 @@ The response data field contains the `forecast` field.
 forecast:
   - datetime: "2025-02-12T17:00:00+01:00"
     advice: code_yellow
-    final: True
+    final: true
   - datetime: "2025-02-12T23:00:00+01:00"
     advice: code_yellow
-    final: True
+    final: true
   - datetime: "2025-02-13T05:00:00+01:00"
     advice: code_orange
-    final: False
+    final: false
   - datetime: "2025-02-13T11:00:00+01:00"
     advice: code_red
-    final: False
+    final: false
 ```
 
 {% enddetails %}

--- a/source/_integrations/telegram.markdown
+++ b/source/_integrations/telegram.markdown
@@ -447,8 +447,8 @@ actions:
       data:
         parse_mode: html
         message_tag: "example_tag"
-        disable_notification: True
-        disable_web_page_preview: True
+        disable_notification: true
+        disable_web_page_preview: true
         message_thread_id: 123
 ```
 


### PR DESCRIPTION
## Proposed change

Several integration docs had YAML examples using capitalized `True`/`False`. The YAML style guide says to only use lowercase `true`/`false`. This lowercases those values across 18 integration pages.

## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards