### PR TITLE
Eve: document Matter firmware upgrade limitation

### DIFF
--- a/source/_integrations/eve.markdown
+++ b/source/_integrations/eve.markdown
@@ -22,3 +22,9 @@ works_with:
 ## Supported devices
 
 {% include integrations/device_list.html brand="eve" %}
+
+## Known limitations
+
+Some Eve devices were originally sold as Bluetooth or HomeKit-only models and need a firmware upgrade to Matter before you can use them with Home Assistant. Eve's upgrade process requires an iPhone or iPad, together with an Apple Thread border router such as a HomePod or Apple TV. Without an Apple device, these models cannot be upgraded to Matter.
+
+Before buying, check [Eve's upgrade to Matter guide](https://www.evehome.com/en/upgrade-to-matter) to confirm whether a device already supports Matter out of the box or needs to be upgraded first.

--- a/source/_integrations/eve.markdown
+++ b/source/_integrations/eve.markdown
@@ -25,6 +25,6 @@ works_with:
 
 ## Known limitations
 
-Some Eve devices were originally sold as Bluetooth or HomeKit-only models and need a firmware upgrade to Matter before you can use them with Home Assistant. Eve's upgrade process requires an iPhone or iPad, together with an Apple Thread border router such as a HomePod or Apple TV. Without an Apple device, these models cannot be upgraded to Matter.
+Some Eve devices were originally sold as Bluetooth or HomeKit-only models and need a firmware upgrade to Matter before you can set them up in Home Assistant via the Matter integration. Eve's upgrade process requires an iPhone or iPad, together with an Apple Thread border router such as a HomePod mini or Apple TV 4K (2nd generation or later). Without an Apple device, these models cannot be upgraded to Matter.
 
 Before buying, check [Eve's upgrade to Matter guide](https://www.evehome.com/en/upgrade-to-matter) to confirm whether a device already supports Matter out of the box or needs to be upgraded first.


### PR DESCRIPTION
## Proposed change

A user bought an Eve device expecting it to work with Home Assistant, only to find it shipped as a Bluetooth/HomeKit model that first needs a Matter firmware upgrade, and that upgrade requires an Apple device. This adds a "Known limitations" section spelling that out so buyers know what to check before purchasing. The Apple requirement is confirmed on Eve's own upgrade page.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #45840

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
