### PR TITLE
Migrate set_value actions for core entity components

### DIFF
--- a/source/_actions/date.set_value.markdown
+++ b/source/_actions/date.set_value.markdown
@@ -1,0 +1,95 @@
+---
+title: "Set date value"
+action: date.set_value
+domain: date
+description: "Sets the value of a date entity."
+---
+
+Use this action to set a date entity to a specific date, for example a next-service date, a holiday start, or any other date you keep track of in Home Assistant.
+
+{% include actions/ui_header.md %}
+
+To set a date from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the date entity you want to set.
+6. From the actions shown for that target, select **Set date**.
+7. Set the **Date** you want to apply.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Date:
+  description: The date to set on the entity, in `YYYY-MM-DD` format.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `date.set_value`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: date.set_value
+  target:
+    entity_id: date.next_service
+  data:
+    date: "2024-11-01"
+{% endexample %}
+
+This sets `date.next_service` to November 1, 2024.
+
+### Options in YAML
+
+{% options_yaml %}
+date:
+  description: The date to set on the entity, in `YYYY-MM-DD` format.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/targets.md %}
+
+## Good to know
+
+- This action only works with date entities.
+- Provide the date in `YYYY-MM-DD` format, for example `2024-11-01`.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: set a reminder date when a task completes
+
+Move a date entity forward whenever a maintenance task is marked done.
+
+- **Trigger**: State: Filter replaced changes to _on_
+- **Action**: Set date
+  - **Target**: Next filter change
+  - **Date**: A date of your choosing
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  - alias: "Set the next filter change date"
+    triggers:
+      - trigger: state
+        entity_id: input_boolean.filter_replaced
+        to: "on"
+    actions:
+      - action: date.set_value
+        target:
+          entity_id: date.next_filter_change
+        data:
+          date: "2024-11-01"
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/datetime.set_value.markdown
+++ b/source/_actions/datetime.set_value.markdown
@@ -1,0 +1,95 @@
+---
+title: "Set date/time value"
+action: datetime.set_value
+domain: datetime
+description: "Sets the value of a date/time entity."
+---
+
+Use this action to set a date/time entity to a specific date and time, for example a next-departure moment, a reminder, or any other timestamp you keep track of in Home Assistant.
+
+{% include actions/ui_header.md %}
+
+To set a date and time from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the date/time entity you want to set.
+6. From the actions shown for that target, select **Set date/time**.
+7. Set the **Date & Time** you want to apply.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Date & Time:
+  description: The date and time to set on the entity.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `datetime.set_value`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: datetime.set_value
+  target:
+    entity_id: datetime.next_departure
+  data:
+    datetime: "2024-11-01T07:15:00"
+{% endexample %}
+
+This sets `datetime.next_departure` to November 1, 2024 at 07:15.
+
+### Options in YAML
+
+{% options_yaml %}
+datetime:
+  description: The date and time to set on the entity. If no time zone is included, the Home Assistant instance's time zone is used.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/targets.md %}
+
+## Good to know
+
+- This action only works with date/time entities.
+- If you leave out the time zone, Home Assistant uses its own configured time zone.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: set a departure time when you leave for work
+
+Update a date/time entity to a fixed moment, for example to record the next planned departure.
+
+- **Trigger**: State: Work mode turns on
+- **Action**: Set date/time
+  - **Target**: Next departure
+  - **Date & time**: A moment of your choosing
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  - alias: "Set the next departure time"
+    triggers:
+      - trigger: state
+        entity_id: input_boolean.work_mode
+        to: "on"
+    actions:
+      - action: datetime.set_value
+        target:
+          entity_id: datetime.next_departure
+        data:
+          datetime: "2024-11-01T07:15:00"
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/number.set_value.markdown
+++ b/source/_actions/number.set_value.markdown
@@ -1,0 +1,94 @@
+---
+title: "Set number value"
+action: number.set_value
+domain: number
+description: "Sets the value of a number entity."
+---
+
+Use this action to set a number entity to a specific value, for example a target temperature, a brightness limit, or any other adjustable number a device exposes.
+
+{% include actions/ui_header.md %}
+
+To set a number value from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the number entity you want to set.
+6. From the actions shown for that target, select **Set number value**.
+7. Set the **Value** you want to apply.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Value:
+  description: The value to set on the number entity. It must be within the entity's allowed minimum, maximum, and step.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `number.set_value`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: number.set_value
+  target:
+    entity_id: number.thermostat_target
+  data:
+    value: 21
+{% endexample %}
+
+This sets `number.thermostat_target` to 21.
+
+### Options in YAML
+
+{% options_yaml %}
+value:
+  description: The value to set on the number entity. It must be within the entity's allowed minimum, maximum, and step.
+  required: true
+  type: float
+{% endoptions_yaml %}
+
+{% include actions/targets.md %}
+
+## Good to know
+
+- This action only works with number entities.
+- The value must respect the entity's minimum, maximum, and step. A value outside the allowed range is rejected.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: lower a target value at night
+
+Set a number entity to a lower value every evening, for example to reduce a charging limit overnight.
+
+- **Trigger**: Time: 23:00
+- **Action**: Set number value
+  - **Target**: Charger current limit
+  - **Value**: 6
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  - alias: "Lower the charging limit at night"
+    triggers:
+      - trigger: time
+        at: "23:00:00"
+    actions:
+      - action: number.set_value
+        target:
+          entity_id: number.charger_current_limit
+        data:
+          value: 6
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/text.set_value.markdown
+++ b/source/_actions/text.set_value.markdown
@@ -1,0 +1,95 @@
+---
+title: "Set text value"
+action: text.set_value
+domain: text
+description: "Sets the value of a text entity."
+---
+
+Use this action to set a text entity to a specific value, for example a label, a message, or any other text a device exposes.
+
+{% include actions/ui_header.md %}
+
+To set a text value from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the text entity you want to set.
+6. From the actions shown for that target, select **Set text value**.
+7. Set the **Value** you want to apply.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Value:
+  description: The text to set on the entity. It must match the entity's allowed pattern and stay within its minimum and maximum length.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `text.set_value`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: text.set_value
+  target:
+    entity_id: text.display_message
+  data:
+    value: "Welcome home"
+{% endexample %}
+
+This sets `text.display_message` to `Welcome home`.
+
+### Options in YAML
+
+{% options_yaml %}
+value:
+  description: The text to set on the entity. It must match the entity's allowed pattern and stay within its minimum and maximum length.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/targets.md %}
+
+## Good to know
+
+- This action only works with text entities.
+- The value must match the entity's pattern, if one is set, and respect its minimum and maximum length. A value outside those limits is rejected.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: show a welcome message when someone arrives
+
+Set a text entity to a message whenever a person comes home, for example to update a display.
+
+- **Trigger**: State: Person arrives home
+- **Action**: Set text value
+  - **Target**: Display message
+  - **Value**: Welcome home
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  - alias: "Show a welcome message"
+    triggers:
+      - trigger: state
+        entity_id: person.your_name
+        to: "home"
+    actions:
+      - action: text.set_value
+        target:
+          entity_id: text.display_message
+        data:
+          value: "Welcome home"
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/time.set_value.markdown
+++ b/source/_actions/time.set_value.markdown
@@ -1,0 +1,94 @@
+---
+title: "Set time value"
+action: time.set_value
+domain: time
+description: "Sets the value of a time entity."
+---
+
+Use this action to set a time entity to a specific time, for example a wake-up time, a watering schedule, or any other time you keep track of in Home Assistant.
+
+{% include actions/ui_header.md %}
+
+To set a time from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the time entity you want to set.
+6. From the actions shown for that target, select **Set time**.
+7. Set the **Time** you want to apply.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Time:
+  description: The time to set on the entity, in `HH:MM:SS` format.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `time.set_value`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: time.set_value
+  target:
+    entity_id: time.wake_up
+  data:
+    time: "07:15:00"
+{% endexample %}
+
+This sets `time.wake_up` to 07:15.
+
+### Options in YAML
+
+{% options_yaml %}
+time:
+  description: The time to set on the entity, in `HH:MM:SS` format.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/targets.md %}
+
+## Good to know
+
+- This action only works with time entities.
+- Provide the time in 24-hour `HH:MM:SS` format, for example `07:15:00`.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: set a watering time at sunset
+
+Update a time entity every evening, for example to schedule the next morning's watering.
+
+- **Trigger**: Sun: Sunset
+- **Action**: Set time
+  - **Target**: Garden watering time
+  - **Time**: A time of your choosing
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  - alias: "Set the next watering time"
+    triggers:
+      - trigger: sun
+        event: sunset
+    actions:
+      - action: time.set_value
+        target:
+          entity_id: time.garden_watering
+        data:
+          time: "07:00:00"
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/date.markdown
+++ b/source/_integrations/date.markdown
@@ -31,17 +31,4 @@ In addition, the entity can have the following states:
 - **Unavailable**: The entity is currently unavailable.
 - **Unknown**: The state is not yet known.
 
-## Actions
-
-### Date actions
-
-Available {% term actions %}: `date.set_value`
-
-### Action: Set value
-
-The `date.set_value` action allows you to set a new value for a date {% term entity %}.
-
-| Data attribute | Optional | Description                                                                |
-| -------------- | -------- | -------------------------------------------------------------------------- |
-| `entity_id`    | no       | String or list of strings that point at `entity_id`'s of dates to control. |
-| `date`         | no       | New date value to set.                                                     |
+{% include integrations/actions.md %}

--- a/source/_integrations/datetime.markdown
+++ b/source/_integrations/datetime.markdown
@@ -31,17 +31,4 @@ In addition, the entity can have the following states:
 - **Unavailable**: The entity is currently unavailable.
 - **Unknown**: The state is not yet known.
 
-## Actions
-
-### datetime actions
-
-Available {% term actions %}: `datetime.set_value`
-
-### Action: Set value
-
-The `datetime.set_value` action allows you to set a new value for a datetime {% term entity %}.
-
-| Data attribute | Optional | Description                                                                                                  |
-| -------------- | -------- | ------------------------------------------------------------------------------------------------------------ |
-| `entity_id`    | no       | String or list of strings that point at `entity_id`'s of datetimes to control.                               |
-| `datetime`     | no       | New datetime value to set. If timezone is not included, the Home Assistant instance's timezone will be used. |
+{% include integrations/actions.md %}

--- a/source/_integrations/number.markdown
+++ b/source/_integrations/number.markdown
@@ -96,14 +96,4 @@ The following device classes are supported for numbers:
 - **wind_direction**: Wind direction in °
 - **wind_speed**: Wind speed in Beaufort, ft/s, km/h, kn, m/s, or mph
 
-## Actions
-
-### Action: Set value
-
-The `number.set_value` action sets the value of specific number entities.
-
-| Data attribute | Optional | Description                                 |
-| -------------- | -------- | ------------------------------------------- |
-| `entity_id`    | yes      | Only act on specific number entities. |
-| `area_id`      | yes      | Only act on number entities in specific areas. |
-| `value`        | no       | The value to set. |
+{% include integrations/actions.md %}

--- a/source/_integrations/text.markdown
+++ b/source/_integrations/text.markdown
@@ -17,20 +17,7 @@ The **Text** {% term integration %} is built for the controlling and monitoring 
 
 If you are looking for a way to create a text entity, please take a look at the [Text helper](/integrations/input_text).
 
-## Actions
-
-### Text actions
-
-Available actions: `text.set_value`
-
-### Action: Set value
-
-The `text.set_value` action sets the textual value of the text entity.
-
-| Data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `entity_id` | no | String or list of strings that point at `entity_id`'s of texts to control.
-| `value` | no | The new text value to set.
+{% include integrations/actions.md %}
 
 {% include integrations/triggers.md %}
 

--- a/source/_integrations/time.markdown
+++ b/source/_integrations/time.markdown
@@ -31,17 +31,4 @@ In addition, the entity can have the following states:
 - **Unavailable**: The entity is currently unavailable.
 - **Unknown**: The state is not yet known.
 
-## Actions
-
-### Time actions
-
-Available actions: `time.set_value`
-
-### Action: Set value
-
-The `time.set_value` action sets a new value for the time entity.
-
-| Data attribute | Optional | Description                                                                |
-| -------------- | -------- | -------------------------------------------------------------------------- |
-| `entity_id`    | no       | String or list of strings that point at `entity_id`'s of times to control. |
-| `time`         | no       | New time value to set.                                                     |
+{% include integrations/actions.md %}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Migrates the `set_value` actions for the number, date, time, datetime, and text entity components from their inline tables on the integration pages to dedicated action pages, referenced through the actions include. Each entity is modeled as the action target, and the parameters and UI labels are verified against the components' `services.yaml` and `strings.json`.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

