### PR TITLE
Migrate siren actions to dedicated action pages

### DIFF
--- a/source/_actions/siren.toggle.markdown
+++ b/source/_actions/siren.toggle.markdown
@@ -1,0 +1,82 @@
+---
+title: "Toggle siren"
+action: siren.toggle
+domain: siren
+description: "Toggles a siren on or off."
+related_actions:
+  - siren.turn_on
+  - siren.turn_off
+---
+
+Use this action to toggle a siren. If the siren is on, it turns off. If it is off, it turns on.
+
+{% include actions/ui_header.md %}
+
+To toggle a siren from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the siren you want to toggle.
+6. From the actions shown for that target, select **Toggle siren**.
+7. Select **Save**.
+
+### Options in the UI
+
+This action has no additional options beyond the target.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `siren.toggle`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: siren.toggle
+  target:
+    entity_id: siren.entry
+{% endexample %}
+
+This toggles `siren.entry` between on and off.
+
+### Options in YAML
+
+This action has no additional YAML options beyond the target.
+
+{% include actions/targets.md %}
+
+## Good to know
+
+- This action only works with sirens that support both turning on and turning off.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: toggle a siren with a button
+
+Toggle a siren whenever you press a physical or dashboard button.
+
+- **Trigger**: Button is pressed
+- **Action**: Toggle siren
+  - **Target**: Entry siren
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  - alias: "Toggle the entry siren with a button"
+    triggers:
+      - trigger: state
+        entity_id: input_button.entry_siren
+    actions:
+      - action: siren.toggle
+        target:
+          entity_id: siren.entry
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/siren.turn_off.markdown
+++ b/source/_actions/siren.turn_off.markdown
@@ -1,0 +1,84 @@
+---
+title: "Turn off siren"
+action: siren.turn_off
+domain: siren
+description: "Turns off a siren."
+related_actions:
+  - siren.turn_on
+  - siren.toggle
+---
+
+Use this action to turn off a siren or chime, for example to silence an alarm after a set time.
+
+{% include actions/ui_header.md %}
+
+To turn off a siren from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the siren you want to turn off.
+6. From the actions shown for that target, select **Turn off siren**.
+7. Select **Save**.
+
+### Options in the UI
+
+This action has no additional options beyond the target.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `siren.turn_off`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: siren.turn_off
+  target:
+    entity_id: siren.entry
+{% endexample %}
+
+This turns off `siren.entry`.
+
+### Options in YAML
+
+This action has no additional YAML options beyond the target.
+
+{% include actions/targets.md %}
+
+## Good to know
+
+- This action only works with sirens that support being turned off.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: turn off a siren after 5 minutes
+
+Turn off a siren once it has been on for a set time.
+
+- **Trigger**: State: Siren has been on for 5 minutes
+- **Action**: Turn off siren
+  - **Target**: Patio siren
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  - alias: "Turn off the patio siren after 5 minutes"
+    triggers:
+      - trigger: state
+        entity_id: siren.patio
+        to: "on"
+        for: "00:05:00"
+    actions:
+      - action: siren.turn_off
+        target:
+          entity_id: siren.patio
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/siren.turn_on.markdown
+++ b/source/_actions/siren.turn_on.markdown
@@ -1,0 +1,113 @@
+---
+title: "Turn on siren"
+action: siren.turn_on
+domain: siren
+description: "Turns on a siren."
+related_actions:
+  - siren.turn_off
+  - siren.toggle
+---
+
+Use this action to turn on a siren or chime, for example to sound an alarm when a door opens while you are away.
+
+{% include actions/ui_header.md %}
+
+To turn on a siren from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the siren you want to turn on.
+6. From the actions shown for that target, select **Turn on siren**.
+7. Optionally, set a tone, volume, or duration if your siren supports them.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Tone:
+  description: The tone to emit. Your siren must support tones, and you can use either the key or the value from its list of available tones.
+  required: false
+Volume:
+  description: The volume to play at, from 0 (inaudible) to 1 (maximum). Your siren must support setting the volume.
+  required: false
+Duration:
+  description: The number of seconds the sound is played. Your siren must support setting a duration.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `siren.turn_on`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: siren.turn_on
+  target:
+    entity_id: siren.entry
+{% endexample %}
+
+This turns on `siren.entry`.
+
+### Options in YAML
+
+{% options_yaml %}
+tone:
+  description: The tone to emit. Your siren must support tones, and you can use either the key or the value from its list of available tones.
+  required: false
+  type: string
+volume_level:
+  description: The volume to play at, from 0 (inaudible) to 1 (maximum). Your siren must support setting the volume.
+  required: false
+  type: float
+duration:
+  description: The number of seconds the sound is played. Your siren must support setting a duration.
+  required: false
+  type: integer
+{% endoptions_yaml %}
+
+{% include actions/targets.md %}
+
+## Good to know
+
+- This action only works with sirens that support being turned on.
+- The tone, volume, and duration options only work if your siren supports them. Check the documentation of the integration that provides the siren.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: sound the siren when a door opens while away
+
+Turn on a siren when a door opens and nobody is home.
+
+- **Trigger**: State: Front door opens
+- **Condition**: Nobody is home
+- **Action**: Turn on siren
+  - **Target**: Entry siren
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  - alias: "Sound the siren when the door opens while away"
+    triggers:
+      - trigger: state
+        entity_id: binary_sensor.front_door
+        to: "on"
+    conditions:
+      - condition: state
+        entity_id: zone.home
+        state: "0"
+    actions:
+      - action: siren.turn_on
+        target:
+          entity_id: siren.entry
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/siren.markdown
+++ b/source/_integrations/siren.markdown
@@ -29,43 +29,7 @@ In addition, the entity can have the following states:
 
 {% include integrations/conditions.md %}
 
-## Actions
-
-### Siren actions
-
-Available {% term actions %}: `siren.turn_on`, `siren.turn_off`, `siren.toggle`
-
-### Action: Turn on
-
-The `siren.turn_on` action turns the siren on.
-
-| Data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `entity_id` | yes | String or list of strings that point at `entity_id`'s of sirens to control.
-
-There are three optional input parameters that can be passed into the action depending on whether your device supports them. Check the device's integration documentation for more details.
-
-| Parameter Name  | Input Type              | Notes                                                                               |
-|---------------- |-------------------------|-------------------------------------------------------------------------------------|
-| `tone`          | `string` or `integer`   | When the `available_tones` property is a map, either the key or value can be used.  |
-| `duration`      | `integer`               |                                                                                     |
-| `volume_level`  | `float` between 0 and 1 |                                                                                     |
-
-### Action: Turn off
-
-The `siren.turn_off` action turns the siren off.
-
-| Data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `entity_id` | yes | String or list of strings that point at `entity_id`'s of sirens to control.
-
-### Action: Toggle
-
-The `siren.toggle` action toggles the siren on or off.
-
-| Data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `entity_id` | yes | String or list of strings that point at `entity_id`'s of sirens to control.
+{% include integrations/actions.md %}
 
 ## Siren automation examples
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Migrates the siren actions (`turn_on`, `turn_off`, and `toggle`) from the inline tables on the integration page to dedicated action pages, referenced through the actions include. Each action is entity-targeted, with `turn_on` taking the optional `tone`, `volume_level`, and `duration` fields. Parameters and UI labels are verified against the integration's `services.yaml` and `strings.json`. The automation examples section on the integration page is kept.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

