### PR TITLE
Migrate lawn mower actions to dedicated action pages

### DIFF
--- a/source/_actions/lawn_mower.dock.markdown
+++ b/source/_actions/lawn_mower.dock.markdown
@@ -1,0 +1,88 @@
+---
+title: "Return lawn mower to dock"
+action: lawn_mower.dock
+domain: lawn_mower
+description: "Returns a lawn mower to its dock."
+related_actions:
+  - lawn_mower.start_mowing
+  - lawn_mower.pause
+---
+
+Use this action to send a robotic lawn mower back to its dock, for example to end a run early when it starts to rain.
+
+{% include actions/ui_header.md %}
+
+To send a lawn mower to its dock from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the lawn mower you want to send to its dock.
+6. From the actions shown for that target, select **Return lawn mower to dock**.
+7. Select **Save**.
+
+### Options in the UI
+
+This action has no additional options beyond the target.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `lawn_mower.dock`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: lawn_mower.dock
+  target:
+    entity_id: lawn_mower.backyard
+{% endexample %}
+
+This sends `lawn_mower.backyard` back to its dock.
+
+### Options in YAML
+
+This action has no additional YAML options beyond the target.
+
+{% include actions/targets.md %}
+
+## Good to know
+
+- This action only works with lawn mowers that support returning to a dock.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: return the mower to dock when rain starts
+
+Send the mower back to its dock when rain is detected while it is mowing.
+
+- **Trigger**: State: Rain sensor turns on
+- **Condition**: Lawn mower is mowing
+- **Action**: Return lawn mower to dock
+  - **Target**: Backyard mower
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  - alias: "Dock the mower when it starts raining"
+    triggers:
+      - trigger: state
+        entity_id: binary_sensor.rain_detected
+        to: "on"
+    conditions:
+      - condition: lawn_mower.is_mowing
+        target:
+          entity_id: lawn_mower.backyard
+    actions:
+      - action: lawn_mower.dock
+        target:
+          entity_id: lawn_mower.backyard
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/lawn_mower.pause.markdown
+++ b/source/_actions/lawn_mower.pause.markdown
@@ -1,0 +1,84 @@
+---
+title: "Pause lawn mower"
+action: lawn_mower.pause
+domain: lawn_mower
+description: "Pauses a lawn mower's current task."
+related_actions:
+  - lawn_mower.start_mowing
+  - lawn_mower.dock
+---
+
+Use this action to pause a robotic lawn mower's current task, for example to stop it briefly while you cross the lawn and resume it afterwards.
+
+{% include actions/ui_header.md %}
+
+To pause a lawn mower from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the lawn mower you want to pause.
+6. From the actions shown for that target, select **Pause lawn mower**.
+7. Select **Save**.
+
+### Options in the UI
+
+This action has no additional options beyond the target.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `lawn_mower.pause`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: lawn_mower.pause
+  target:
+    entity_id: lawn_mower.backyard
+{% endexample %}
+
+This pauses `lawn_mower.backyard`.
+
+### Options in YAML
+
+This action has no additional YAML options beyond the target.
+
+{% include actions/targets.md %}
+
+## Good to know
+
+- This action only works with lawn mowers that support pausing.
+- To resume mowing later, use the [Start lawn mower](/actions/lawn_mower.start_mowing/) action.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: pause the mower when a door opens
+
+Pause the mower when someone steps into the garden, for example when a gate or back door opens.
+
+- **Trigger**: State: Back door opens
+- **Action**: Pause lawn mower
+  - **Target**: Backyard mower
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  - alias: "Pause the mower when the back door opens"
+    triggers:
+      - trigger: state
+        entity_id: binary_sensor.back_door
+        to: "on"
+    actions:
+      - action: lawn_mower.pause
+        target:
+          entity_id: lawn_mower.backyard
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/lawn_mower.start_mowing.markdown
+++ b/source/_actions/lawn_mower.start_mowing.markdown
@@ -1,0 +1,82 @@
+---
+title: "Start lawn mower"
+action: lawn_mower.start_mowing
+domain: lawn_mower
+description: "Starts or resumes a lawn mower's mowing task."
+related_actions:
+  - lawn_mower.pause
+  - lawn_mower.dock
+---
+
+Use this action to start or resume mowing on a robotic lawn mower, for example to begin a scheduled run or pick up where a paused task left off.
+
+{% include actions/ui_header.md %}
+
+To start mowing from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the lawn mower you want to start.
+6. From the actions shown for that target, select **Start lawn mower**.
+7. Select **Save**.
+
+### Options in the UI
+
+This action has no additional options beyond the target.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `lawn_mower.start_mowing`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: lawn_mower.start_mowing
+  target:
+    entity_id: lawn_mower.backyard
+{% endexample %}
+
+This starts mowing on `lawn_mower.backyard`.
+
+### Options in YAML
+
+This action has no additional YAML options beyond the target.
+
+{% include actions/targets.md %}
+
+## Good to know
+
+- This action only works with lawn mowers that support starting a mowing task.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: start mowing on a schedule
+
+Start your mower automatically at a set time, for example on a dry weekday morning.
+
+- **Trigger**: Time: 09:00
+- **Action**: Start lawn mower
+  - **Target**: Backyard mower
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  - alias: "Start mowing in the morning"
+    triggers:
+      - trigger: time
+        at: "09:00:00"
+    actions:
+      - action: lawn_mower.start_mowing
+        target:
+          entity_id: lawn_mower.backyard
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/lawn_mower.markdown
+++ b/source/_integrations/lawn_mower.markdown
@@ -32,35 +32,7 @@ A lawn mower entity can have the following states:
 
 {% include integrations/conditions.md %}
 
-## Actions
-
-Available actions: `start_mowing`, `pause` and `dock`.
-
-Before calling one of these actions, make sure your lawn_mower platform supports it.
-
-### Action: Start mowing
-
-The `lawn_mower.start_mowing` action starts or resumes a mowing task.
-
-| Data attribute | Optional | Description                                                          |
-| -------------- | -------- | -------------------------------------------------------------------- |
-| `entity_id`    | yes      | Only act on specific lawn_mower. Use `entity_id: all` to target all. |
-
-### Action: Pause
-
-The `lawn_mower.pause` action pauses a mowing task.
-
-| Data attribute | Optional | Description                                                          |
-| -------------- | -------- | -------------------------------------------------------------------- |
-| `entity_id`    | yes      | Only act on specific lawn_mower. Use `entity_id: all` to target all. |
-
-### Action: Dock
-
-The `lawn_mower.dock` action tells the lawn mower to return to its dock.
-
-| Data attribute | Optional | Description                                                          |
-| -------------- | -------- | -------------------------------------------------------------------- |
-| `entity_id`    | yes      | Only act on specific lawn_mower. Use `entity_id: all` to target all. |
+{% include integrations/actions.md %}
 
 ## Lawn mower automation examples
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Migrates the lawn mower actions (`start_mowing`, `pause`, and `dock`) from the inline tables on the integration page to dedicated action pages, referenced through the actions include. Each action is entity-targeted with no extra options, verified against the integration's `services.yaml` and `strings.json`. The automation examples section on the integration page is kept.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

