### PR TITLE
Use single-word spelling for "email" and "website"

### DIFF
--- a/source/_integrations/evohome.markdown
+++ b/source/_integrations/evohome.markdown
@@ -46,7 +46,7 @@ evohome:
 
 {% configuration %}
 username:
-  description: The username (email address) that has access to the [TCC](https://international.mytotalconnectcomfort.com/Account/Login) web site.
+  description: The username (email address) that has access to the [TCC](https://international.mytotalconnectcomfort.com/Account/Login) website.
   required: true
   type: string
 password:

--- a/source/_integrations/heos.markdown
+++ b/source/_integrations/heos.markdown
@@ -61,7 +61,7 @@ The integration provides the following configuration options. By entering your H
 
 {% configuration_basic %}
 Username:
-  description: "The username or e-mail address of your HEOS Account."
+  description: "The username or email address of your HEOS Account."
 Password:
   description: "The password to your HEOS Account."
 {% endconfiguration_basic %}

--- a/source/_integrations/imap.markdown
+++ b/source/_integrations/imap.markdown
@@ -49,7 +49,7 @@ If you’re going to use Gmail, 2-step verification must be enabled on your Gmai
 10. Click **Submit**.
 11. Assign your integration to an "Area" if desired, then click **Finish**.
 
-Congratulations, you now have a sensor that counts the number of unread e-mails in your Gmail account. From here you can create additional sensors based upon the data that comes through the event bus when there's a new message detected.
+Congratulations, you now have a sensor that counts the number of unread emails in your Gmail account. From here you can create additional sensors based upon the data that comes through the event bus when there's a new message detected.
 
 ### Configuring IMAP Searches
 

--- a/source/_integrations/lightwave.markdown
+++ b/source/_integrations/lightwave.markdown
@@ -129,5 +129,5 @@ lightwave:
       trvs:
         R1Dh:                       # The ID of the TRV.
           name: Bedroom TRV
-          serial: E84902            # Serial number of the TRV - found in the Lightwave App, or web site
+          serial: E84902            # Serial number of the TRV - found in the Lightwave App, or website
 ```

--- a/source/_integrations/mvglive.markdown
+++ b/source/_integrations/mvglive.markdown
@@ -32,7 +32,7 @@ sensor:
 
 {% configuration %}
 station:
-  description: Name of the stop or station. Visit [the MVG live web site](https://www.mvg.de/meinhalt.html) to find valid names. Be aware, that not all data of interest might be available (i.e., bus departure-times in Haar).
+  description: Name of the stop or station. Visit [the MVG live website](https://www.mvg.de/meinhalt.html) to find valid names. Be aware, that not all data of interest might be available (i.e., bus departure-times in Haar).
   required: true
   type: string
 destinations:

--- a/source/_integrations/rmvtransport.markdown
+++ b/source/_integrations/rmvtransport.markdown
@@ -21,7 +21,7 @@ The **RMV** {% term integration %} will give you the departure time of the next 
 
 ## Setup
 
-Visit the [RMV OpenData web site](https://opendata.rmv.de) to find a list of valid station IDs. You will need to use the "HAFAS_ID".
+Visit the [RMV OpenData website](https://opendata.rmv.de) to find a list of valid station IDs. You will need to use the "HAFAS_ID".
 
 ## Configuration
 

--- a/source/_integrations/spaceapi.markdown
+++ b/source/_integrations/spaceapi.markdown
@@ -48,7 +48,7 @@ logo:
   required: true
   type: string
 url:
-  description: URL of the hackerspace's web site.
+  description: URL of the hackerspace's website.
   required: true
   type: string
 location:


### PR DESCRIPTION
## Proposed change

Updates a few integration pages to the single-word spelling used by the Microsoft Style Guide: "e-mail" → "email" and "web site" → "website".

Left unchanged: the SMTP page's YAML example alias (would need full re-casing), the Google Mail page's literal YouTube video title, and uses of "web page".

## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards