### PR TITLE
Use "whether" instead of redundant "whether or not"

### DIFF
--- a/source/_integrations/calendar.markdown
+++ b/source/_integrations/calendar.markdown
@@ -52,7 +52,7 @@ The card shows upcoming events from one or more calendar entities and provides a
 
 ## The state of a calendar entity
 
-The state shows whether or not there is an active event:
+The state shows whether there is an active event:
 
 - **On**: The calendar has an active event.
 - **Off**: The calendar does not have an active event.

--- a/source/_integrations/flo.markdown
+++ b/source/_integrations/flo.markdown
@@ -24,7 +24,7 @@ The **Flo** {% term integration %} integrates
 
 There is currently support for the following device types within Home Assistant:
 
-- **Binary sensor**: reports whether or not there are any alerts.
+- **Binary sensor**: reports whether there are any alerts.
 - **Sensor**: reports on the device's system mode, water flow rate, temperature, water pressure, and daily water consumption.
 - **Switch**: allows you to open and close the valve on the water shutoff device.
 

--- a/source/_integrations/lifx.markdown
+++ b/source/_integrations/lifx.markdown
@@ -56,7 +56,7 @@ All devices start counting zones at zero (0), which means the zone numbers for t
 
 You can control the HEV LEDs in LIFX Clean bulbs using the `set_hev_cycle_state` action. The action can start or stop a HEV (or "Clean") cycle either using the default duration configured on the bulb or for a custom duration specified when performing the action. Home Assistant will return or log an error if an incompatible bulb is specified when performing the action.
 
-To determine whether or not a HEV cycle is currently running, Home Assistant exposes a Clean Cycle binary sensor for all HEV-enabled bulbs. This sensor can be used to trigger automations to occur when a HEV cycle starts or stops. To reduce network load, HEV cycle status is only checked every 10 seconds so this sensor may not update instantaneously.
+To determine whether a HEV cycle is currently running, Home Assistant exposes a Clean Cycle binary sensor for all HEV-enabled bulbs. This sensor can be used to trigger automations to occur when a HEV cycle starts or stops. To reduce network load, HEV cycle status is only checked every 10 seconds so this sensor may not update instantaneously.
 
 ### Action: Set HEV cycle state
 

--- a/source/_integrations/siren.markdown
+++ b/source/_integrations/siren.markdown
@@ -43,7 +43,7 @@ The `siren.turn_on` action turns the siren on.
 | ---------------------- | -------- | ----------- |
 | `entity_id` | yes | String or list of strings that point at `entity_id`'s of sirens to control.
 
-There are three optional input parameters that can be passed into the action depending on whether or not your device supports them. Check the device's integration documentation for more details.
+There are three optional input parameters that can be passed into the action depending on whether your device supports them. Check the device's integration documentation for more details.
 
 | Parameter Name  | Input Type              | Notes                                                                               |
 |---------------- |-------------------------|-------------------------------------------------------------------------------------|

--- a/source/_integrations/sonos.markdown
+++ b/source/_integrations/sonos.markdown
@@ -446,7 +446,7 @@ The `sonos.update_alarm` action updates an existing Sonos alarm.
 | `alarm_id` | no | Integer that is used in Sonos to refer to your alarm.
 | `time` | yes | Time to set the alarm.
 | `volume` | yes | Float for volume level.
-| `enabled` | yes | Boolean for whether or not to enable this alarm.
+| `enabled` | yes | Boolean for whether to enable this alarm.
 | `include_linked_zones` | yes | Boolean that defines if the alarm also plays on grouped players.
 
 ### Action: Play queue

--- a/source/_integrations/stream.markdown
+++ b/source/_integrations/stream.markdown
@@ -53,7 +53,7 @@ part_duration:
 
 LL-HLS reduces the start time and delay for a stream, but it has strict timing and network requirements and opens additional browser connections. To avoid running into browser limits it is strongly recommended to use an HTTP/2 proxy (e.g., NGINX or haproxy) to take advantage of request pipelining. LL-HLS is enabled by default, but when not using HTTP/2, the Home Assistant frontend will revert back to regular HLS if too many streams are open.
 
-You can further adjust LL-HLS settings in {% term "`configuration.yaml`" %} as it may perform better or worse with different values depending on your network setup, cameras, or whether or not they are local or cloud.
+You can further adjust LL-HLS settings in {% term "`configuration.yaml`" %} as it may perform better or worse with different values depending on your network setup, cameras, or whether they are local or cloud.
 
 Example configuration:
 

--- a/source/_integrations/todo.markdown
+++ b/source/_integrations/todo.markdown
@@ -18,7 +18,7 @@ related:
 
 The **To-do list** {% term integration %} provides to-do list {% term entities %}, allowing other integrations
 to integrate to-do lists into Home Assistant. To-do lists are shown on the **To-do lists**
-dashboard for tracking items and whether or not they have been completed.
+dashboard for tracking items and whether they have been completed.
 
 {% include integrations/building_block_integration.md %}
 

--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -658,7 +658,7 @@ The `zwave_js.set_value` action sets a value on a Z-Wave device. It is for advan
 | `endpoint`        | no       | ID of Endpoint that you want to set the value for.                                                                                                                                                                                                                      |
 | `value`           | yes      | The new value that you want to set.                                                                                                                                                                                                                                     |
 | `options`         | no       | Set value options map. Refer to the Z-Wave JS documentation for more information on what options can be set.                                                                                                                                                            |
-| `wait_for_result` | no       | Boolean that indicates whether or not to wait for a response from the node. If not included in the payload, the integration will decide whether to wait or not. If set to `true`, note that the action can take a while if setting a value on an asleep battery device. |
+| `wait_for_result` | no       | Boolean that indicates whether to wait for a response from the node. If not included in the payload, the integration will decide whether to wait or not. If set to `true`, note that the action can take a while if setting a value on an asleep battery device. |
 
 ### Action: Multicast set value
 


### PR DESCRIPTION
## Proposed change

A small readability pass replacing the redundant "whether or not" with "whether" across 8 integration pages, following the Microsoft Writing Style Guide. In each case the "or not" carried no meaning. Cases where "or not" is required (the "regardless of whether" sense) were left untouched, including the second "decide whether to wait or not" phrase in the Z-Wave JS page.

## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards