### PR TITLE
Use "use" instead of wordy "make use of"

### DIFF
--- a/source/_integrations/acmeda.markdown
+++ b/source/_integrations/acmeda.markdown
@@ -35,4 +35,4 @@ If the IP address for the hub changes, you will need to re-register it with Home
 The integration has the following limitations:
 
 - Covers with position as well as tilt are not supported.
-- The integration doesn't make use of rooms and scenes configured in the hub, use the equivalent functionality in Home Assistant instead.
+- The integration doesn't use rooms and scenes configured in the hub, use the equivalent functionality in Home Assistant instead.

--- a/source/_integrations/alert.markdown
+++ b/source/_integrations/alert.markdown
@@ -34,7 +34,7 @@ possible states:
 
 ### Basic example
 
-The `alert` integration makes use of any of the `notification` integrations. To
+The `alert` integration uses any of the `notification` integrations. To
 setup the `alert` integration, first, you must set up a [notification integration](/integrations/notify).
 Then, add the following to your {% term "`configuration.yaml`" %} file.
 {% include integrations/restart_ha_after_config_inclusion.md %}

--- a/source/_integrations/anthemav.markdown
+++ b/source/_integrations/anthemav.markdown
@@ -56,7 +56,7 @@ port:
 
 {% warning %}
 
-The {% term integration %} will maintain a persistent connection to the network control port which will prevent any other application from communicating with the receiver. This includes the Anthem iOS and Android remote control apps as well as the ARC-2 Anthem Room Calibration software. If you want to use another application that makes use of the network control port, disable this {% term integration %} and restart Home Assistant.
+The {% term integration %} will maintain a persistent connection to the network control port which will prevent any other application from communicating with the receiver. This includes the Anthem iOS and Android remote control apps as well as the ARC-2 Anthem Room Calibration software. If you want to use another application that uses the network control port, disable this {% term integration %} and restart Home Assistant.
 <br /><br />
 *The underlying Python module has hooks for halting and resuming the network connection but those functions are currently unsupported by the Home Assistant platform.*
 

--- a/source/_integrations/blink.markdown
+++ b/source/_integrations/blink.markdown
@@ -112,7 +112,7 @@ The following are some examples showing how to correctly perform an action using
 
 ### Snap picture and save locally
 
-This example script shows how to take a picture with your camera, named `My Camera` in your Blink app (this is **not necessarily** the friendly name in Home Assistant).  After snapping a picture, the image will then be saved to a local directory called `/tmp/my_image.jpg`.  Note that this example makes use of actions found in the [camera integration](/integrations/camera#action-snapshot)
+This example script shows how to take a picture with your camera, named `My Camera` in your Blink app (this is **not necessarily** the friendly name in Home Assistant).  After snapping a picture, the image will then be saved to a local directory called `/tmp/my_image.jpg`.  Note that this example uses actions found in the [camera integration](/integrations/camera#action-snapshot)
 
 ```yaml
 alias: "Blink Snap Picture"

--- a/source/_integrations/blue_current.markdown
+++ b/source/_integrations/blue_current.markdown
@@ -98,6 +98,6 @@ The Blue Current integration provides the following switches:
 - Toggle **Plug & Charge**
   - Allows you to start a session without having to scan a card.
 - Toggle linked charging cards only
-  - When enabled, visitors can't make use of the charge point. Only linked charging cards are allowed.
+  - When enabled, visitors can't use the charge point. Only linked charging cards are allowed.
 - Toggle charge point block
   - Enables or disables a charge point.

--- a/source/_integrations/knx.markdown
+++ b/source/_integrations/knx.markdown
@@ -156,7 +156,7 @@ Telegram history limit:
 
 ## Basic configuration
 
-To make use of the various platforms offered by the KNX integration, you will need to set them up via the KNX panel or add the corresponding configuration yaml to your {% term "`configuration.yaml`" %}. See [Splitting up the configuration](/docs/configuration/splitting_configuration/) if you like to arrange YAML parts in dedicated files.
+To use the various platforms offered by the KNX integration, you will need to set them up via the KNX panel or add the corresponding configuration yaml to your {% term "`configuration.yaml`" %}. See [Splitting up the configuration](/docs/configuration/splitting_configuration/) if you like to arrange YAML parts in dedicated files.
 {% include integrations/restart_ha_after_config_inclusion.md %}
 
 ```yaml

--- a/source/_integrations/media_source.markdown
+++ b/source/_integrations/media_source.markdown
@@ -96,7 +96,7 @@ data:
 
 ### Identifying a media source from the media browser
 
-If you wish to make use of the `media-source://` URI for an action, and the media is already available in the media browser (either as locally stored on the Home Assistant machine, or mapped using network storage) the following steps can help to determine the `media-source` uri.
+If you wish to use the `media-source://` URI for an action, and the media is already available in the media browser (either as locally stored on the Home Assistant machine, or mapped using network storage) the following steps can help to determine the `media-source` uri.
 
 1. Select **Media** in the sidebar.
 2. Navigate to the folder containing the media you wish to play.\

--- a/source/_integrations/roku.markdown
+++ b/source/_integrations/roku.markdown
@@ -200,7 +200,7 @@ actions:
 
 The `media_player.play_media` action may be used to send media URLs (primarily videos) for direct playback on your device.
 
-This feature makes use of the PlayOnRoku API. If you are using an older Roku OS (pre-11.5), the defaults of this integration should just work with the configuration defaults. Alternatively, you can configure a third-party application that supports the PlayOnRoku API via the `Play Media Roku Application ID` option.
+This feature uses the PlayOnRoku API. If you are using an older Roku OS (pre-11.5), the defaults of this integration should just work with the configuration defaults. Alternatively, you can configure a third-party application that supports the PlayOnRoku API via the `Play Media Roku Application ID` option.
 
 The following third-party applications have been tested with this integration:
 
@@ -259,7 +259,7 @@ actions:
 
 ### Camera stream integration
 
-The `camera.play_stream` action may be used to send camera streams (HLS) directly to your device. This feature requires the [`stream` integration](/integrations/stream) and makes use of the PlayOnRoku API.
+The `camera.play_stream` action may be used to send camera streams (HLS) directly to your device. This feature requires the [`stream` integration](/integrations/stream) and uses the PlayOnRoku API.
 
 #### Example
 

--- a/source/_integrations/russound_rio.markdown
+++ b/source/_integrations/russound_rio.markdown
@@ -20,7 +20,7 @@ ha_quality_scale: silver
 ha_zeroconf: true
 ---
 
-The **Russound RIO** {% term integration %} allows you to control Russound devices that make use of the RIO protocol.
+The **Russound RIO** {% term integration %} allows you to control Russound devices that use the RIO protocol.
 
 The platform automatically discovers all enabled zones and sources. Each zone is added as a media player device with the enabled sources available as inputs. Media information is supported if the selected source reports it. The integration allows you to navigate presets, control volume of all zones, and play radio stations all from your Home Assistant dashboard.
 

--- a/source/_integrations/russound_rnet.markdown
+++ b/source/_integrations/russound_rnet.markdown
@@ -17,11 +17,11 @@ ha_codeowners:
   - '@noahhusby'
 ---
 
-The **Russound RNET** {% term integration %} allows you to control Russound devices that make use of the RNET protocol.
+The **Russound RNET** {% term integration %} allows you to control Russound devices that use the RNET protocol.
 
 This has initially been tested against a Russound CAV6.6 unit with six zones and six sources. It will also work with a Russound CAA66, but be sure to use a null-modem cable. If you have mutiple controllers connected via the RNET link ports, every increment of 6 zones maps to the corresponding controller ID.
 
-Connecting to the Russound device is only possible by TCP, you can make use of a TCP to Serial gateway such as [tcp_serial_redirect](https://github.com/pyserial/pyserial/blob/master/examples/tcp_serial_redirect.py)
+Connecting to the Russound device is only possible by TCP, you can use a TCP to Serial gateway such as [tcp_serial_redirect](https://github.com/pyserial/pyserial/blob/master/examples/tcp_serial_redirect.py)
 
 ## Supported devices
 

--- a/source/_integrations/sensor.mqtt.markdown
+++ b/source/_integrations/sensor.mqtt.markdown
@@ -309,7 +309,7 @@ Topic: `home/sensor1/attributes`
     "ConnectedSSID": <string>
 }
  ```
- It also makes use of the `availability` topic.
+ It also uses the `availability` topic.
 
 Extra attributes will be displayed in the frontend and can also be extracted in [Templates](/docs/templating/states/). For example, to extract the `ClientName` attribute from the sensor below, use a template similar to: {% raw %}`{{ state_attr('sensor.bs_rssi', 'ClientName') }}`{% endraw %}.
 

--- a/source/_integrations/sensorpush_cloud.markdown
+++ b/source/_integrations/sensorpush_cloud.markdown
@@ -19,7 +19,7 @@ Integrates [SensorPush Cloud](https://www.sensorpush.com/) devices into Home Ass
 
 ## Prerequisites
 
-A [G1 WiFi Gateway](https://www.sensorpush.com/products/p/g1-gateway) is required to make use of the Cloud API. To activate API access, log in to the [Gateway Cloud Dashboard](https://dashboard.sensorpush.com/) and agree to the terms of service.
+A [G1 WiFi Gateway](https://www.sensorpush.com/products/p/g1-gateway) is required to use the Cloud API. To activate API access, log in to the [Gateway Cloud Dashboard](https://dashboard.sensorpush.com/) and agree to the terms of service.
 
 Sensor entities (temperature, humidity, barometric pressure) will not be available to Home Assistant until you have activated the device with the SensorPush app on iOS or Android.
 

--- a/source/_integrations/squeezebox.markdown
+++ b/source/_integrations/squeezebox.markdown
@@ -338,7 +338,7 @@ The integration uses {% term polling %} to receive updates from the Lyrion Music
 
 ## Known limitations
 
-The LMS API, which is used by this integration, does not currently provide the ability to override or control fade-in & crossfade settings. This means that if you have enabled **Play or Resume fade-in duration** within the player's audio settings, this fade-in will be applied to any announcement played. This could potentially lead to the start of an announcement being missed as it fades in. You should, therefore, consider a short **Play or Resume fade-in duration** or preferably disabling this feature if you make use of announcements.
+The LMS API, which is used by this integration, does not currently provide the ability to override or control fade-in & crossfade settings. This means that if you have enabled **Play or Resume fade-in duration** within the player's audio settings, this fade-in will be applied to any announcement played. This could potentially lead to the start of an announcement being missed as it fades in. You should, therefore, consider a short **Play or Resume fade-in duration** or preferably disabling this feature if you use announcements.
 
 ## Removing the integration
 

--- a/source/_integrations/template.markdown
+++ b/source/_integrations/template.markdown
@@ -2564,7 +2564,7 @@ template:
 
 #### Video tutorial
 
-This video tutorial explains how to set up a trigger based template that makes use of an action to retrieve the weather forecast (precipitation).
+This video tutorial explains how to set up a trigger based template that uses an action to retrieve the weather forecast (precipitation).
 
 <lite-youtube videoid="zrWqDjaRBf0" videotitle="How to create Action Template Sensors in Home Assistant" posterquality="maxresdefault"></lite-youtube>
 


### PR DESCRIPTION
## Proposed change

A small readability pass replacing the wordy "make use of" / "makes use of" with the plainer "use" / "uses" across 14 integration pages, following the Microsoft Writing Style Guide's plain-language guidance.

## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards