### PR TITLE
Command line: document restart needed to activate

### DIFF
--- a/source/_integrations/command_line.markdown
+++ b/source/_integrations/command_line.markdown
@@ -27,6 +27,8 @@ ha_quality_scale: legacy
 
 The **Command line** {% term integration %} offers functionality that issues specific commands to get data or to control a device.
 
+This is a YAML-only integration, so you set it up in your {% term "`configuration.yaml`" %} file. After you add or change its configuration, restart Home Assistant to apply the changes. Once the integration is loaded, you can use the [`command_line.reload`](#action-reload) action to pick up later changes to your entities without restarting.
+
 {% tip %}
 It's highly recommended to enclose the command in single quotes `'` as it ensures all characters can be used in the command and reduces the risk of unintentional escaping. To include a single quote in a command enclosed in single quotes, double it: `''`.
 {% endtip %}


### PR DESCRIPTION
## Proposed change

The Command line page never told you that, being a YAML-only integration, it is activated by restarting Home Assistant after you edit `configuration.yaml`. A first-time addition needs a restart (the `command_line.reload` service only exists once the integration is loaded at startup), and reload then applies later entity changes. This adds a short activation paragraph covering both.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #45580

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
