### PR TITLE
Fix broken internal links in integration docs

### DIFF
--- a/source/_integrations/doods.markdown
+++ b/source/_integrations/doods.markdown
@@ -199,7 +199,7 @@ image_processing:
 
 ## Optimizing resources
 
-The [Image processing integration](/components/image_processing/) processes the image from a camera at a fixed period given by the `scan_interval`. This leads to excessive processing if the image on the camera hasn't changed, as the default `scan_interval` is 10 seconds. You can override this by adding to your configuration `scan_interval: 10000` (setting the interval to 10,000 seconds) and then call the `image_processing.scan` action when you actually want to perform processing.
+The [Image processing integration](/integrations/image_processing/) processes the image from a camera at a fixed period given by the `scan_interval`. This leads to excessive processing if the image on the camera hasn't changed, as the default `scan_interval` is 10 seconds. You can override this by adding to your configuration `scan_interval: 10000` (setting the interval to 10,000 seconds) and then call the `image_processing.scan` action when you actually want to perform processing.
 
 ```yaml
 # Example advanced configuration.yaml entry

--- a/source/_integrations/sleep_as_android.markdown
+++ b/source/_integrations/sleep_as_android.markdown
@@ -201,7 +201,7 @@ The **Sleep as Android** app can be automated through its [Intent API](https://s
 - Start, stop, or pause sleep tracking
 - Stop lullaby playback
 
-Thanks to the **Home Assistant Companion App for Android**, which supports [broadcasting intents](/docs/notifications/notification-commands#broadcast-intent), you can trigger these actions directly from Home Assistant.
+Thanks to the **Home Assistant Companion App for Android**, which supports [broadcasting intents](https://companion.home-assistant.io/docs/notifications/notification-commands#broadcast-intent), you can trigger these actions directly from Home Assistant.
 
 To make this even easier, you can import the following blueprint. It supports nearly all Sleep as Android actions, so you can automate your sleep routine without writing any custom scripts:
 

--- a/source/_integrations/suez_water.markdown
+++ b/source/_integrations/suez_water.markdown
@@ -46,7 +46,7 @@ At the initial setup, the integration pulls historical daily usage since the cou
 
 {% details "Prerequisites" %}
 
-- The Energy dashboard must be enabled in your Home Assistant instance. If you haven't set it up yet, please refer to the [Energy dashboard documentation](/home-assistant-energy/).
+- The Energy dashboard must be enabled in your Home Assistant instance. If you haven't set it up yet, please refer to the [Energy dashboard documentation](/docs/energy/).
 
 {% enddetails %}
 

--- a/source/_integrations/vacuum.markdown
+++ b/source/_integrations/vacuum.markdown
@@ -78,7 +78,7 @@ Start from one small pain point, then decide which vacuum signal kicks things of
 When the vacuum starts a run during a scheduled meeting, pause it automatically so the call stays quiet, then send yourself a reminder to resume the job later.
 
 - **Trigger**: `vacuum.started_cleaning` for the office vacuum.
-- **Conditions**: A calendar or busy [sensor](/docs/core/entity/binary-sensor/) reports that a meeting is in progress, and `vacuum.is_cleaning` confirms the robot is still running.
+- **Conditions**: A calendar or busy [sensor](/integrations/binary_sensor/) reports that a meeting is in progress, and `vacuum.is_cleaning` confirms the robot is still running.
 - **Actions**: `vacuum.pause` to stop the run, followed by a mobile notification that explains why the vacuum paused.
 
 {% details "YAML example for pausing during meetings" %}


### PR DESCRIPTION
## Proposed change

Fixes four internal links in integration documentation that pointed to paths that no longer resolve: the legacy `/components/` path in DOODS, a developer-docs path in Vacuum, a companion-app docs path in Sleep as Android (now a full URL to the companion site), and a non-existent energy docs path in Suez Water. They now point to the correct locations.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards