### PR TITLE
Remove references to removed integrations

### DIFF
--- a/source/_integrations/intent_script.markdown
+++ b/source/_integrations/intent_script.markdown
@@ -11,7 +11,7 @@ ha_codeowners:
   - '@arturpragacz'
 ---
 
-The **Intent Script** integration allows users to configure actions and responses to intents. Intents can be fired by any integration that supports it. Examples are [Alexa](/integrations/alexa/) (Amazon Echo), [Dialogflow](/integrations/dialogflow/) (Google Assistant) and [Snips](/integrations/snips/). Internally they can be fired by [custom sentences](/voice_control/custom_sentences_yaml/).
+The **Intent Script** integration allows users to configure actions and responses to intents. Intents can be fired by any integration that supports it. Examples are [Alexa](/integrations/alexa/) (Amazon Echo) and [Dialogflow](/integrations/dialogflow/) (Google Assistant). Internally they can be fired by [custom sentences](/voice_control/custom_sentences_yaml/).
 
 If you are using intent script with LLMs and have parameters, make sure to mention the parameters and their types in the description.
 

--- a/source/_integrations/rachio.markdown
+++ b/source/_integrations/rachio.markdown
@@ -55,18 +55,6 @@ After setting up the integration, change the options to set the duration in minu
 
 The Rachio smart hose timers are not currently capable of receiving real-time updates. Instead, they rely on polling. Because of this, the current state of valves started from a schedule or the physical button will not show up immediately. Polling occurs every 2 minutes when one base station is used, with an additional minute added for every additional base station to remain with the API rate limit. Up to 4 valves can be paired to a single base station.
 
-### iFrame
-
-If you would like to see and control more detailed zone information, create an [iFrame](/integrations/panel_iframe/) that renders the Rachio web app.
-
-```yaml
-panel_iframe:
-  rachio:
-    title: Rachio
-    url: "https://app.rach.io"
-    icon: mdi:sprinkler-variant
-```
-
 ## Switch
 
 The `rachio` switch platform allows you to toggle zones, valves, and schedules connected to your [Rachio irrigation system](https://rachio.com/) on and off.

--- a/source/_integrations/sensor.rest.markdown
+++ b/source/_integrations/sensor.rest.markdown
@@ -274,7 +274,7 @@ my_sensor_secret_token: Bearer gh_DHQIXKVf6Pr4H8Yqz8uhApk_mnV6Zje6Pr4H8Yqz8A8nCx
 
 ### Use GitHub to get the latest release of Home Assistant
 
-This sample is very similar to the [`updater`](/integrations/updater/) integration but the information is received from GitHub.
+This sample retrieves the latest Home Assistant release information from GitHub.
 
 ```yaml
 sensor:


### PR DESCRIPTION
## Proposed change

The `panel_iframe`, Snips, and `updater` integrations were removed from Home Assistant. Links to them now redirect to a "removed integration" page, and the documentation still showed YAML and examples that no longer work. This removes those stale references:

- `rachio`: removed the iFrame section that documented the `panel_iframe` integration with non-working YAML.
- `intent_script`: dropped Snips from the list of intent-firing integrations.
- `sensor.rest`: reworded the GitHub example intro that compared it to the `updater` integration (the example itself stays).

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards