### PR TITLE
Use "log in" verb instead of "login" noun

### DIFF
--- a/source/_integrations/alexa.smart_home.markdown
+++ b/source/_integrations/alexa.smart_home.markdown
@@ -218,7 +218,7 @@ This test event is a `Discovery` directive, your Home Assistant instance will re
 
 Click the `Test` button. If you don't have `LONG_LIVED_ACCESS_TOKEN` set, or you haven't enabled `DEBUG` you will get a `INVALID_AUTHORIZATION_CREDENTIAL` response as the execution result.
 
-You can login to your Home Assistant and [generate a long-lived access token][generate-long-lived-access-token]. After you have entered your long-lived access token into the environment variable `LONG_LIVED_ACCESS_TOKEN` and set the `DEBUG` environment variable to `True`, do not forget to click the `Save` button before you `Test` again.
+You can log in to your Home Assistant and [generate a long-lived access token][generate-long-lived-access-token]. After you have entered your long-lived access token into the environment variable `LONG_LIVED_ACCESS_TOKEN` and set the `DEBUG` environment variable to `True`, do not forget to click the `Save` button before you `Test` again.
 
 This time, you will get a list of your devices in the response. 🎉
 

--- a/source/_integrations/anglian_water.markdown
+++ b/source/_integrations/anglian_water.markdown
@@ -32,9 +32,9 @@ The following devices are not supported by the integration:
 
 {% configuration_basic %}
 Username:
-    description: "The username / email used to login to your Anglian Water account."
+    description: "The username / email used to log in to your Anglian Water account."
 Password:
-    description: "The password used to login to your Anglian Water account."
+    description: "The password used to log in to your Anglian Water account."
 Account number:
     description: "If a valid smart meter is not associated with the default billing account linked to your Anglian Water login, please have your latest bill handy. You will be asked to provide the account number found at the top."
 {% endconfiguration_basic %}

--- a/source/_integrations/egardia.markdown
+++ b/source/_integrations/egardia.markdown
@@ -22,7 +22,7 @@ ha_quality_scale: legacy
 
 The **Egardia** {% term integration %} enables the ability to control an [Egardia](https://egardia.com/)/[Woonveilig](https://woonveilig.nl) control panel. These alarm panels are known under different brand names across the world, including Woonveilig in the Netherlands. This was tested on the WL-1716, GATE-01, GATE-02 and GATE-03 versions of the Egardia/Woonveilig platform. Not only will you integrate your alarm control panel, supported sensors (door contacts at this moment) will be added automatically.
 
-You will need to know the IP of your alarm panel on your local network. Test if you can login to the panel by browsing to the IP address and log in using your Egardia/Woonveilig account.
+You will need to know the IP of your alarm panel on your local network. Test if you can log in to the panel by browsing to the IP address and log in using your Egardia/Woonveilig account.
 
 ## Basic configuration
 

--- a/source/_integrations/elkm1.markdown
+++ b/source/_integrations/elkm1.markdown
@@ -178,11 +178,11 @@ host:
   required: true
   type: string
 username:
-  description: Username to login to Elk. Required if using a secure connection method.
+  description: Username to log in to Elk. Required if using a secure connection method.
   required: false
   type: string
 password:
-  description: Password to login to Elk. Required if using a secure connection method.
+  description: Password to log in to Elk. Required if using a secure connection method.
   required: false
   type: string
 prefix:

--- a/source/_integrations/epion.markdown
+++ b/source/_integrations/epion.markdown
@@ -25,7 +25,7 @@ Requires a configured Epion Air device and an Epion account with access to this 
 
 Epion API token setup.
 
-1. Login to [Epion](https://www.epion.nl/).
+1. Log in to [Epion](https://www.epion.nl/).
 2. Select [Integrations](https://epion.nl/dashboard/integrations) in the left menu.
 3. To create a new token, if you don't see one already, select **Generate new Token**.
 4. Copy your generated token. The token is a set of alphanumeric characters separated by hyphens. It starts with "a/".

--- a/source/_integrations/freedns.markdown
+++ b/source/_integrations/freedns.markdown
@@ -16,7 +16,7 @@ With the **FreeDNS** {% term integration %} you can keep your [FreeDNS](https://
 
 You need to determine your update URL or your access token.
 
-1. Head over to the [FreeDNS](https://freedns.afraid.org) website and login to your account.
+1. Head over to the [FreeDNS](https://freedns.afraid.org) website and log in to your account.
 2. Select the menu "Dynamic DNS"
 3. You should now see your update candidates in a table at the bottom of the page.
 4. Copy the link target of the "Direct URL".
@@ -38,7 +38,7 @@ freedns:
 
 You need to determine your update URL or your access token.
 
-1. Head over to the [FreeDNS](https://freedns.afraid.org) website and login to your account.
+1. Head over to the [FreeDNS](https://freedns.afraid.org) website and log in to your account.
 2. Select the menu "Dynamic DNS"
 3. You should now see your update candidates in a table at the bottom of the page.
 4. Head over to page [Version 2](https://freedns.afraid.org/dynamic/v2/), and enable the candidate.

--- a/source/_integrations/fritz.markdown
+++ b/source/_integrations/fritz.markdown
@@ -44,7 +44,7 @@ There is support for the following device families within Home Assistant:
 ## Prerequisites
 
 {% important %}
-Both the TR-064 (_Permit access for apps_) and UPnP (_Transmit status information over UPnP_) protocol needs to be enabled in the FRITZ!Box under **Home Network** > **Network** > **Network settings** > **Access Settings in the Home Network** for Home Assistant to login and read device info.
+Both the TR-064 (_Permit access for apps_) and UPnP (_Transmit status information over UPnP_) protocol needs to be enabled in the FRITZ!Box under **Home Network** > **Network** > **Network settings** > **Access Settings in the Home Network** for Home Assistant to log in and read device info.
 
 To use the [dial](#action-dial) action, the click to dial service of the FRITZ!Box must also be enabled under **Telephony** > **Calls** > **Click to Dial**.
 {% endimportant %}

--- a/source/_integrations/hassio.markdown
+++ b/source/_integrations/hassio.markdown
@@ -164,8 +164,8 @@ The `hassio.backup_partial` action creates a partial backup.
 
 | Data attribute | Optional | Description |
 | ---------------------- | -------- | ----------- |
-| `apps` | yes | List of app slugs to backup
-| `folders` | yes | List of directories to backup
+| `apps` | yes | List of app slugs to back up
+| `folders` | yes | List of directories to back up
 | `name` | yes | Name of the backup file. Default is the current date and time in the user's local time
 | `password` | yes | Optional password for backup
 | `compressed` | yes | `false` to create uncompressed backups

--- a/source/_integrations/hdmi_cec.markdown
+++ b/source/_integrations/hdmi_cec.markdown
@@ -61,7 +61,7 @@ If after symlinking and adding `hdmi_cec:` to your configuration you are getting
 
 ## Testing your installation
 
-- Login to Raspberry Pi
+- Log in to Raspberry Pi
 
 ```bash
 ssh pi@your_raspberry_pi_ip

--- a/source/_integrations/hitron_coda.markdown
+++ b/source/_integrations/hitron_coda.markdown
@@ -34,7 +34,7 @@ host:
   required: true
   type: string
 username:
-  description: The username to login into the router (user should have read access to the web interface of the router). Usually "cusadmin".
+  description: The username to log in to the router (user should have read access to the web interface of the router). Usually "cusadmin".
   required: true
   type: string
 password:

--- a/source/_integrations/loqed.markdown
+++ b/source/_integrations/loqed.markdown
@@ -32,7 +32,7 @@ On the [LOQED personal access token website](https://integrations.production.loq
 
 {% details "Generate access token" %}
 
-1. Login with your LOQED App email address (you need to be an admin).
+1. Log in with your LOQED App email address (you need to be an admin).
 2. Select **Create**.
 3. Give your personal access token a name (this will not be used further on, but we recommend something like "Home Assistant" to recognize it as used by Home Assistant).
 4. Select **Save**.
@@ -55,5 +55,5 @@ First, remove the integration from Home Assistant. This will remove any configur
 
 On [LOQED personal access token website](https://integrations.production.loqed.com/personal-access-tokens), please follow the following steps:
 
-1. Login with your LOQED App email address (you need to be admin).
+1. Log in with your LOQED App email address (you need to be admin).
 2. Select **delete** on the Personal Access Token you used when creating this integration.

--- a/source/_integrations/microbees.markdown
+++ b/source/_integrations/microbees.markdown
@@ -30,7 +30,7 @@ ha_integration_type: hub
 The **microBees** {% term integration %} allows you to control your [microBees devices](https://www.microbees.com/) such as plugs and wall switches.
 To use this integration you need OAuth2 Client ID and Client Secret and your user credentials.
 
-To retrieve the OAuth2 Client ID and Client Secret go to [microBees Developer Dashboard](https://developers.microbees.com/dashboard), login with your microBees account and [create a new app](https://developers.microbees.com/dashboard/?p=wizard), choose a Label for your App, select WebApplication and input https://my.home-assistant.io as Website URL.
+To retrieve the OAuth2 Client ID and Client Secret go to [microBees Developer Dashboard](https://developers.microbees.com/dashboard), log in with your microBees account and [create a new app](https://developers.microbees.com/dashboard/?p=wizard), choose a Label for your App, select WebApplication and input https://my.home-assistant.io as Website URL.
 
 There is currently support for the following device types within Home Assistant:
 - **Switch**

--- a/source/_integrations/nad.markdown
+++ b/source/_integrations/nad.markdown
@@ -99,7 +99,7 @@ The `min_volume` and `max_volume` options are there to protect you against miscl
 {% important %}
 On Linux the user running Home Assistant needs `dialout` permissions to access the serial port.
 This can be added to the user by doing `sudo usermod -a -G dialout <username>`.
-Be aware that the user might need to logout and logon again to activate these permissions.
+Be aware that the user might need to log out and log on again to activate these permissions.
 {% endimportant %}
 
 An example of a full configuration:

--- a/source/_integrations/neurio_energy.markdown
+++ b/source/_integrations/neurio_energy.markdown
@@ -15,7 +15,7 @@ related:
 ha_quality_scale: legacy
 ---
 
-Integrate your [Neurio](https://neur.io/) meter information into Home Assistant. To get an API key and secret, login to your [Neurio account](https://my.neur.io/#settings/applications/register) and register an application. Note the Homepage URL and Callback URL are optional.
+Integrate your [Neurio](https://neur.io/) meter information into Home Assistant. To get an API key and secret, log in to your [Neurio account](https://my.neur.io/#settings/applications/register) and register an application. Note the Homepage URL and Callback URL are optional.
 
 To enable this {% term integration %} in your installation, add the following to your {% term "`configuration.yaml`" %} file.
 {% include integrations/restart_ha_after_config_inclusion.md %}

--- a/source/_integrations/nyt_games.markdown
+++ b/source/_integrations/nyt_games.markdown
@@ -21,7 +21,7 @@ The [NYT Games](https://www.nytimes.com/crosswords) {% term integration %} fetch
 Before setting up the integration, you need to fetch the token from the dev tools of your browser.
 
 1. On your computer, go to [NYT Games](https://www.nytimes.com/crosswords).
-2. Login with your account.
+2. Log in with your account.
 3. Open the developer tools via right-click or by pressing F12.
 4. Open the network tab and refresh the page.
 5. Select a request with `.json` in the name and go to the cookie tab.

--- a/source/_integrations/ombi.markdown
+++ b/source/_integrations/ombi.markdown
@@ -25,7 +25,7 @@ This {% term integration %} needs to authenticate to your Ombi instance with eit
 
 To find your `api_key` open the Ombi web interface. Navigate to **Settings** and then to **Ombi**, you should then be able to see your `api_key`.
 
-If you want to use `password` authentication simply use the same `password` you normally use to login to Ombi. Alternatively, you can set up a separate local account in Ombi designated for Home Assistant. To do this, open the Ombi web interface. Navigate to **User Management** and then press **Add User To Ombi**. Input your desired user details and use the same details when configuring this integration.
+If you want to use `password` authentication simply use the same `password` you normally use to log in to Ombi. Alternatively, you can set up a separate local account in Ombi designated for Home Assistant. To do this, open the Ombi web interface. Navigate to **User Management** and then press **Add User To Ombi**. Input your desired user details and use the same details when configuring this integration.
 
 ## Configuration
 

--- a/source/_integrations/sftp_storage.markdown
+++ b/source/_integrations/sftp_storage.markdown
@@ -52,7 +52,7 @@ Remote path:
   type: string
 {% endconfiguration_basic %}
 
-If both `Password` and `Private Key File` are provided, service will try to login with private key first, then fallback to password-based authentication if private key authentication fails.
+If both `Password` and `Private Key File` are provided, service will try to log in with private key first, then fallback to password-based authentication if private key authentication fails.
 
 ## Removing the integration
 

--- a/source/_integrations/synology_dsm.markdown
+++ b/source/_integrations/synology_dsm.markdown
@@ -49,7 +49,7 @@ When SSDP is activated on a NAS with two or more NICs with different IP addresse
 You must grant the user administrator rights, as the basic functions of this integration require them due to the structure of the Synology DSM API.
 {% endnote %}
 
-When creating the user, it is possible to deny access to all locations and applications. By doing this, the user will not be able to login to the web interface or view any of the files on the Synology NAS. It is still able to read the utilization and storage information using the API.
+When creating the user, it is possible to deny access to all locations and applications. By doing this, the user will not be able to log in to the web interface or view any of the files on the Synology NAS. It is still able to read the utilization and storage information using the API.
 
 If you want to add cameras from [Surveillance Station](https://www.synology.com/surveillance), the user needs application permission for [Surveillance Station](https://www.synology.com/surveillance).
 
@@ -59,10 +59,10 @@ If you want to use a shared folder from the [File Station](https://www.synology.
 
 If you have the "Enforce 2-step verification for the following users" option checked under **Control Panel > Security > Account > 2-Factor Authentication**, you'll need to configure the 2-step verification/one-time password (OTP) for the user you just created before the credentials for this user will work with Home Assistant.
 
-Make sure to log out of your "normal" user's account and then login with the separate user you created specifically for Home Assistant. DSM will walk you through the process of setting up the one-time password for this user which you'll then be able to use in Home Assistant's frontend configuration screen.
+Make sure to log out of your "normal" user's account and then log in with the separate user you created specifically for Home Assistant. DSM will walk you through the process of setting up the one-time password for this user which you'll then be able to use in Home Assistant's frontend configuration screen.
 
 {% note %}
-If you denied access to all locations and applications it is normal to receive a message indicating you do not have access to DSM when trying to login with this separate user. As noted above, you do not need access to the DSM and Home Assistant will still be able to read statistics from your NAS.
+If you denied access to all locations and applications it is normal to receive a message indicating you do not have access to DSM when trying to log in with this separate user. As noted above, you do not need access to the DSM and Home Assistant will still be able to read statistics from your NAS.
 {% endnote %}
 
 ## Backup location

--- a/source/_integrations/tado.markdown
+++ b/source/_integrations/tado.markdown
@@ -52,7 +52,7 @@ As of **March 21st 2025**, Tado has changed the authentication method. This mean
 
 1. When you set up this integration, the integration will setup a "Device Code" and provide a URL to Tado's authentication server.
 2. Follow the URL and confirm the "Device Code" (normally it should be copied automatically).
-3. Follow the steps to login and authenticate your account.
+3. Follow the steps to log in and authenticate your account.
 4. Once the authentication is completed, go back to Home Assistant. Wait a few seconds for the loading screen to finish. You are now connected with Tado!
 
 {% important %}

--- a/source/_integrations/tomorrowio.markdown
+++ b/source/_integrations/tomorrowio.markdown
@@ -23,7 +23,7 @@ The **Tomorrow.io** {% term integration %} allows you to obtain weather, air qua
 
 ## Obtain an API key
 
-You can obtain a free API key by signing up with [Tomorrow.io](https://www.tomorrow.io/weather-api/). The integration assumes that your API key is associated with a free Tomorrow.io account. Free accounts include a limited number of daily API requests and the number of daily API requests included varies by account. Login to Tomorrow.io to view the number of daily API requests included with your account.
+You can obtain a free API key by signing up with [Tomorrow.io](https://www.tomorrow.io/weather-api/). The integration assumes that your API key is associated with a free Tomorrow.io account. Free accounts include a limited number of daily API requests and the number of daily API requests included varies by account. Log in to Tomorrow.io to view the number of daily API requests included with your account.
 
 The refresh interval defaults to a time period that is compatible with an account limited to 100 daily API requests and this integration should use around 90% of the available daily requests.
 

--- a/source/_integrations/tuya.markdown
+++ b/source/_integrations/tuya.markdown
@@ -159,7 +159,7 @@ When Tuya updates the terms and conditions of iot.tuya.com, the integration will
 
 To fix this:
 
-1. Login to [iot.tuya.com](https://iot.tuya.com), and accept the terms and conditions.
+1. Log in to [iot.tuya.com](https://iot.tuya.com), and accept the terms and conditions.
 2. Restart Home Assistant.
 3. Reconfigure the Tuya integration.
 

--- a/source/_integrations/unifiprotect.markdown
+++ b/source/_integrations/unifiprotect.markdown
@@ -78,7 +78,7 @@ It is recommended you use the Administrator or a user with full read/write acces
 but it is not required. The entities that are created will automatically adjust based on the permissions of the user you
 use has.
 
-1. Login to your _Local Portal_ on your UniFi OS device, and click on _Users_.  
+1. Log in to your _Local Portal_ on your UniFi OS device, and click on _Users_.  
 **Note**: This **must** be done from the UniFi OS by accessing it directly by IP address (for example _192.168.1.1_), not via `unifi.ui.com` or within the UniFi Protect app.
 2. Go to **Admins & Users** from the left hand side menu and select the **Admins** tab or go to [IP address]/admins/ (for example _192.168.1.1/admins/_).
 3. Click on **+** in the top right corner and select **Add Admin**.

--- a/source/_integrations/vasttrafik.markdown
+++ b/source/_integrations/vasttrafik.markdown
@@ -97,7 +97,7 @@ In cases where the wrong station is being selected, it is possible to provide th
 
 To retrieve the ID using `curl`:
 
-1. Login into the Västtrafik API and go to ["Applikationer"](https://developer.vasttrafik.se/applications)
+1. Log in to the Västtrafik API and go to ["Applikationer"](https://developer.vasttrafik.se/applications)
 2. Click "* Generera accesstoken", and then "Kopiera". 
 3. Execute the following `curl` command, replacing "<ACCESS_TOKEN>" and "<STATION_NAME>" as necessary:
 

--- a/source/_integrations/xiaomi_miio.markdown
+++ b/source/_integrations/xiaomi_miio.markdown
@@ -1779,7 +1779,7 @@ Allowed `params` for the `reset_consumable` command:
 ### Using FloleVac (Android)
 
 1. Download [FloleVac](https://play.google.com/store/apps/details?id=de.flole.xiaomi)
-2. Login with your Xiaomi credentials
+2. Log in with your Xiaomi credentials
 3. Open Map (make sure you're on the same network as your vacuum cleaner)
 4. Select "Zone cleanup" and draw a box around the zone you'd like to clean
 5. Long press "Cleanup" and the zone coordinates will be copied to your clipboard
@@ -2167,7 +2167,7 @@ This token (32 hexadecimal characters) is required for the Xiaomi Mi Robot Vacuu
 
 1. Configure the robot with the Mi-Home app. Make sure to select the correct region, as Xiaomi uses different product names for different geographical areas. Note that the new RoboRock app is currently not supported for this method.
 2. Install [BlueStacks](https://www.bluestacks.com).
-3. Set up [Mi Home version 5.4.49](https://www.apkmirror.com/apk/xiaomi-inc/mihome/mihome-5-4-49-release/) in BlueStacks and login to synchronize devices.
+3. Set up [Mi Home version 5.4.49](https://www.apkmirror.com/apk/xiaomi-inc/mihome/mihome-5-4-49-release/) in BlueStacks and log in to synchronize devices.
 4. Open Filemanager in the `More Apps` menu.
 5. Use `Explore` on the left and navigate to `sdcard/SmartHome/logs/plug_DeviceManager`.
 6. Click on `Export to Windows` in the lower left corner and select any or all files to export to you local disk.


### PR DESCRIPTION
## Proposed change

Several integration pages used "login" (the noun) where the verb "log in" is correct, for example "you can login to your account" or "Login with your credentials". This corrects those to the two-word verb form. It also fixes a couple of related cases: "to backup" → "to back up" and "to logout and logon" → "to log out and log on".

Noun and adjective uses ("a regular login", "web login", "social login"), the "Login with Amazon" product name, and Habitica's config-flow option labels are intentionally left unchanged.

## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards