### PR TITLE
Hikvision: document Luma NVR compatibility

### DIFF
--- a/source/_integrations/hikvision.markdown
+++ b/source/_integrations/hikvision.markdown
@@ -71,11 +71,11 @@ and has been confirmed to work with the following models:
 - ERI-K104-PR (NVR)
 - IPC-D140H(-M)
 
-This platform also was confirmed to work with the following Hikvision-based NVRs
+This platform has also been confirmed to work with the following Hikvision-based NVRs:
 
 - N46PCK (Annke H800 4K NVR)
 - N48PAW (Annke 4K NVR)
-- Luma NVR
+- Luma NVRs
 
 {% include integrations/config_flow.md %}
 

--- a/source/_integrations/hikvision.markdown
+++ b/source/_integrations/hikvision.markdown
@@ -71,10 +71,11 @@ and has been confirmed to work with the following models:
 - ERI-K104-PR (NVR)
 - IPC-D140H(-M)
 
-This platform also was confirmed to work with the following Hikvison-based NVRS
+This platform also was confirmed to work with the following Hikvision-based NVRs
 
 - N46PCK (Annke H800 4K NVR)
 - N48PAW (Annke 4K NVR)
+- Luma NVR
 
 {% include integrations/config_flow.md %}
 


### PR DESCRIPTION
## Proposed change

Luma NVRs are rebranded Hikvision-based hardware, and a user confirmed their Luma NVR works with the Hikvision integration. The page already lists other Hikvision-based rebrands (Annke), so this adds the Luma NVR to that list. It also fixes the brand name spelling (`Hikvison` to `Hikvision`) on that line.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #45748

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
