### PR TITLE
Sensor: add missing conductivity device class

### DIFF
--- a/source/_integrations/sensor.markdown
+++ b/source/_integrations/sensor.markdown
@@ -57,6 +57,7 @@ The following device classes are supported for sensors:
 - **blood_glucose_concentration**: Blood glucose concentration in mg/dL, mmol/L
 - **carbon_dioxide**: Carbon Dioxide (CO₂) concentration in ppm
 - **carbon_monoxide**: Carbon Monoxide (CO) concentration in ppb, ppm, µg/m³, mg/m³
+- **conductivity**: Conductivity in S/cm, mS/cm, or µS/cm
 - **current**: Current in A, mA, µA
 - **data_rate**: Data rate in bit/s, kbit/s, Mbit/s, Gbit/s, B/s, kB/s, MB/s, GB/s, KiB/s, MiB/s or GiB/s
 - **data_size**: Data size in bit, kbit, Mbit, Gbit, B, kB, MB, GB, TB, PB, EB, ZB, YB, KiB, MiB, GiB, TiB, PiB, EiB, ZiB or YiB


### PR DESCRIPTION
## Proposed change

The `conductivity` device class exists in core but was missing from the device class list on the sensor integration page. This adds it, with the units taken from core (`S/cm`, `mS/cm`, `µS/cm`).

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #45723

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
