### PR TITLE
Rewrite Rituals Perfume Genie docs

### DIFF
--- a/source/_integrations/rituals_perfume_genie.markdown
+++ b/source/_integrations/rituals_perfume_genie.markdown
@@ -25,69 +25,75 @@ ha_platforms:
 ha_integration_type: hub
 ---
 
-The [Rituals Perfume Genie](https://www.rituals.com/perfume-genie-b2b.html) {% term integration %} allows you to control and monitor your Rituals perfume diffusers connected to your Rituals account.
+The **Rituals Perfume Genie** {% term integration %} lets you control and monitor your [Rituals](https://www.rituals.com/) perfume diffusers from Home Assistant.
 
-## Use cases
+The Perfume Genie is a smart fragrance diffuser. Once it is connected to your home Wi-Fi and linked to your Rituals account, this integration brings it into Home Assistant. You can start and stop the fragrance, set how much is diffused, and keep an eye on the cartridge and battery, all without reaching for the Rituals app.
 
-- Monitor current device state.
-- Control fragrance diffusion and amount.
-- Expose cartridge level, type and room configuration.
+That opens the door to fragrance that follows your day. Picture the diffuser easing on as you walk through the door in the evening, winding down on its own at bedtime, and a gentle reminder reaching you when the cartridge runs low. Because every control is available to your automations, your home can set the mood on its own.
 
 ## Supported devices
 
+The following devices are supported by this integration:
+
 - Rituals Perfume Genie
-- Rituals Perfume Genie 2nd Generation
-- Rituals Perfume Genie 3rd Generation
+- Rituals Perfume Genie 2nd generation
+- Rituals Perfume Genie 3rd generation
+
+## Prerequisites
+
+Before you set up the integration, make sure you have:
+
+- A Rituals account.
+- Your Perfume Genie set up in the Rituals mobile app and connected to your Wi-Fi network.
+- The email address and password for your Rituals account.
 
 {% include integrations/config_flow.md %}
 
 {% configuration_basic %}
 Email:
-  description: "The email address used to register your Rituals Perfume Genie."
+  description: "The email address for your Rituals account."
 Password:
-  description: "The password used to register your Rituals Perfume Genie."
+  description: "The password for your Rituals account."
 {% endconfiguration_basic %}
 
 ## Supported functionality
 
-The integration will fetch data from each device.
-Below is a complete overview of the entities this integration provides.
+Each diffuser on your Rituals account is added to Home Assistant as a device, with the entities described below.
 
-{% important %}
-Some entities are only available on the battery powered model.
-{% endimportant %}
-
-### Binary Sensor
-
-- Charging state
-
-### Number
-
-- Perfume amount
-
-### Select
-
-- Room size
-
-### Sensor
-
-- Battery percentage
-- Fill level
-- Perfume label
-- WiFi signal
+{% note %}
+The entities you see depend on your model. The battery and charging entities appear on the battery-powered model only. On mains-powered models, the **Room size** control is disabled by default. You can turn it on from the entity's settings if you want to use it.
+{% endnote %}
 
 ### Switch
 
-- Fan
+- **Diffuser**: The main switch for the diffuser. Turn it on to start diffusing fragrance, and off to stop. This switch carries the name of your diffuser.
+
+### Number
+
+- **Perfume amount**: Sets how much fragrance is diffused, on a scale from 1 (lightest) to 3 (strongest).
+
+### Select
+
+- **Room size**: Tells the diffuser how large the room is, in square meters, so it can pace the fragrance to suit the space. You can choose 15, 30, 60, or 100.
+
+### Binary sensor
+
+- **Charging**: Shows whether the diffuser's battery is charging. Available on the battery-powered model only.
+
+### Sensors
+
+- **Battery**: The remaining battery charge, as a percentage. Available on the battery-powered model only.
+- **Fill**: How full the current fragrance cartridge is.
+- **Perfume**: The name of the fragrance cartridge currently in the diffuser.
+- **Wi-Fi signal**: The strength of the diffuser's Wi-Fi connection, as a percentage.
 
 ## Examples
 
-The following examples show how to use the Rituals Perfume Genie integration in Home Assistant automations.
-These examples are just a starting point, and you can use them as inspiration to create your own automations.
+The following example shows how to use the Rituals Perfume Genie integration in a Home Assistant automation. It is a starting point you can build on for your own ideas.
 
-### Turn the Perfume Genie on at a specific time
+### Turn the diffuser on at a specific time
 
-The following example will turn on the Perfume Genie at 18:00.
+This automation starts the fragrance every evening at 18:00.
 
 ```yaml
 automation:
@@ -95,15 +101,45 @@ automation:
     triggers:
       - trigger: time
         at: "18:00:00"
-
     actions:
       - action: switch.turn_on
         target:
           entity_id: switch.rituals_perfume_genie_diffuser
 ```
 
+## Data updates
+
+Home Assistant {% term polling polls %} your Rituals account for updates every few minutes. With a single diffuser, it polls every 3 minutes. Each additional diffuser on your account lengthens that interval, which keeps Home Assistant within the limits of the Rituals service.
+
+## Known limitations
+
+- The integration relies on the Rituals cloud service. If your internet connection or the Rituals service is unavailable, Home Assistant cannot read from or control your diffuser.
+- The battery and charging entities are available on the battery-powered model only.
+
+## Troubleshooting
+
+### Authentication fails or the diffuser stops updating
+
+#### Symptom: "Reauthentication required" or entities show as unavailable
+
+After a while, Home Assistant can no longer reach your Rituals account, or you are asked to sign in again.
+
+##### Resolution
+
+1. Confirm you can sign in to the Rituals mobile app with the same email address and password.
+2. If you recently changed your Rituals password, enter the new password when Home Assistant prompts you to reauthenticate.
+3. Check that the diffuser is powered on and connected to your Wi-Fi network in the Rituals app.
+
+### A diffuser is missing from Home Assistant
+
+If one of your diffusers does not appear:
+
+1. Open the Rituals mobile app and confirm the diffuser is registered to your account and online.
+2. Make sure the diffuser is connected to your Wi-Fi network.
+3. Reload the integration from its page under {% my integrations title="**Settings** > **Devices & services**" %}.
+
 ## Removing the integration
 
-This integration follows standard integration removal, no extra steps are required.
+This integration follows standard integration removal. No extra steps are required.
 
 {% include integrations/remove_device_service.md %}


### PR DESCRIPTION
## Proposed change

Brings the Rituals Perfume Genie integration page up to standard. The introduction now leads with a scenario-driven overview, and the page gains Prerequisites, Data updates, Known limitations, and Troubleshooting sections. Each entity is explained in plain language.

It also corrects several inaccuracies against the integration: the switch is the main diffuser control (named after the device, not "Fan"), the sensors are named Battery, Fill, Perfume, and Wi-Fi signal, the binary sensor is Charging, and the Perfume amount (1-3) and Room size (15/30/60/100 m²) ranges are now documented.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards