### PR TITLE
Use "several" instead of the wordy "a number of"

### DIFF
--- a/source/_integrations/abode.markdown
+++ b/source/_integrations/abode.markdown
@@ -49,7 +49,7 @@ There is currently support for the following {% term device %} types within Home
 
 ## Events
 
-There are a number of {% term events %} that can be triggered from Abode.
+There are several {% term events %} that can be triggered from Abode.
 They are grouped into the below events:
 
 - **abode_alarm**: Fired when an alarm event is triggered from Abode. This includes Smoke, CO, Panic, and Burglar alarms.

--- a/source/_integrations/airgradient.markdown
+++ b/source/_integrations/airgradient.markdown
@@ -74,7 +74,7 @@ The integration will fetch data from each device. The following sensors are supp
 - Temperature
 - Total volatile organic compounds index
 
-A number of configuration entities are available as sensors to automate with if you control the device via the AirGradient dashboard instead of set it to control locally.
+Several configuration entities are available as sensors to automate with if you control the device via the AirGradient dashboard instead of set it to control locally.
 - CO2 automatic baseline calibration days
 - NOx learning offset
 - Total volatile organic compounds learning offset

--- a/source/_integrations/airthings_ble.markdown
+++ b/source/_integrations/airthings_ble.markdown
@@ -20,7 +20,7 @@ ha_integration_type: device
 
 Integrates Airthings BLE {% term sensors %} into Home Assistant.
 
-[Airthings](https://www.airthings.com/) provide different {% term devices %} for measuring the air quality. Initially focusing on radon gas sensors, each device provides a number of different sensors to monitor typical contaminants whose presence contributes to bad air quality in the home.
+[Airthings](https://www.airthings.com/) provide different {% term devices %} for measuring the air quality. Initially focusing on radon gas sensors, each device provides several different sensors to monitor typical contaminants whose presence contributes to bad air quality in the home.
 
 Requires Airthings hardware and a compatible Bluetooth dongle.
 

--- a/source/_integrations/azure_event_hub.markdown
+++ b/source/_integrations/azure_event_hub.markdown
@@ -97,7 +97,7 @@ filter:
 
 ## Using the data in Azure
 
-There are a number of ways to stream the data that comes into the Event Hub into storages in Azure, the easiest way is to use the built-in Capture function and this allows you to capture the data in Azure Blob Storage or Azure Data Lake store, [details here](https://learn.microsoft.com/azure/event-hubs/event-hubs-capture-overview).
+There are several ways to stream the data that comes into the Event Hub into storages in Azure, the easiest way is to use the built-in Capture function and this allows you to capture the data in Azure Blob Storage or Azure Data Lake store, [details here](https://learn.microsoft.com/azure/event-hubs/event-hubs-capture-overview).
 
 Other storages in Azure (and outside) are possible with an [Azure Stream Analytics job](https://learn.microsoft.com/azure/stream-analytics/stream-analytics-define-inputs#stream-data-from-event-hubs), for instance for [Cosmos DB](https://learn.microsoft.com/azure/stream-analytics/stream-analytics-documentdb-output), [Azure SQL DB](https://learn.microsoft.com/azure/stream-analytics/stream-analytics-sql-output-perf), [Azure Table Storage](https://learn.microsoft.com/azure/stream-analytics/stream-analytics-define-outputs), custom writing to [Azure Blob Storage](https://learn.microsoft.com/azure/stream-analytics/stream-analytics-custom-path-patterns-blob-storage-output) and [Topic and Queues](https://learn.microsoft.com/azure/stream-analytics/stream-analytics-quick-create-portal#configure-job-output).
 

--- a/source/_integrations/bang_olufsen.markdown
+++ b/source/_integrations/bang_olufsen.markdown
@@ -62,7 +62,7 @@ Currently, for each added physical device, a single device is created that inclu
 
 ### Media player
 
-A number of features are available through the media player entity:
+Several features are available through the media player entity:
 
 - See current metadata, progress, volume, and more.
 - Control next/previous, play/pause, shuffle/repeat settings, volume, sound mode, audio and video sources, and more.
@@ -138,7 +138,7 @@ In total, this amounts to 90 different remote key Event entities per remote.
 
 ##### Configuring light and control functions
 
-A number of functions are available on the Beoremote One. These are available as `function` 1-17 for the **Light** submenu and 1-27 for the **Control** submenu.
+Several functions are available on the Beoremote One. These are available as `function` 1-17 for the **Light** submenu and 1-27 for the **Control** submenu.
 
 Only a subset of these functions are enabled by default. Change settings for the **Control** and **Light** submenus following these steps:
 

--- a/source/_integrations/bayesian.markdown
+++ b/source/_integrations/bayesian.markdown
@@ -134,7 +134,7 @@ When configuring these conditional probabilities, define the probability of the 
 
 ## Full examples
 
-These are a number of worked examples which you may find helpful for each of the observation types. While these are YAML examples, UI configurations work in the same way, except that probabilities are expressed in percentages.
+These are several worked examples which you may find helpful for each of the observation types. While these are YAML examples, UI configurations work in the same way, except that probabilities are expressed in percentages.
 
 ### State
 

--- a/source/_integrations/easyenergy.markdown
+++ b/source/_integrations/easyenergy.markdown
@@ -81,7 +81,7 @@ The prices retrieved via the API are bare prices including VAT, however an energ
 
 ## Sensors
 
-The easyEnergy integration creates a number of sensor entities for both gas
+The easyEnergy integration creates several sensor entities for both gas
 and electricity prices.
 
 ### Energy market prices

--- a/source/_integrations/energyzero.markdown
+++ b/source/_integrations/energyzero.markdown
@@ -46,7 +46,7 @@ The prices retrieved via the API are bare prices including VAT, however an energ
 
 ## Sensors
 
-The EnergyZero integration creates a number of sensor entities for both gas and electricity prices.
+The EnergyZero integration creates several sensor entities for both gas and electricity prices.
 
 ### Energy market price
 

--- a/source/_integrations/flux_led.markdown
+++ b/source/_integrations/flux_led.markdown
@@ -207,7 +207,7 @@ If a strip controller device will not stay on wifi or goes offline during adjust
 
 ### Effects
 
-The Magic Home light offers a number of effects which are not included in other lighting packages. These can be selected from the front-end, or sent in the effect field of the `light.turn_on` command.
+The Magic Home light offers several effects which are not included in other lighting packages. These can be selected from the front-end, or sent in the effect field of the `light.turn_on` command.
 
 | Effect Name                                                                                                  | Description                                                        |
 |--------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------|

--- a/source/_integrations/fully_kiosk.markdown
+++ b/source/_integrations/fully_kiosk.markdown
@@ -29,7 +29,7 @@ ha_dhcp: true
 ha_quality_scale: bronze
 ---
 
-[Fully Kiosk Browser](https://www.fully-kiosk.com) is a powerful kiosk browser for Android devices. It provides a number of features for monitoring and controlling your Android device. This integration gives you access to control your device and view the status in Home Assistant.
+[Fully Kiosk Browser](https://www.fully-kiosk.com) is a powerful kiosk browser for Android devices. It provides several features for monitoring and controlling your Android device. This integration gives you access to control your device and view the status in Home Assistant.
 
 ## Requirements
 

--- a/source/_integrations/homekit_controller.markdown
+++ b/source/_integrations/homekit_controller.markdown
@@ -306,7 +306,7 @@ You may say a log entry that looks like this:
 HomeKit device update skipped as previous poll still in flight
 ```
 
-In these cases it's unlikely that the integration itself is directly responsible. This is a safety feature to avoid overloading your Home Assistant instance. It means that Home Assistant tried to poll your accessory but the previous poll was still happening. This means it is taking over 1 minute to poll your accessory. This could be caused by a number of things:
+In these cases it's unlikely that the integration itself is directly responsible. This is a safety feature to avoid overloading your Home Assistant instance. It means that Home Assistant tried to poll your accessory but the previous poll was still happening. This means it is taking over 1 minute to poll your accessory. This could be caused by several things:
 
 - You have too many blocking synchronous integrations for your Home Assistant instance. All synchronous integrations share a thread pool, and if there are lots of tasks to run on it they will queued, which will cause delays. In the worst cases this queue can build up faster than it can be emptied. Faster hardware may help, but you may need to disable some integrations.
 - Your network connection to an accessory is poor and the integration is unable to reach the accessory reliably. This will likely require a change to your network setup to improve Wi-Fi coverage or replace damaged cabling.

--- a/source/_integrations/kira.markdown
+++ b/source/_integrations/kira.markdown
@@ -172,7 +172,7 @@ When you have filled in the data to match your YAML entry save the script and te
   <img src='/images/integrations/kira/kira_test_script.png' />
 </p>
 
-Once you know the code is working and procedure is correct you can use the facility in any number of ways, perhaps triggering the output based on sensor readings or by adding a number of buttons as a virtual remote in the Home Assistant front end.
+Once you know the code is working and procedure is correct you can use the facility in any number of ways, perhaps triggering the output based on sensor readings or by adding several buttons as a virtual remote in the Home Assistant front end.
 
 ### Example sensor
 

--- a/source/_integrations/luci.markdown
+++ b/source/_integrations/luci.markdown
@@ -62,7 +62,7 @@ verify_ssl:
 
 See the [device tracker integration page](/integrations/device_tracker/) for instructions how to configure the people to be tracked.
 
-This device tracker provides a number of additional attributes for each tracked device (if it is at home): `flags`, `ip`, `device`, and `host`. The first three attributes are taken from the ARP table returned by the luci RPC. The `host` attribute is taken from the platform configuration and can be used to distinguish in which router a device is logged in, if you are using multiple OpenWrt routers.
+This device tracker provides several additional attributes for each tracked device (if it is at home): `flags`, `ip`, `device`, and `host`. The first three attributes are taken from the ARP table returned by the luci RPC. The `host` attribute is taken from the platform configuration and can be used to distinguish in which router a device is logged in, if you are using multiple OpenWrt routers.
 
 {% note %}
 Some installations have [a small bug](https://github.com/openwrt/luci/issues/576). The timeout for luci RPC calls is not set and this makes the call fail. 

--- a/source/_integrations/metoffice.markdown
+++ b/source/_integrations/metoffice.markdown
@@ -27,7 +27,7 @@ The **Met Office** weather {% term integration %} uses the Met Office's [DataHub
 
 ## Entities
 
-This integration creates a number of weather entities for each entry created in the configuration by location: one weather entity with a summary and a forecast (daily, hourly, and twice-daily), and sensor entities for individual reporting on each of the individual measurements. Note that only some of the sensor entities flagged below are enabled by default, so your system isn't overrun on initial configuration.
+This integration creates several weather entities for each entry created in the configuration by location: one weather entity with a summary and a forecast (daily, hourly, and twice-daily), and sensor entities for individual reporting on each of the individual measurements. Note that only some of the sensor entities flagged below are enabled by default, so your system isn't overrun on initial configuration.
 
 The available sensor entities:
 

--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -32,7 +32,7 @@ Configure the modbus communication with modbus devices. This is a general setup 
 
 The modbus integration allows you to use multiple connections each with multiple sensors etc.
 
-The modbus integration provides a number of parameters to help communicate with "difficult" devices, these parameters are independent of the type of communication.
+The modbus integration provides several parameters to help communicate with "difficult" devices, these parameters are independent of the type of communication.
 
 To enable this integration, add it to your {% term "`configuration.yaml`" %} file.
 {% include integrations/restart_ha_after_config_inclusion.md %}

--- a/source/_integrations/netgear_lte.markdown
+++ b/source/_integrations/netgear_lte.markdown
@@ -27,7 +27,7 @@ There is currently support for the following device types within Home Assistant:
 - Sensors
 - Binary sensors
 
-The integration supports sending notifications with SMS, reporting incoming SMS with events and reporting the modem and connection state in a number of sensors and binary sensors.
+The integration supports sending notifications with SMS, reporting incoming SMS with events and reporting the modem and connection state in several sensors and binary sensors.
 
 {% note %}
 Splitting of long SMS messages is not supported so notifications can contain a maximum of 70 characters. Simple messages using the reduced GSM-7 alphabet can contain up to 160 characters. Most emojis are not supported.

--- a/source/_integrations/nextbus.markdown
+++ b/source/_integrations/nextbus.markdown
@@ -15,6 +15,6 @@ ha_platforms:
 ha_integration_type: service
 ---
 
-The **NextBus** {% term integration %} will give you the next departure time and associated data from your public transit station/stop. The data comes from [NextBus](https://www.nextbus.com), which provides real time transit data for a number of transit authorities.
+The **NextBus** {% term integration %} will give you the next departure time and associated data from your public transit station/stop. The data comes from [NextBus](https://www.nextbus.com), which provides real time transit data for several transit authorities.
 
 {% include integrations/config_flow.md %}

--- a/source/_integrations/numato.markdown
+++ b/source/_integrations/numato.markdown
@@ -153,7 +153,7 @@ on how to connect a switch to an input port, for example.
 The `numato` sensor platform allows you to operate some GPIOs of your USB GPIO
 expander in analog input mode.
 
-The Numato device has a number of built-in analog-digital-converters (ADCs) to
+The Numato device has several built-in analog-digital-converters (ADCs) to
 convert a voltage level between VCC and GND into a 10-bit integer value. Read
 the [IO Ports](#io-ports) section for constraints on the ports to use.
 

--- a/source/_integrations/pi_hole.markdown
+++ b/source/_integrations/pi_hole.markdown
@@ -82,4 +82,4 @@ The integration creates a switch for the Pi-hole allowing you to toggle ad-block
 
 ## Sensors
 
-The integration creates a number of sensors that report various ad-blocking metrics as well as diagnostic information about the Pi-hole itself.
+The integration creates several sensors that report various ad-blocking metrics as well as diagnostic information about the Pi-hole itself.

--- a/source/_integrations/recorder.markdown
+++ b/source/_integrations/recorder.markdown
@@ -21,7 +21,7 @@ The **Recorder** {% term integration %} is by default enabled as dependency of t
 This integration constantly saves data. If you use the default configuration, the data will be saved on the media Home Assistant is installed on. In case of Raspberry Pi with an SD card, it might affect your system's reaction time and life expectancy of the storage medium (the SD card). It is therefore recommended to set the [commit_interval](/integrations/recorder#commit_interval) to higher value, e.g. 30s, limit the amount of stored data (e.g., by excluding devices) or store the data elsewhere (e.g., another system).
 {% endimportant %}
 
-Home Assistant uses [SQLAlchemy](https://www.sqlalchemy.org/), which is an Object Relational Mapper (ORM). This makes it possible to use a number of database solutions.
+Home Assistant uses [SQLAlchemy](https://www.sqlalchemy.org/), which is an Object Relational Mapper (ORM). This makes it possible to use several database solutions.
 
 The supported database solutions are:
 - [MariaDB](https://mariadb.org/) ≥ 10.3

--- a/source/_integrations/rflink.markdown
+++ b/source/_integrations/rflink.markdown
@@ -36,7 +36,7 @@ This {% term integration %} is tested with the following hardware/software:
 
 The 433 MHz spectrum is used by many manufacturers. Mostly using their own protocol/standard, they use this spectrum to communicate with devices such as light switches, blinds, weather stations, alarms, and various other sensors.
 
-The RFLink Gateway supports a number of RF frequencies, using a wide range of low-cost hardware. [Their website](https://www.rflink.nl) provides details for various RF transmitters, receivers, and transceiver modules for 433MHz, 868MHz, and 2.4 GHz.
+The RFLink Gateway supports several RF frequencies, using a wide range of low-cost hardware. [Their website](https://www.rflink.nl) provides details for various RF transmitters, receivers, and transceiver modules for 433MHz, 868MHz, and 2.4 GHz.
 
 {% note %}
 Versions later than R44 add support for IKEA Ansluta, Philips Living Colors Gen1, and MySensors devices.

--- a/source/_integrations/smappee.markdown
+++ b/source/_integrations/smappee.markdown
@@ -74,7 +74,7 @@ smappee:
 
 Once Home Assistant restarted, go to **Settings** > **Devices & services** and select the Smappee integration. You will be redirected to a login page and be able to select the locations you would like to use within Home Assistant.
 
-Using the Smappee cloud integration allows you to access your Smappee monitor and other shared devices from outside your local network. Additionally a number of (binary) sensor entities become available as well.
+Using the Smappee cloud integration allows you to access your Smappee monitor and other shared devices from outside your local network. Additionally, several (binary) sensor entities become available as well.
 
 ### Sensor
 

--- a/source/_integrations/tellstick.markdown
+++ b/source/_integrations/tellstick.markdown
@@ -22,7 +22,7 @@ related:
 ha_quality_scale: legacy
 ---
 
-The **TellStick** {% term integration %} integrates [TellStick][tellstick-gateway] devices into Home Assistant. This integration allows users to add switches, lights, and sensors which are communicating with 433 MHz. There are a number of vendors (Capidi Elro, Intertechno, Nexa, Proove, Sartano, and Viking) who are selling products that work with TellStick. For more details, please check the TellStick [protocol list](http://developer.telldus.com/wiki/TellStick_conf).
+The **TellStick** {% term integration %} integrates [TellStick][tellstick-gateway] devices into Home Assistant. This integration allows users to add switches, lights, and sensors which are communicating with 433 MHz. There are several vendors (Capidi Elro, Intertechno, Nexa, Proove, Sartano, and Viking) who are selling products that work with TellStick. For more details, please check the TellStick [protocol list](http://developer.telldus.com/wiki/TellStick_conf).
 
 There is currently support for the following device types within Home Assistant:
 

--- a/source/_integrations/unifiprotect.markdown
+++ b/source/_integrations/unifiprotect.markdown
@@ -225,7 +225,7 @@ Each UniFi Protect siren is added as a separate device in Home Assistant, linked
 
 ### NVR
 
-Your main UniFi Protect <abbr title="Network Video Recorder">NVR</abbr> device also gets a number of entities that can be used for tracking and controlling your UniFi Protect system:
+Your main UniFi Protect <abbr title="Network Video Recorder">NVR</abbr> device also gets several entities that can be used for tracking and controlling your UniFi Protect system:
 
 - **Alarm Manager**: An alarm control panel entity to arm and disarm the NVR Alarm Manager. It arms using the currently selected alarm profile and always reports the generic _armed away_ state. The name of the active profile is shown by the **Alarm profile** entity instead. This requires UniFi Protect 7.1 or later. See [Public API features](#public-api-features).
 - **Alarm profile**: A select entity that lets you switch between the alarm profiles configured in UniFi Protect. The state reflects the currently active alarm profile. You can only change the profile while the alarm is disarmed. To switch profiles while armed, disarm first, select the new profile, and arm again. This requires UniFi Protect 7.1 or later. See [Public API features](#public-api-features).

--- a/source/_integrations/wled.markdown
+++ b/source/_integrations/wled.markdown
@@ -130,7 +130,7 @@ for the following information from WLED:
 
 ### Switches
 
-The {% term integration %} will also create a number of
+The {% term integration %} will also create several
 [switch entities](/integrations/switch).
 
 #### Nightlight


### PR DESCRIPTION
## Proposed change

Replaces the wordy "a number of" with "several" across integration pages where it refers to an unspecified quantity of countable things (sensors, entities, features, and so on). Literal-quantity uses such as "a number of seconds" are intentionally left untouched.

## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards