### PR TITLE
Installation: deselect Secure Boot for VirtualBox

### DIFF
--- a/source/_includes/installation/operating_system.md
+++ b/source/_includes/installation/operating_system.md
@@ -330,7 +330,7 @@ Minimum recommended assignments:
     1. **Base Memory:** Move the slider to at least **2048 MB** (2GB).
     2. **Number of CPUs:** Move the slider to at least **2**.
     3. **EFI:** Check the box for **Enable EFI (special OSes only)**. This is required for Home Assistant to boot.
-    4. **Secure Boot:** Deselect **Enable Secure Boot**. Home Assistant does not boot with Secure Boot enabled.
+    4. **Secure Boot:** Deselect **Enable Secure Boot**. Home Assistant OS does not boot with Secure Boot enabled.
     5. Select **Next**.
 
     #### Finalizing the wizard

--- a/source/_includes/installation/operating_system.md
+++ b/source/_includes/installation/operating_system.md
@@ -330,7 +330,8 @@ Minimum recommended assignments:
     1. **Base Memory:** Move the slider to at least **2048 MB** (2GB).
     2. **Number of CPUs:** Move the slider to at least **2**.
     3. **EFI:** Check the box for **Enable EFI (special OSes only)**. This is required for Home Assistant to boot.
-    4. Select **Next**.
+    4. **Secure Boot:** Deselect **Enable Secure Boot**. Home Assistant does not boot with Secure Boot enabled.
+    5. Select **Next**.
 
     #### Finalizing the wizard
 


### PR DESCRIPTION
## Proposed change

The VirtualBox "Configure hardware" steps enabled EFI but never told you to turn off Secure Boot. Home Assistant OS does not boot with Secure Boot enabled, so this adds the missing deselection step, matching how the other hypervisor sections on this page already handle Secure Boot.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #45786

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
