### PR TITLE
Fix accidental doubled words

### DIFF
--- a/source/_integrations/bayesian.markdown
+++ b/source/_integrations/bayesian.markdown
@@ -167,7 +167,7 @@ binary_sensor:
     - platform: "state"
       entity_id: "sun.sun"
       prob_given_true: 0.7 # If I am in bed then there is a good chance the sun will be down, but in the summer mornings I may still be in bed
-      prob_given_false: 0.45 # If I am am awake then there is a reasonable chance the sun will be below the horizon - especially in winter
+      prob_given_false: 0.45 # If I am awake then there is a reasonable chance the sun will be below the horizon - especially in winter
       to_state: "below_horizon"
     - platform: "state"
       entity_id: "sensor.android_charger_type"

--- a/source/_integrations/google_tasks.markdown
+++ b/source/_integrations/google_tasks.markdown
@@ -95,7 +95,7 @@ Google Tasks to-do list.
 ## Data updates
 
 The Google Tasks integration fetches task lists once initially, and creates a
-to-do list for each task list. Data for each to-do list refreshed refreshed by
+to-do list for each task list. Data for each to-do list is refreshed by
 {% term polling %} every 30 minutes.
 
 Updates to the to-do list in Home Assistant use the Google Tasks API and changes

--- a/source/_integrations/imap.markdown
+++ b/source/_integrations/imap.markdown
@@ -313,7 +313,7 @@ actions:
       message: "{{ message_text['subject'] }}"
 ```
 
-In case you want want to process a message part, use the `fetch_part` action, and specify the `part` option. 
+In case you want to process a message part, use the `fetch_part` action, and specify the `part` option. 
 
 ```yaml
 alias: "imap fetch and seen example"

--- a/source/_integrations/nissan_leaf.markdown
+++ b/source/_integrations/nissan_leaf.markdown
@@ -26,7 +26,7 @@ The **Nissan Leaf** {% term integration %} offers integration with the [NissanCo
 Please be aware that the `nissan_leaf` {% term integration %} only works with Nissan vehicles from before 2019. Newer vehicles will not work with this integration.
 {% endimportant %}
 
-The {% term integration %} offers offers:
+The {% term integration %} offers:
 
 - sensors for the battery status, range and charging status.
 - a switch to start and stop the climate control.

--- a/source/_integrations/tibber.markdown
+++ b/source/_integrations/tibber.markdown
@@ -78,7 +78,7 @@ If you have a Tibber Pulse it will also show the electricity consumption in real
 - net kWh produced since last hour shift
 - Current on L1, L2 and L3
 - Estimate of kWh consumption current hour
-- kWh consumed since since last hour shift
+- kWh consumed since last hour shift
 - Average consumption since midnight (Watt)
 - Last meter active import register state (kWh)
 - Last meter active export register state (kWh)


### PR DESCRIPTION
## Proposed change

Removed accidentally repeated words on five integration pages: "refreshed refreshed" (Google Tasks), "want want" (IMAP), "offers offers" (Nissan Leaf), "since since" (Tibber), and "am am" (Bayesian). The Google Tasks sentence now reads "is refreshed by" so it stays grammatical.

## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards