### PR TITLE
Sentry: build out documentation to standard structure

### DIFF
--- a/source/_integrations/sentry.markdown
+++ b/source/_integrations/sentry.markdown
@@ -13,39 +13,59 @@ ha_domain: sentry
 ha_integration_type: service
 ---
 
-{% important %}
-The free Sentry account allows 5000 events per month. Depending on the amount of events sent to Sentry, you will either have to upgrade your Sentry account or have a period without data flowing from Home Assistant to Sentry.
-{% endimportant %}
-
 The **Sentry** {% term integration %} connects Home Assistant to [Sentry](https://sentry.io/), an error tracking service that can be cloud-hosted or self-hosted. It captures logged errors and unhandled exceptions and sends them to your Sentry instance, where you can browse, search, and get alerted on them.
 
-This is primarily useful if you are developing custom integrations or want deeper insight into errors happening inside your Home Assistant instance. Sentry groups repeated errors, shows stack traces, and can notify you when new issues appear, so you do not have to watch the logs manually.
+This is mainly useful if you develop custom integrations or want deeper insight into errors happening inside your Home Assistant instance. Sentry groups repeated errors, shows stack traces, and can notify you when new issues appear, so you do not have to watch the logs manually.
+
+{% important %}
+A free Sentry account includes 5000 events per month. Depending on how many events Home Assistant sends, you may need to upgrade your Sentry account or accept periods without data flowing from Home Assistant to Sentry.
+{% endimportant %}
 
 ## Prerequisites
 
-Before setting up the integration, you need a Sentry account and a DSN (Data Source Name). The DSN tells Home Assistant where to send error events.
+You need a Sentry account and a <abbr title="Data Source Name">DSN</abbr>. The DSN tells Home Assistant where to send error events.
 
-Follow these steps to get the DSN:
+To get your DSN:
 
 1. Go to **Projects**.
 2. Select **Create project**.
-3. Fill out the **Give your project a name** and **choose Assign a Team** fields and select the **Create project** button.
-4. Select the **Get your DSN** link in top of the page.
-   - Your DSN is now visible and looks like <https://sdasdasdasdsadsadas@sentry.io/sdsdfsdf>
+3. Fill out the **Give your project a name** field and assign a team, then select **Create project**.
+4. Select the **Get your DSN** link at the top of the page. Your DSN looks like `https://examplePublicKey@o0.ingest.sentry.io/0`.
 
 {% include integrations/config_flow.md %}
 
-## Options
+{% configuration_basic %}
+Sentry DSN:
+  description: "The Data Source Name (DSN) of your Sentry project. It tells Home Assistant where to send error events."
+{% endconfiguration_basic %}
 
-The Sentry integration provides settings to:
+## Configuration options
 
-- Set an environment name for your instance.
-- Limit the event log level to trigger on, and the log level of the breadcrumbs.
-- Ability to send out error events that are handled.
-- Ability to send out events caused by custom integrations.
-- Ability to send out events originating from third-party Python packages.
-- Enable performance tracing and tune the tracing sample rate used.
+After setup, you can fine-tune what Home Assistant sends to Sentry. Go to {% my integrations title="**Settings** > **Devices & services**" %}, select the **Sentry** integration, and then select **Configure**.
 
-To change the settings, go to {% my integrations title="**Settings** > **Devices & services**" %}. Select the **Sentry** integration. Then, select **Options**.
+- **The log level Sentry will register an event for**: The minimum log level that creates a Sentry event. Defaults to **error**.
+- **The log level Sentry will record events as breadcrumbs for**: The minimum log level recorded as breadcrumbs, which add context leading up to an event. Defaults to **warning**.
+- **Optional name of the environment**: A label, such as `production` or `development`, to separate events in Sentry.
+- **Send handled events**: Also send errors that Home Assistant already caught and handled. Off by default.
+- **Send events from custom components**: Include errors that originate from custom integrations. Off by default.
+- **Send events from third-party packages**: Include errors that originate from third-party Python packages. Off by default.
+- **Enable performance tracing**: Send performance tracing data to Sentry. Off by default.
+- **Tracing sample rate**: The fraction of traces to send when tracing is enabled, between 0.0 and 1.0 (1.0 sends all of them). Defaults to 1.0.
 
-After changing the Sentry settings, you'll need to restart Home Assistant to make them effective.
+{% note %}
+After changing these options, restart Home Assistant to apply them.
+{% endnote %}
+
+## Supported functionality
+
+The Sentry integration does not add any {% term entities %}. Once set up, it runs in the background and forwards errors and unhandled exceptions to your Sentry instance as they happen. Each event is enriched with context about your installation, such as the integrations in use, to help with debugging.
+
+## Data updates
+
+Sentry does not poll for data. Home Assistant sends events to your Sentry instance as errors occur.
+
+## Removing the integration
+
+This integration follows standard integration removal. No extra steps are required.
+
+{% include integrations/remove_device_service.md %}

--- a/source/_integrations/sentry.markdown
+++ b/source/_integrations/sentry.markdown
@@ -41,7 +41,7 @@ Sentry DSN:
 
 ## Configuration options
 
-After setup, you can fine-tune what Home Assistant sends to Sentry. Go to {% my integrations title="**Settings** > **Devices & services**" %}, select the **Sentry** integration, and then select **Configure**.
+After setup, you can fine-tune what Home Assistant sends to Sentry. Go to {% my integrations title="**Settings** > **Devices & services**" %}, select the **Sentry** integration, and then select the cogwheel {% icon "mdi:cog-outline" %} (**Configure**).
 
 - **The log level Sentry will register an event for**: The minimum log level that creates a Sentry event. Defaults to **error**.
 - **The log level Sentry will record events as breadcrumbs for**: The minimum log level recorded as breadcrumbs, which add context leading up to an event. Defaults to **warning**.

--- a/source/_integrations/sentry.markdown
+++ b/source/_integrations/sentry.markdown
@@ -29,7 +29,7 @@ To get your DSN:
 
 1. Go to **Projects**.
 2. Select **Create project**.
-3. Fill out the **Give your project a name** field and assign a team, then select **Create project**.
+3. Fill out the **Give your project a name** field, assign a team, and then select **Create project**.
 4. Select the **Get your DSN** link at the top of the page. Your DSN looks like `https://examplePublicKey@o0.ingest.sentry.io/0`.
 
 {% include integrations/config_flow.md %}


### PR DESCRIPTION
## Proposed change

Expanded the Sentry page into the standard integration structure. Added a configuration block for the DSN field, documented all eight configuration options with their real labels and defaults, and added supported functionality, data updates, and a removing section. Also moved the free-tier notice below the intro and replaced the placeholder DSN with Sentry's standard example format. All details verified against the integration in core.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards