### PR TITLE
Moon: build out documentation to standard structure

### DIFF
--- a/source/_integrations/moon.markdown
+++ b/source/_integrations/moon.markdown
@@ -16,21 +16,48 @@ ha_config_flow: true
 ha_integration_type: service
 ---
 
-The **Moon** {% term integration %} tracks the phases of the moon.
+The **Moon** {% term integration %} adds a sensor to Home Assistant that tells you the current phase of the moon, from new moon to full moon and back again.
+
+It works out the phase on your own system from the current date, so it needs no account, no API key, and no internet connection. Show the moon phase on a dashboard, or use it as a condition in your automations, for example to only run a garden light scene on the night of a full moon.
+
+## Configuration
 
 {% include integrations/config_flow.md %}
 
-The sensor provided by this integration will return one of the following values:
+There is nothing to set up. The Moon integration has no options, and you can add it only once.
 
-- `new_moon`
-- `waxing_crescent`
-- `first_quarter`
-- `waxing_gibbous`
-- `full_moon`
-- `waning_gibbous`
-- `last_quarter`
-- `waning_crescent`
+## Supported functionality
+
+### Sensor
+
+The integration provides a single **Phase** sensor. It reports the current moon phase as one of eight values:
+
+- **New moon**: The moon sits between the Earth and the Sun and is not visible.
+- **Waxing crescent**: A thin sliver of light that grows each night.
+- **First quarter**: Half of the moon is lit, and the lit part is growing.
+- **Waxing gibbous**: More than half is lit and still growing toward full.
+- **Full moon**: The whole face of the moon is lit.
+- **Waning gibbous**: More than half is lit, but the lit part is shrinking.
+- **Last quarter**: Half of the moon is lit, and the lit part is shrinking.
+- **Waning crescent**: A thin sliver of light that shrinks toward the next new moon.
+
+The sensor shows a matching moon icon for each phase, so you can recognize the current phase at a glance.
 
 <p class='img'>
-<img src='/images/screenshots/more-info-dialog-moon.png' />
+<img src='/images/screenshots/more-info-dialog-moon.png' alt="The more info dialog showing the current moon phase.">
+The more info dialog showing the current moon phase.
 </p>
+
+## Data updates
+
+The phase is calculated on your own system from the current date, so no data is fetched from the internet. Home Assistant recalculates it as the date advances, so the sensor changes at most once per day.
+
+## Known limitations
+
+- The phase is based on the date only. The sensor does not report the exact percentage of illumination, moonrise and moonset times, or how the moon looks from your specific location or hemisphere.
+
+## Removing the integration
+
+This integration follows standard integration removal. No extra steps are required.
+
+{% include integrations/remove_device_service.md %}


### PR DESCRIPTION
## Proposed change

Expanded the thin Moon page (a single line plus a raw list of state values) into the standard integration structure: intro with a use case, configuration note (no options, single instance), the **Phase** sensor with all eight phases explained in plain language, data updates, and known limitations. All details verified against the integration in core.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards