### PR TITLE
Fix spelling mistakes

### DIFF
--- a/source/_integrations/motion_blinds.markdown
+++ b/source/_integrations/motion_blinds.markdown
@@ -139,14 +139,14 @@ Controlling the two bars can be done through three different entities that will 
 ### Top entity
 
 - 'Up/Open' will move the Top bar to the top of the window (absolute position 100).
-- 'Down/Close' will move the Top bar to the position of the Bottom bar, therefore, making the part of the window that is covered as small as possible, but the two bars will be at the position of the Bottom bar (not at the top of the window). When the bars are moved completly together, the Top bar will not accept another "Down" command. First the Top bar needs to be moved up, even if the Bottom bar already moved further down.
+- 'Down/Close' will move the Top bar to the position of the Bottom bar, therefore, making the part of the window that is covered as small as possible, but the two bars will be at the position of the Bottom bar (not at the top of the window). When the bars are moved completely together, the Top bar will not accept another "Down" command. First the Top bar needs to be moved up, even if the Bottom bar already moved further down.
 - 'Position' is the relative position in which the Top bar can move, so from the top of the window (100) to the position of the Bottom bar (0), note that the position will therefore change if the Bottom bar is moved, since the space in which the Top bar is allowed to move changes.
 - 'Absolute position' is the position of the Top bar with respect to the window, so 0 = bottom of the window and 100 = top of the window. Note that not all absolute positions are reachable at all moments due to the Bottom bar.
 - 'Width' is the percentage of the window covered by fabric (the space between the Top and Bottom bars).
 
 ### Bottom entity
 
-- 'Up/Open' will move the Bottom bar to the position of the Top bar. When the bars are moved completly together, the Bottom bar will not accept another "Up" command. First the Bottom bar needs to be moved down, even if the Top bar already moved further up.
+- 'Up/Open' will move the Bottom bar to the position of the Top bar. When the bars are moved completely together, the Bottom bar will not accept another "Up" command. First the Bottom bar needs to be moved down, even if the Top bar already moved further up.
 - 'Down/Close' will move the Top bar to the bottom of the window (absolute position 0).
 - 'Position' is the relative position in which the Bottom bar can move, so from the position of the Top bar (100) to the bottom of the window (0), note that the position will therefore change if the Top bar is moved, since the space in which the Bottom bar is allowed to move changes.
 - 'Absolute position' is the position of the Bottom bar with respect to the window, so 0 = bottom of the window and 100 = top of the window. Note that not all absolute positions are reachable at all moments due to the Top bar.

--- a/source/_integrations/rainmachine.markdown
+++ b/source/_integrations/rainmachine.markdown
@@ -43,7 +43,7 @@ Note that some entities are disabled by default. If you are missing a sensor or 
 
 The integration has two configuration options: 
 
-1. "Default Zone Run Time": sets a default duration when turning on a zone switch (default: 600 seconds). This can be overriden with an action (see below). 
+1. "Default Zone Run Time": sets a default duration when turning on a zone switch (default: 600 seconds). This can be overridden with an action (see below).
 2. "Use Run Times from App": if enabled, will use the zone-specific run times from the last time the zone was turned on manually in the RainMachine App – this allows you to set per-zone default times using the RainMachine app instead of the same default time for all zones.
 
 ## Actions


### PR DESCRIPTION
## Proposed change

Fixes a few spelling mistakes in integration documentation: "completly" → "completely" on the Motion Blinds page and "overriden" → "overridden" on the RainMachine page.

## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards