### PR TITLE
Rewrite AdGuard Home docs and move actions to dedicated pages

### DIFF
--- a/source/_actions/adguard.add_url.markdown
+++ b/source/_actions/adguard.add_url.markdown
@@ -1,0 +1,108 @@
+---
+title: "Add URL"
+action: adguard.add_url
+domain: adguard
+description: "Adds a new filter subscription to AdGuard Home."
+related_actions:
+  - adguard.remove_url
+  - adguard.enable_url
+  - adguard.disable_url
+  - adguard.refresh
+---
+
+The **Add URL** action subscribes AdGuard Home to a new filter list. AdGuard Home downloads the rules from the URL you provide and starts blocking the domains on that list.
+
+This is handy when you want to bring an extra blocklist online only when you need it, for example a stricter list during exam week or a seasonal list around the holidays, instead of adding it by hand in the AdGuard Home interface.
+
+{% include actions/ui_header.md %}
+
+To add a filter subscription from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **AdGuard Home: Add URL**.
+6. Enter a **Name** for the subscription and the **URL** of the filter list.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Name:
+  description: The name of the filter subscription.
+  required: true
+URL:
+  description: The filter URL to subscribe to, containing the filter rules.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `adguard.add_url`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: adguard.add_url
+  data:
+    name: "Example blocklist"
+    url: "https://www.example.com/filter/1.txt"
+{% endexample %}
+
+This subscribes AdGuard Home to the filter list at the given URL.
+
+### Options in YAML
+
+{% options_yaml %}
+name:
+  description: >
+    The name of the filter subscription.
+  required: true
+  type: string
+url:
+  description: >
+    The filter URL to subscribe to, containing the filter rules.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+## Good to know
+
+- A newly added subscription is enabled right away.
+- AdGuard Home does not block on the new rules until it has downloaded the list. To apply them immediately, follow this action with [Refresh](/actions/adguard.refresh/).
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: add a stricter blocklist during study time
+
+When study time starts, subscribe to an extra blocklist and refresh AdGuard Home so the rules take effect right away.
+
+- **Trigger**: A study-time helper turns on
+- **Action**: AdGuard Home: Add URL, followed by AdGuard Home: Refresh
+
+{% details "YAML example for adding a blocklist during study time" %}
+
+{% example %}
+automation: |
+  alias: "Add study-time blocklist"
+  triggers:
+    - trigger: state
+      entity_id: input_boolean.study_time
+      to: "on"
+  actions:
+    - action: adguard.add_url
+      data:
+        name: "Study-time blocklist"
+        url: "https://www.example.com/study-blocklist.txt"
+    - action: adguard.refresh
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/adguard.disable_url.markdown
+++ b/source/_actions/adguard.disable_url.markdown
@@ -1,0 +1,96 @@
+---
+title: "Disable URL"
+action: adguard.disable_url
+domain: adguard
+description: "Disables a filter subscription in AdGuard Home."
+related_actions:
+  - adguard.enable_url
+  - adguard.add_url
+  - adguard.remove_url
+  - adguard.refresh
+---
+
+The **Disable URL** action switches off a filter subscription without removing it. AdGuard Home keeps the list, but stops blocking the domains on it until you switch it back on.
+
+Use this when you want to relax filtering for a while, then return to it later. Because the subscription stays in place, you can turn it back on at any time with [Enable URL](/actions/adguard.enable_url/), which makes the two a natural pair for scheduled blocking.
+
+{% include actions/ui_header.md %}
+
+To disable a filter subscription from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **AdGuard Home: Disable URL**.
+6. Enter the **URL** of the filter list you want to disable.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+URL:
+  description: The filter subscription URL to disable.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `adguard.disable_url`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: adguard.disable_url
+  data:
+    url: "https://www.example.com/filter/1.txt"
+{% endexample %}
+
+This switches the matching filter subscription off while keeping it in AdGuard Home.
+
+### Options in YAML
+
+{% options_yaml %}
+url:
+  description: >
+    The filter subscription URL to disable.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+## Good to know
+
+- The subscription stays in AdGuard Home, so you can switch it back on later with [Enable URL](/actions/adguard.enable_url/).
+- To remove a list completely instead of just switching it off, use [Remove URL](/actions/adguard.remove_url/).
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: relax filtering after bedtime hours
+
+Switch the stricter bedtime blocklist back off in the morning so normal browsing resumes.
+
+- **Trigger**: Time, 07:00
+- **Action**: AdGuard Home: Disable URL
+
+{% details "YAML example for disabling a blocklist in the morning" %}
+
+{% example %}
+automation: |
+  alias: "Disable bedtime blocklist"
+  triggers:
+    - trigger: time
+      at: "07:00:00"
+  actions:
+    - action: adguard.disable_url
+      data:
+        url: "https://www.example.com/bedtime-blocklist.txt"
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/adguard.enable_url.markdown
+++ b/source/_actions/adguard.enable_url.markdown
@@ -1,0 +1,97 @@
+---
+title: "Enable URL"
+action: adguard.enable_url
+domain: adguard
+description: "Enables a filter subscription in AdGuard Home."
+related_actions:
+  - adguard.disable_url
+  - adguard.add_url
+  - adguard.remove_url
+  - adguard.refresh
+---
+
+The **Enable URL** action switches on a filter subscription that was previously turned off. AdGuard Home starts blocking the domains on that list again, without you having to add the list from scratch.
+
+This pairs nicely with [Disable URL](/actions/adguard.disable_url/) to turn a blocklist on and off on a schedule, for example a stricter list that switches on during homework time or at bedtime.
+
+{% include actions/ui_header.md %}
+
+To enable a filter subscription from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **AdGuard Home: Enable URL**.
+6. Enter the **URL** of the filter list you want to enable.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+URL:
+  description: The filter subscription URL to enable.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `adguard.enable_url`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: adguard.enable_url
+  data:
+    url: "https://www.example.com/filter/1.txt"
+{% endexample %}
+
+This switches the matching filter subscription back on.
+
+### Options in YAML
+
+{% options_yaml %}
+url:
+  description: >
+    The filter subscription URL to enable.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+## Good to know
+
+- The list must already be added to AdGuard Home. To bring a brand-new list online, use [Add URL](/actions/adguard.add_url/) instead.
+- To apply the rules right away instead of waiting for the next scheduled update, follow this action with [Refresh](/actions/adguard.refresh/).
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: enable a stricter blocklist at bedtime
+
+Switch on a stricter blocklist for the kids' devices every evening, and refresh AdGuard Home so it applies straight away.
+
+- **Trigger**: Time, 20:00
+- **Action**: AdGuard Home: Enable URL, followed by AdGuard Home: Refresh
+
+{% details "YAML example for enabling a blocklist at bedtime" %}
+
+{% example %}
+automation: |
+  alias: "Enable bedtime blocklist"
+  triggers:
+    - trigger: time
+      at: "20:00:00"
+  actions:
+    - action: adguard.enable_url
+      data:
+        url: "https://www.example.com/bedtime-blocklist.txt"
+    - action: adguard.refresh
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/adguard.refresh.markdown
+++ b/source/_actions/adguard.refresh.markdown
@@ -1,0 +1,92 @@
+---
+title: "Refresh"
+action: adguard.refresh
+domain: adguard
+description: "Refreshes all filter subscriptions in AdGuard Home."
+related_actions:
+  - adguard.add_url
+  - adguard.remove_url
+  - adguard.enable_url
+  - adguard.disable_url
+---
+
+The **Refresh** action tells AdGuard Home to re-download all of its filter subscriptions and pull in the latest blocking rules. This keeps your blocklists current and applies any changes right away.
+
+It pairs well with the other actions. After you add or enable a list, a refresh makes the new rules take effect immediately instead of waiting for AdGuard Home's next scheduled update.
+
+{% include actions/ui_header.md %}
+
+To refresh your filter subscriptions from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **AdGuard Home: Refresh**.
+6. _Optional_: Turn on **Force** to bypass AdGuard Home's update throttling.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Force:
+  description: Force the update, bypassing AdGuard Home's throttling. Leave off for a regular refresh.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `adguard.refresh`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: adguard.refresh
+{% endexample %}
+
+This refreshes all filter subscriptions in AdGuard Home.
+
+### Options in YAML
+
+{% options_yaml %}
+force:
+  description: >
+    Force the update, bypassing AdGuard Home's throttling. Omit for a regular refresh.
+  required: false
+  type: boolean
+  default: false
+{% endoptions_yaml %}
+
+## Good to know
+
+- AdGuard Home normally throttles filter updates to reduce load. Only turn on **Force** when you need the rules updated immediately, and use it sparingly.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: refresh blocklists every night
+
+Keep your blocklists current by refreshing them once a day, while everyone is asleep.
+
+- **Trigger**: Time, 04:00
+- **Action**: AdGuard Home: Refresh
+
+{% details "YAML example for a nightly blocklist refresh" %}
+
+{% example %}
+automation: |
+  alias: "Refresh AdGuard Home blocklists nightly"
+  triggers:
+    - trigger: time
+      at: "04:00:00"
+  actions:
+    - action: adguard.refresh
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/adguard.remove_url.markdown
+++ b/source/_actions/adguard.remove_url.markdown
@@ -1,0 +1,97 @@
+---
+title: "Remove URL"
+action: adguard.remove_url
+domain: adguard
+description: "Removes a filter subscription from AdGuard Home."
+related_actions:
+  - adguard.add_url
+  - adguard.enable_url
+  - adguard.disable_url
+  - adguard.refresh
+---
+
+The **Remove URL** action deletes a filter subscription from AdGuard Home. AdGuard Home stops using the rules from that list and removes the subscription completely.
+
+Use this to clean up a blocklist you no longer need, such as a temporary list you added earlier. If you only want to switch a list off for a while and keep it around, use [Disable URL](/actions/adguard.disable_url/) instead.
+
+{% include actions/ui_header.md %}
+
+To remove a filter subscription from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **AdGuard Home: Remove URL**.
+6. Enter the **URL** of the filter list you want to remove.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+URL:
+  description: The filter subscription URL to remove.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `adguard.remove_url`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: adguard.remove_url
+  data:
+    url: "https://www.example.com/filter/1.txt"
+{% endexample %}
+
+This removes the matching filter subscription from AdGuard Home.
+
+### Options in YAML
+
+{% options_yaml %}
+url:
+  description: >
+    The filter subscription URL to remove.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+## Good to know
+
+- The URL you provide must match the subscription URL exactly. You can find the exact URL in the AdGuard Home interface under **Filters** > **DNS blocklists**.
+- To switch a list off temporarily without deleting it, use [Disable URL](/actions/adguard.disable_url/) instead.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: remove the study-time blocklist afterward
+
+When study time ends, remove the extra blocklist you added earlier so normal browsing resumes.
+
+- **Trigger**: A study-time helper turns off
+- **Action**: AdGuard Home: Remove URL
+
+{% details "YAML example for removing a blocklist when study time ends" %}
+
+{% example %}
+automation: |
+  alias: "Remove study-time blocklist"
+  triggers:
+    - trigger: state
+      entity_id: input_boolean.study_time
+      to: "off"
+  actions:
+    - action: adguard.remove_url
+      data:
+        url: "https://www.example.com/study-blocklist.txt"
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/adguard.markdown
+++ b/source/_integrations/adguard.markdown
@@ -19,17 +19,19 @@ ha_platforms:
 ha_integration_type: service
 ---
 
-The **AdGuard Home** {% term integration %} allows you to control and monitor your [AdGuard Home](https://adguard.com/adguard-home/overview.html) instance in Home Assistant.
+The **AdGuard Home** {% term integration %} lets you monitor and control your [AdGuard Home](https://adguard.com/adguard-home/overview.html) instance from Home Assistant.
 
-AdGuard Home is a network-wide software for blocking advertisements and tracking. It provides DNS-level protection, automatically covering all home devices without requiring client-side software. When you use AdGuard Home as your DNS server, it blocks advertisements, trackers, and malicious domains for all devices on your network.
+AdGuard Home is network-wide software for blocking advertisements and tracking. It works at the DNS level, so once your devices use it as their DNS server, every phone, laptop, tablet, and smart device on your network is protected automatically, with nothing to install on each one. It blocks ads, trackers, and known malicious domains across the board.
+
+With this integration, you can keep an eye on how much AdGuard Home is blocking right from your dashboard, and turn its protection features on or off without opening the AdGuard Home interface. Picture stricter filtering switching on the moment guests join your Wi-Fi, parental controls turning on while the kids do their homework, and a notification reaching you when DNS lookups start to slow down. Because every feature is available to your automations, you decide when and how your network protects itself.
 
 ## Prerequisites
 
-Before setting up the AdGuard Home integration, ensure you have:
+Before you set up the integration, make sure you have:
 
-1. AdGuard Home installed and running on your network
-2. The IP address or hostname of your AdGuard Home instance
-3. Admin access to AdGuard Home
+- AdGuard Home installed and running on your network
+- The IP address or hostname of your AdGuard Home instance
+- Admin access to AdGuard Home
 
 {% include integrations/config_flow.md %}
 
@@ -50,34 +52,34 @@ Verify SSL certificate:
 
 ### Sensors
 
-This integration provides sensors for the following information from AdGuard Home:
+This integration provides sensors that give you insight into what AdGuard Home is doing on your network:
 
-- Number of DNS queries.
-- Number of blocked DNS queries.
-- Ratio (%) of blocked DNS queries.
-- Number of requests blocked by safe browsing.
-- Number of safe searches enforced.
-- Number of requests blocked by parental control.
-- Total number of active filter rules loaded.
-- Average response time of AdGuard's DNS server in milliseconds.
+- **DNS queries**: The total number of DNS lookups AdGuard Home has handled.
+- **DNS queries blocked**: How many of those lookups were blocked.
+- **DNS queries blocked ratio**: The share of all queries that were blocked, as a percentage.
+- **Safe browsing blocked**: The number of requests blocked for matching known phishing or malware sites.
+- **Safe searches enforced**: How many times safe search was enforced on search engines.
+- **Parental control blocked**: The number of requests blocked by parental control.
+- **Rules count**: The total number of active filter rules currently loaded.
+- **Average processing speed**: The average response time of the AdGuard Home DNS server, in milliseconds.
 
 ### Switches
 
 The integration provides switches to control AdGuard Home features:
 
-- **AdGuard protection**: Master switch that controls all AdGuard features
-- **Filtering**: Enables DNS filtering using blocklists
-- **Safe browsing**: Blocks known phishing and malware sites
-- **Parental control**: Blocks adult content
-- **Safe search**: Enforces safe search on search engines
-- **Query log**: Records DNS queries for statistics
+- **Protection**: The master switch that controls all AdGuard Home protection at once.
+- **Filtering**: Enables DNS filtering using your blocklists.
+- **Safe browsing**: Blocks known phishing and malware sites.
+- **Parental control**: Blocks adult content.
+- **Safe search**: Enforces safe search on search engines.
+- **Query log**: Records DNS queries, which AdGuard Home needs to produce statistics.
 
 These switches enable powerful automations. For example, you could automatically enable parental controls during school hours or disable ad blocking for specific time periods.
 
-The **AdGuard protection** switch acts as a master control. When turned off, it bypasses all AdGuard features regardless of individual switch states.
+The **Protection** switch acts as a master control. When turned off, it bypasses all AdGuard Home protection, regardless of the individual switch states.
 
 {% important %}
-Turning off **Query log** stops all sensor updates. AdGuard requires query logging to provide statistics.
+Turning off **Query log** stops all sensor updates. AdGuard Home requires query logging to provide statistics.
 {% endimportant %}
 
 ### Update
@@ -88,58 +90,7 @@ The integration provides an {% term update %} entity to check for and install Ad
 For Docker-based installations of AdGuard Home, no update entity is available for the AdGuard Home software. If you have installed the [AdGuard Home app for Home Assistant](https://github.com/hassio-addons/addon-adguard-home) (formerly known as AdGuard Home add-on) on {% term "Home Assistant Operating System" %}, Home Assistant provides an update entity for the AdGuard Home app for Home Assistant.
 {% endnote %}
 
-## Actions
-
-The integration provides {% term actions %} to manage filter subscriptions in AdGuard Home. Use these actions in automations to dynamically control content filtering based on time, presence, or other conditions.
-
-For example, you could create automations that:
-
-- Block social media during work hours
-- Enable strict filtering when guests connect to your network
-- Temporarily disable filtering for specific downloads
-
-### Action: Add URL
-
-The `adguard.add_url` action is used to add a new filter subscription to AdGuard Home.
-
-| Data attribute | Optional | Description                                   |
-| -------------- | -------- | --------------------------------------------- |
-| `name`         | No       | The name of the filter subscription           |
-| `url`          | No       | The filter list URL containing blocking rules |
-
-### Action: Remove URL
-
-The `adguard.remove_url` action is used to remove a filter subscription from AdGuard Home.
-
-| Data attribute | Optional | Description                           |
-| -------------- | -------- | ------------------------------------- |
-| `url`          | No       | The filter subscription URL to remove |
-
-### Action: Enable URL
-
-The `adguard.enable_url` action is used to enable a previously disabled filter subscription.
-
-| Data attribute | Optional | Description                           |
-| -------------- | -------- | ------------------------------------- |
-| `url`          | No       | The filter subscription URL to enable |
-
-### Action: Disable URL
-
-The `adguard.disable_url` action is used to temporarily disable a filter subscription without removing it.
-
-| Data attribute | Optional | Description                            |
-| -------------- | -------- | -------------------------------------- |
-| `url`          | No       | The filter subscription URL to disable |
-
-### Action: Refresh
-
-The `adguard.refresh` action is used to refresh all filter subscriptions to get the latest blocking rules.
-
-| Data attribute | Optional | Description                                     |
-| -------------- | -------- | ----------------------------------------------- |
-| `force`        | Yes      | Force update (bypasses AdGuard Home throttling) |
-
-By default, `force` is `false`. AdGuard Home normally throttles filter updates to reduce server load. Use forced updates sparingly.
+{% include integrations/actions.md %}
 
 ## Examples
 
@@ -216,6 +167,10 @@ automation:
 ## Data updates
 
 The AdGuard Home integration polls for updates every 10 seconds to provide near real-time statistics and ensure switch states remain synchronized.
+
+## Known limitations
+
+AdGuard Home only filters devices that use it as their DNS server. A device on mobile data, connected through a VPN, or set to use a different DNS server bypasses AdGuard Home entirely. For those devices, your blocklists, parental controls, and safe browsing settings do not apply.
 
 ## Troubleshooting
 

--- a/source/_integrations/adguard.markdown
+++ b/source/_integrations/adguard.markdown
@@ -21,7 +21,7 @@ ha_integration_type: service
 
 The **AdGuard Home** {% term integration %} lets you monitor and control your [AdGuard Home](https://adguard.com/adguard-home/overview.html) instance from Home Assistant.
 
-AdGuard Home is network-wide software for blocking advertisements and tracking. It works at the DNS level, so once your devices use it as their DNS server, every phone, laptop, tablet, and smart device on your network is protected automatically, with nothing to install on each one. It blocks ads, trackers, and known malicious domains across the board.
+AdGuard Home is network-wide software for blocking advertisements and tracking. It works at the DNS level, so once your devices use it as their DNS server, every phone, laptop, tablet, and smart device on your network is protected automatically, with nothing to install on each one. It blocks advertisements, trackers, and known malicious domains across the board.
 
 With this integration, you can keep an eye on how much AdGuard Home is blocking right from your dashboard, and turn its protection features on or off without opening the AdGuard Home interface. Picture stricter filtering switching on the moment guests join your Wi-Fi, parental controls turning on while the kids do their homework, and a notification reaching you when DNS lookups start to slow down. Because every feature is available to your automations, you decide when and how your network protects itself.
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Rewrites the AdGuard Home integration page for clarity and moves its five filter list actions into dedicated action collection pages.

The integration page gains a use-case driven introduction, the sensor and switch entities now use their real names (verified against the integration's `strings.json`, including the master switch, which is **Protection**, not "AdGuard protection"), the prerequisites became a bulleted list, and a **Known limitations** section explains that AdGuard Home only filters devices that use it as their DNS server. The five inline action tables are replaced by `{% include integrations/actions.md %}`.

The new action pages (`add_url`, `remove_url`, `enable_url`, `disable_url`, `refresh`) each include a UI walkthrough, UI and YAML option references, and a worked automation example. All parameters, requiredness, and defaults are verified against the integration's `services.yaml` and `strings.json`.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
