### PR TITLE
Use "log in" verb instead of "login" noun in section headings

### DIFF
--- a/source/_integrations/habitica.markdown
+++ b/source/_integrations/habitica.markdown
@@ -55,7 +55,7 @@ The Habitica integration lets you automate task management, such as creating to-
 
 {% include integrations/config_flow.md %}
 
-### Login to Habitica
+### Log in to Habitica
 
 {% configuration_basic %}
 "Email or username":

--- a/source/_integrations/overkiz.markdown
+++ b/source/_integrations/overkiz.markdown
@@ -69,7 +69,7 @@ Over 6000 devices from 60 brands are compatible with the Overkiz platform. This 
 
 The Overkiz integration supports both the Overkiz cloud API and the local API (only supported by some Somfy hubs). For compatible Somfy hubs, you can connect locally, allowing device control without an internet connection. Start by selecting the server or app that you use to control your devices.
 
-### Login to Overkiz (Cloud API)
+### Log in to Overkiz (Cloud API)
 
 {% configuration_basic %}
 "Username":
@@ -78,7 +78,7 @@ Password:
   description: "Password for your Overkiz cloud account (account you use in your IoT app)."
 {% endconfiguration_basic %}
 
-### Login to Overkiz (Local API)
+### Log in to Overkiz (Local API)
 
 To use the local API, you must enable [Somfy TaHoma Developer Mode](https://github.com/Somfy-Developer/Somfy-TaHoma-Developer-Mode?tab=readme-ov-file#getting-started) in the TaHoma by Somfy app. Follow the [official instructions](https://github.com/Somfy-Developer/Somfy-TaHoma-Developer-Mode?tab=readme-ov-file#getting-started) to generate a token. This token is required to connect Home Assistant to your hub using the local API.
 

--- a/source/_integrations/playstation_network.markdown
+++ b/source/_integrations/playstation_network.markdown
@@ -53,7 +53,7 @@ It is recommended, especially if you have configured multiple PlayStation accoun
 
 {% include integrations/config_flow.md %}
 
-### Login to PlayStation Network
+### Log in to PlayStation Network
 
 {% configuration_basic %}
 "NPSSO Token":


### PR DESCRIPTION
## Proposed change

Follow-up to #45950, fixing the remaining "Login" noun used as a verb in section headings. These were held back from the earlier sweep because changing a heading changes its anchor; I verified none of these anchors are referenced anywhere in the repository, so no links break.

Changes "Login to ..." to "Log in to ..." in the Habitica, Overkiz, and PlayStation Network integration pages.

## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards