### PR TITLE
Fix "Devices & services" UI string casing

### DIFF
--- a/source/_integrations/asuswrt.markdown
+++ b/source/_integrations/asuswrt.markdown
@@ -54,7 +54,7 @@ If the integration is configured to use the http(s) protocol, also the following
 - Last boot sensor (Timestamp)
 - Uptime sensor (HH:MM:SS)
 
-By default, the integration will create **enabled** Device Tracker entities for devices that HA already knows about via some other integration. The ASUSWRT integration will create **disabled** device_tracker entities for other devices on the network, and the user can enable them manually in the Home Assistant GUI: go to Settings > Devices & Services > Entities. Filter on Integrations = ASUSWRT. Filter on Status = Disabled. Now you should see the disabled device_tracker entities and you can enable them one at a time as desired.
+By default, the integration will create **enabled** Device Tracker entities for devices that HA already knows about via some other integration. The ASUSWRT integration will create **disabled** device_tracker entities for other devices on the network, and the user can enable them manually in the Home Assistant GUI: go to Settings > Devices & services > Entities. Filter on Integrations = ASUSWRT. Filter on Status = Disabled. Now you should see the disabled device_tracker entities and you can enable them one at a time as desired.
 
 {% include integrations/option_flow.md %}
 {% configuration_basic %}

--- a/source/_integrations/google_drive.markdown
+++ b/source/_integrations/google_drive.markdown
@@ -68,7 +68,7 @@ Send an alert when the drive usage is close to the storage limit and needs clean
 
 {% details "Example YAML configuration" %}
 
-Create an automation with the following code. Remember to replace `your_email_gmail_com` with the actual ID of your sensors (found in **Settings** > **Devices & Services** > **Entities**) and replace `notify.my_device` with your actual notifier.
+Create an automation with the following code. Remember to replace `your_email_gmail_com` with the actual ID of your sensors (found in **Settings** > **Devices & services** > **Entities**) and replace `notify.my_device` with your actual notifier.
 
 ```yaml
 alias: Alert when Google Account is close to storage limit

--- a/source/_integrations/pooldose.markdown
+++ b/source/_integrations/pooldose.markdown
@@ -467,7 +467,7 @@ This integration provides diagnostics to help with debugging and troubleshooting
 - The device information reported by the coordinator with sensitive values redacted.
 - The most recent data fetched from the device by the coordinator.
 
-To collect diagnostics, go to **Settings** > **Devices & Services**, open the PoolDose integration,
+To collect diagnostics, go to **Settings** > **Devices & services**, open the PoolDose integration,
 click the three-dot menu on the integration entry and choose **Download diagnostics**. Attach the downloaded file when reporting issues to help maintainers investigate.
 
 ## Removing the integration

--- a/source/_integrations/ptdevices.markdown
+++ b/source/_integrations/ptdevices.markdown
@@ -73,7 +73,7 @@ The PTDevices integration provides the following entities.
 
 {% note %}
 
-Some sensors are disabled by default because they provide information that is only useful to advanced users. You can manually enable them in {% my entities title="**Settings** > **Devices & Services** > **Entities**" %}> the sensor entity you want to enable > **Advanced settings** > **Enabled**.
+Some sensors are disabled by default because they provide information that is only useful to advanced users. You can manually enable them in {% my entities title="**Settings** > **Devices & services** > **Entities**" %}> the sensor entity you want to enable > **Advanced settings** > **Enabled**.
 
 {% endnote %}
 


### PR DESCRIPTION
## Proposed change

The Home Assistant menu is named **Devices & services**, using sentence-style capitalization. Four integration pages used title case (**Devices & Services**); they now match the actual UI string, consistent with the 130+ other pages that already use the correct casing.

## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards