### PR TITLE
Launch Library: build out documentation to standard structure

### DIFF
--- a/source/_integrations/launch_library.markdown
+++ b/source/_integrations/launch_library.markdown
@@ -16,10 +16,38 @@ ha_config_flow: true
 ha_integration_type: service
 ---
 
-The **Launch Library** {% term integration %} will provide you with information about the next planned space launch and SpaceX Starship event.
+The **Launch Library** {% term integration %} provides information about upcoming spaceflight, including the next planned rocket launch and the next SpaceX Starship launch and event.
+
+You can use it to keep an eye on the next launch from a dashboard, get a notification when a launch is about to happen, or announce upcoming launches through your media players.
+
+The data comes from the [Launch Library 2 API](https://thespacedevs.com/llapi) by The Space Devs.
+
+## Prerequisites
+
+There are no prerequisites. The integration uses a public data source, so you do not need an account or API key.
 
 {% include integrations/config_flow.md %}
 
-The data this platform presents comes from [launchlibrary.net][launchlibrary].
+You can only add this integration once. It provides information about the next launch worldwide, not for a specific location or provider.
 
-[launchlibrary]: https://launchlibrary.net/
+## Supported functionality
+
+The integration creates the following {% term sensor %} entities:
+
+- **Next launch**: The name of the next upcoming rocket launch. Additional attributes show the launch provider, the launch pad, the facility, and the provider's country code.
+- **Launch time**: The scheduled date and time of the next launch. Additional attributes show the start and end of the launch window.
+- **Launch probability**: The estimated probability of the launch happening, as a percentage. This is unavailable when the provider does not share a probability.
+- **Launch status**: The current status of the next launch, such as whether it is confirmed, on hold, or in flight. An additional attribute shows the hold reason when there is one.
+- **Launch mission**: The name of the mission for the next launch. Additional attributes show the mission type, the target orbit, and a description of the mission.
+- **Next Starship launch**: The scheduled date and time of the next SpaceX Starship launch. Additional attributes show the mission title, status, target orbit, and a description.
+- **Next Starship event**: The scheduled date and time of the next SpaceX Starship event. Additional attributes show the event title, location, a link to the stream, and a description.
+
+## Data updates
+
+The integration {% term polling polls %} the Launch Library 2 API once an hour for the latest information.
+
+## Removing the integration
+
+This integration follows standard integration removal. No extra steps are required.
+
+{% include integrations/remove_device_service.md %}

--- a/source/_integrations/launch_library.markdown
+++ b/source/_integrations/launch_library.markdown
@@ -16,7 +16,7 @@ ha_config_flow: true
 ha_integration_type: service
 ---
 
-The **Launch Library** {% term integration %} provides information about upcoming spaceflight, including the next planned rocket launch and the next SpaceX Starship launch and event.
+The **Launch Library** {% term integration %} provides information about upcoming spaceflight, including the next planned rocket launch, the next SpaceX Starship launch, and the next SpaceX Starship event.
 
 You can use it to keep an eye on the next launch from a dashboard, get a notification when a launch is about to happen, or announce upcoming launches through your media players.
 


### PR DESCRIPTION
## Proposed change

The Launch Library page was a single sentence plus the config flow include, and it still pointed at the defunct launchlibrary.net as its data source. This builds it out to the standard integration structure: an introduction with a use case, prerequisites, configuration, the seven sensors it creates with their attributes, data updates, and removal. The data source is corrected to the Launch Library 2 API by The Space Devs, which is what the integration actually uses.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
