### PR TITLE
Templating: note strftime names are always English

### DIFF
--- a/source/_docs/templating/dates-and-times.markdown
+++ b/source/_docs/templating/dates-and-times.markdown
@@ -113,6 +113,10 @@ Here are the ones you will use most often:
 
 The Python documentation has the [full list of format codes](https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes) if you need something unusual.
 
+{% note %}
+Weekday and month names from `strftime`, like the ones produced by `%A` and `%B`, are always in English, regardless of the language set in your Home Assistant profile. There is currently no built-in way to render them in another language.
+{% endnote %}
+
 ## Parsing text into a datetime with strptime
 
 [`strptime`](/template-functions/strptime/) is the reverse of `strftime`. It takes a piece of text and a format string, and gives you back a datetime.


### PR DESCRIPTION
## Proposed change

The dates and times templating page never told you that `strftime` weekday and month names always render in English, regardless of the language set in your Home Assistant profile. This adds a short note clarifying that behavior and that there is currently no built-in way to localize those names.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #45500

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
