### PR TITLE
Radio Browser: build out documentation to standard structure

### DIFF
--- a/source/_integrations/radio_browser.markdown
+++ b/source/_integrations/radio_browser.markdown
@@ -13,26 +13,45 @@ ha_codeowners:
 ha_integration_type: service
 ---
 
-The **Radio Browser** {% term integration %} allows you to use the directory of
-radio stations collected on [Radio Browser](https://www.radio-browser.info)
-in Home Assistant.
+The **Radio Browser** {% term integration %} brings the worldwide directory of internet radio stations from [Radio Browser](https://www.radio-browser.info) into Home Assistant. It adds Radio Browser as a media source, so you can browse thousands of stations and play them on your media players, like a speaker in the kitchen or a Cast device in the living room.
+
+There is no account and no API key to set up. The directory is free and community-maintained.
+
+## Prerequisites
+
+To see stations near you under **Local stations**, set your home location in Home Assistant under {% my general title="**Settings** > **System** > **General**" %}. Browsing all other categories works without it.
 
 {% include integrations/config_flow.md %}
 
-To start the Radio Browser, in Home Assistant, go to **Media** > **Radio Browser** and select the speaker.
-![Starting the radio browser](/images/integrations/radio_browser/radio_browser.png)
+There is nothing to configure. The Radio Browser integration has no options, and you can add it only once.
 
-## Automation
+## Supported functionality
 
-You can also use the Radio Browser in automations. When creating an automation in the UI, use the **Play Media** action to browse the Radio Browser directory and select a station. The station identifier is filled in automatically. This allows you, for example, to create an automation that starts playing your favorite radio station on your Cast devices.
+Radio Browser does not add any {% term entities %}. Instead, it adds a media source you can browse from the media browser and from the **Play Media** action.
 
-If you prefer to write an automation in YAML, you need the station's UUID. To find it:
+To listen to a station, go to **Media** > **Radio Browser**, then pick a station and choose the player to send it to:
+
+![Starting the Radio Browser](/images/integrations/radio_browser/radio_browser.png)
+
+When you open Radio Browser, you can find stations in several ways:
+
+- **Popular**: The most listened-to stations across the whole directory.
+- **By Category**: Stations grouped by genre and topic tags, such as news, jazz, or classical.
+- **By Language**: Stations grouped by the language they broadcast in.
+- **Local stations**: Stations broadcasting close to your Home Assistant location.
+- **Country list**: Stations grouped per country.
+
+## Examples
+
+You can also start a station from an automation or script. The easiest way is to create the automation in the UI: add the **Play Media** action, browse the Radio Browser directory, and select a station. The station identifier is filled in for you. This lets you, for example, start your favorite station on the kitchen speaker every morning.
+
+If you prefer to write the automation in YAML, you need the station's UUID. To find it:
 
 1. Open the [Radio Browser website](https://www.radio-browser.info).
 2. Search for the station you want.
 3. Select the station to open its details page. The UUID is shown on that page and is also part of the station's URL.
 
-Then use the UUID in the `media_content_id` as shown below:
+Then use the UUID in the `media_content_id`:
 
 ```yaml
 action: media_player.play_media
@@ -44,4 +63,14 @@ data:
   media_content_type: audio/mpeg
 ```
 
-See [Media Player](/integrations/media_player) for more options.
+See the [media player](/integrations/media_player/) documentation for more options.
+
+## Data updates
+
+Radio Browser does not poll in the background. The station directory is fetched live from the Radio Browser service each time you browse it, so you always see the current listings.
+
+## Removing the integration
+
+This integration follows standard integration removal. No extra steps are required.
+
+{% include integrations/remove_device_service.md %}

--- a/source/_integrations/radio_browser.markdown
+++ b/source/_integrations/radio_browser.markdown
@@ -39,7 +39,7 @@ When you open Radio Browser, you can find stations in several ways:
 - **By Category**: Stations grouped by genre and topic tags, such as news, jazz, or classical.
 - **By Language**: Stations grouped by the language they broadcast in.
 - **Local stations**: Stations broadcasting close to your Home Assistant location.
-- **Country list**: Stations grouped per country.
+- **Country list**: Stations grouped by country.
 
 ## Examples
 


### PR DESCRIPTION
## Proposed change

Expanded the Radio Browser page into the standard integration structure: a clearer intro and use case, a prerequisites note (Local stations needs your home location), a configuration note (no options, single instance), a supported functionality section explaining the media source and its browse categories, data updates, and a removing section. Kept and lightly polished the existing automation guidance and YAML example. All details verified against the integration in core.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards