### PR TITLE
Build out Open-Meteo documentation

### DIFF
--- a/source/_integrations/open_meteo.markdown
+++ b/source/_integrations/open_meteo.markdown
@@ -15,14 +15,59 @@ ha_platforms:
 ha_integration_type: service
 ---
 
-The **Open-Meteo** {% term integration %} integrates the free weather forecast from
-[Open-Meteo](https://open-meteo.com) with Home Assistant.
+The **Open-Meteo** {% term integration %} adds free weather forecasts to Home Assistant for any location you choose, with no account or API key to set up.
 
-Open-Meteo offers free weather forecast APIs for open-source developers and
-non-commercial use. No account or API key is required to use this service.
+[Open-Meteo](https://open-meteo.com) is a weather service that is free for open-source and non-commercial use. It works together with national weather services and picks the best available forecast model for your location, at a resolution of 1 to 11 km. Point it at your home, a holiday address, or any other place you have set up as a zone, and Home Assistant gets the current conditions and a forecast you can show on a dashboard or use to drive automations, such as a reminder to bring in the laundry before the rain arrives.
 
-Open-Meteo collaborates with National Weather Services providing Open Data
-with 1 to 11 km resolution. Their high-performance APIs select the best
-weather model for your location.
+## Prerequisites
+
+You need a {% term zone %} to forecast for. Home Assistant already has a Home zone set to your installation's location, so in most cases there is nothing to prepare. To forecast for another place, add a zone first under {% my zones title="**Settings** > **Areas, labels & zones**" %}.
+
+No account or API key is required.
 
 {% include integrations/config_flow.md %}
+
+{% configuration_basic %}
+Zone:
+  description: "The zone whose location is used for the weather forecast. Choose the Home zone, or any other zone you have created."
+{% endconfiguration_basic %}
+
+Each zone you add gives you one weather entity, named after that zone. To forecast for more than one location, add the integration again and choose a different zone.
+
+## Supported functionality
+
+### Weather
+
+The integration provides a single weather entity for the selected zone. It reports the current conditions along with a daily and an hourly forecast.
+
+The current conditions include:
+
+- The weather condition, such as sunny, cloudy, or rainy
+- Temperature
+- Wind speed and direction
+
+The daily forecast adds a high and low temperature, expected precipitation, and wind for each day. The hourly forecast covers the condition, temperature, and precipitation for the hours ahead.
+
+You can show the forecast on a dashboard with the weather card, or read it in an automation or script with the [`weather.get_forecasts`](/integrations/weather/) action. Temperature, wind speed, and precipitation are shown in the units from your Home Assistant settings.
+
+## Data updates
+
+Home Assistant {% term polling polls %} Open-Meteo for new data every 30 minutes.
+
+## Known limitations
+
+- Open-Meteo is free for open-source and non-commercial use. For commercial use, see the [Open-Meteo website](https://open-meteo.com).
+- A forecast is only as precise as the weather model available for the chosen location, so accuracy varies from place to place.
+- New data arrives every 30 minutes, so the current conditions are not real-time.
+
+## Troubleshooting
+
+### The weather entity shows as unavailable
+
+Open-Meteo is an online service. If the weather entity becomes unavailable, check that your Home Assistant instance can reach the internet. The entity recovers on its own once Open-Meteo is reachable again and the next update succeeds.
+
+## Removing the integration
+
+This integration follows standard integration removal. No extra steps are required.
+
+{% include integrations/remove_device_service.md %}


### PR DESCRIPTION
## Proposed change

Expands the Open-Meteo integration page from a short introduction into a full integration page. It now leads with the user benefit and the no-account setup, and adds Prerequisites, Configuration, Supported functionality, Data updates, Known limitations, and Troubleshooting sections.

The Supported functionality section describes the weather entity, its current conditions, and its daily and hourly forecasts. The configuration documents the zone selector, and the data update section states the 30-minute polling interval.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards