### PR TITLE
Fix "Developer tools" UI string casing

### DIFF
--- a/source/_integrations/opower.markdown
+++ b/source/_integrations/opower.markdown
@@ -112,7 +112,7 @@ Depending on your utility, some or all of the usage and cost sensors may not be 
 
 The primary way this integration provides historical energy data to Home Assistant is through **statistics**. These statistics are not exposed as standard sensor entities.
 
-Use these statistics when configuring the Energy dashboard by selecting a **statistic**. You can also view the available statistics in **Developer Tools > Statistics**.
+Use these statistics when configuring the Energy dashboard by selecting a **statistic**. You can also view the available statistics in **Developer tools > Statistics**.
 {% endnote %}
 
 The integration adds the following diagnostic sensors for each account:

--- a/source/_integrations/sensibo.markdown
+++ b/source/_integrations/sensibo.markdown
@@ -181,7 +181,7 @@ HVAC mode:
 
 **Proposed action use:**
 
-1. Go to {% my server_controls title="**Settings** > **Developer Tools** > **YAML**" %}.
+1. Go to {% my server_controls title="**Settings** > **Developer tools** > **YAML**" %}.
 2. Switch to the **Actions** page.
 3. Use the `sensibo.get_device_capabilities` action.
 4. Select the `climate` entity as the target.

--- a/source/_integrations/spotify.markdown
+++ b/source/_integrations/spotify.markdown
@@ -131,7 +131,7 @@ data:
   source: "Denon AVR-X2000"
 ```
 
-The Spotify API cannot initiate playback to a device not already known to the Spotify API. The source list of available devices can be found in the Details section of the Spotify Media Player Control and the `source_list` attribute in the {% my developer_states title="**Settings** > **Developer Tools** > **States**" %}.
+The Spotify API cannot initiate playback to a device not already known to the Spotify API. The source list of available devices can be found in the Details section of the Spotify Media Player Control and the `source_list` attribute in the {% my developer_states title="**Settings** > **Developer tools** > **States**" %}.
 
 ## Playing Spotify playlists
 


### PR DESCRIPTION
## Proposed change

The Home Assistant menu is named **Developer tools**, using sentence-style capitalization. Three integration pages referenced it in title case (**Developer Tools**); they now match the actual UI string. External references to AirNow's and the browser's own "Developer Tools" were intentionally left unchanged.

## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards