### PR TITLE
Use "many" instead of the wordy "a large number of"

### DIFF
--- a/source/_integrations/anthropic.markdown
+++ b/source/_integrations/anthropic.markdown
@@ -96,7 +96,7 @@ Enable web fetch:
 Maximum web fetches:
   description: Limits the number of web fetches that can be performed per user request.
 Enable tool search tool:
-  description: With [this tool](https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-search-tool), instead of loading all tool definitions into the context window upfront, Claude searches the tool catalog and loads only the tools it needs. This may improve performance if you don't need to control devices every time, or if you have a long prompt or a large number of additional tools.
+  description: With [this tool](https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-search-tool), instead of loading all tool definitions into the context window upfront, Claude searches the tool catalog and loads only the tools it needs. This may improve performance if you don't need to control devices every time, or if you have a long prompt or many additional tools.
 {% endconfiguration_basic %}
 
 ## Supported features
@@ -115,7 +115,7 @@ The following table describes which [API features](https://platform.claude.com/d
 |---|---|---|---|
 | [Context windows](https://platform.claude.com/docs/en/build-with-claude/context-windows) | Up to 1M tokens for processing large documents, extensive codebases, and long conversations. | Supported | This is a basic feature, supported by default |
 | [Adaptive thinking](https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking) | Let Claude dynamically decide when and how much to think. Use the effort parameter to control thinking depth. | Supported | Use the **Thinking effort** parameter to control the effort for 4.6+ models |
-| [Batch processing](https://platform.claude.com/docs/en/build-with-claude/batch-processing) | Process large volumes of requests asynchronously for cost savings. Send batches with a large number of queries per batch. Batch API calls cost 50% less than standard API calls. | Not supported | This feature does not apply to Home Assistant. There is currently no clear smart home use case for batch processing. |
+| [Batch processing](https://platform.claude.com/docs/en/build-with-claude/batch-processing) | Process large volumes of requests asynchronously for cost savings. Send batches with many queries per batch. Batch API calls cost 50% less than standard API calls. | Not supported | This feature does not apply to Home Assistant. There is currently no clear smart home use case for batch processing. |
 | [Citations](https://platform.claude.com/docs/en/build-with-claude/citations) | Ground Claude's responses in source documents. With Citations, Claude can provide detailed references to the exact sentences and passages it uses to generate responses, leading to more verifiable, trustworthy outputs. | Not supported | We support receiving the citations but don't currently display them in the interface |
 | [Data residency](https://platform.claude.com/docs/en/build-with-claude/data-residency) | Control where model inference runs using geographic controls. Specify `"global"` or `"us"` routing per request via the `inference_geo` parameter. | Not supported | We might add support later, but it is not clear why you would need this in Home Assistant |
 | [Effort](https://platform.claude.com/docs/en/build-with-claude/effort) | Control how many tokens Claude uses when responding with the effort parameter, trading off between response thoroughness and token efficiency. Supported on Opus 4.6 and Opus 4.5. | Supported | Use the **Thinking effort** parameter to control the effort for 4.6+ models |

--- a/source/_integrations/homee.markdown
+++ b/source/_integrations/homee.markdown
@@ -88,7 +88,7 @@ Commands of the "Warema WMS Handsender" remote controls are not passed to the ex
 
 Homeegrams are {% term automations %} in homee. The integration implements them as {% term switches %} that the user can trigger and that momentarily turn on if the Homeegram is played in homee, so they can also be used as a {% term trigger %} in Home Assistant.
 Although turning off a Homeegram in HA can be triggered by the user, it is not supported and will raise an error.
-Only Homeegrams that perform at least two actions are enabled by default to avoid creating a large number of low-value entities in your Home Assistant installation.
+Only Homeegrams that perform at least two actions are enabled by default to avoid creating many low-value entities in your Home Assistant installation.
 
 ## Limitations
 

--- a/source/_integrations/homekit.markdown
+++ b/source/_integrations/homekit.markdown
@@ -531,7 +531,7 @@ The following home hubs showed strong results when testing with 300 accessories:
 
 - Apple TV 4k Gen 1 (best results when using ethernet instead of Wi-Fi)
 
-The following home hubs have been reported to have trouble with a large number of accessories:
+The following home hubs have been reported to have trouble with many accessories:
 
 - Apple TV HD
 - Various iPad models

--- a/source/_integrations/mqtt.markdown
+++ b/source/_integrations/mqtt.markdown
@@ -1454,7 +1454,7 @@ mqtt:
       ...
 ```
 
-If you have a large number of manually configured items, you might want to consider [splitting up the configuration](/docs/configuration/splitting_configuration/).
+If you have many manually configured items, you might want to consider [splitting up the configuration](/docs/configuration/splitting_configuration/).
 
 {% note %}
 Documentation on the MQTT components that support YAML [can be found here](/integrations/mqtt/#configuration-via-yaml).

--- a/source/_integrations/zwave_js.markdown
+++ b/source/_integrations/zwave_js.markdown
@@ -1325,7 +1325,7 @@ _Many_ reported issues result from RF interference caused by the system's USB po
 
 After ensuring you are using an extension cable, rebuild network routes.
 
-The combination of these two steps corrects a large number of reported difficulties.
+The combination of these two steps corrects many reported difficulties.
 
 ### My Z-Wave adapter isn't recognized automatically during setup
 


### PR DESCRIPTION
## Proposed change

Replaces the wordy "a large number of" with "many" across integration pages. This keeps the large-quantity meaning while reading more plainly.

## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards