### PR TITLE
Add removal instructions to CCM15

### DIFF
--- a/source/_integrations/ccm15.markdown
+++ b/source/_integrations/ccm15.markdown
@@ -27,3 +27,9 @@ There is currently support for the following device types within Home Assistant:
 ## Climate
 
 Each data controller can support up to 64 `climate` devices.
+
+## Removing the integration
+
+This integration follows standard integration removal, no extra steps are required.
+
+{% include integrations/remove_device_service.md %}


### PR DESCRIPTION
## Proposed change

Add a "Removing the integration" section to the CCM15 integration documentation,
using the standard `remove_device_service.md` include (the same pattern other
integrations use, e.g. `acaia`).

This is required for the integration's Bronze quality-scale tier
(`docs-removal-instructions` rule) and accompanies the code PR linked below.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: home-assistant/core#173801
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards