### PR TITLE
RDW: fix outdated automation trigger syntax in example

### DIFF
--- a/source/_integrations/rdw.markdown
+++ b/source/_integrations/rdw.markdown
@@ -62,11 +62,10 @@ The **RDW** integration provides the following entities for your vehicle:
 This automation sends you an important notification when the RDW reports a safety recall for your vehicle:
 
 ```yaml
-# Automation to alert you about safety recalls for your vehicle
 automation:
   - alias: "Vehicle recall alert"
-    trigger:
-      - platform: state
+    triggers:
+      - trigger: state
         entity_id: binary_sensor.rdw_ab123c_pending_recall
         to: "on"
     actions:


### PR DESCRIPTION
## Proposed change

The recall alert automation example on the RDW page used the deprecated trigger syntax (`trigger:` with `- platform: state`). Updated it to the modern `triggers:` / `- trigger: state` form so a copied example works as-is. Also dropped the redundant comment that duplicated the alias.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards