### PR TITLE
Migrate cover actions to dedicated action pages

### DIFF
--- a/source/_actions/cover.close_cover.markdown
+++ b/source/_actions/cover.close_cover.markdown
@@ -1,0 +1,84 @@
+---
+title: "Close cover"
+action: cover.close_cover
+domain: cover
+description: "Closes a cover."
+related_actions:
+  - cover.open_cover
+  - cover.stop_cover
+  - cover.toggle
+  - cover.set_cover_position
+---
+
+Use this action to close a cover, such as a roller shutter, blind, awning, or garage door.
+
+{% include actions/ui_header.md %}
+
+To close a cover from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the cover you want to close.
+6. From the actions shown for that target, select **Close cover**.
+7. Select **Save**.
+
+### Options in the UI
+
+This action has no additional options beyond the target.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `cover.close_cover`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: cover.close_cover
+  target:
+    entity_id: cover.living_room_blind
+{% endexample %}
+
+This closes `cover.living_room_blind`.
+
+### Options in YAML
+
+This action has no additional YAML options beyond the target.
+
+{% include actions/targets.md %}
+
+## Good to know
+
+- This action only works with cover entities that support closing.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: close a shutter at sunset
+
+Close a cover at sunset, for example to keep heat in for the night.
+
+- **Trigger**: Sun: Sunset
+- **Action**: Close cover
+  - **Target**: Bedroom shutter
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  - alias: "Close the bedroom shutter at sunset"
+    triggers:
+      - trigger: sun
+        event: sunset
+    actions:
+      - action: cover.close_cover
+        target:
+          entity_id: cover.bedroom_shutter
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/cover.close_cover_tilt.markdown
+++ b/source/_actions/cover.close_cover_tilt.markdown
@@ -1,0 +1,84 @@
+---
+title: "Close cover tilt"
+action: cover.close_cover_tilt
+domain: cover
+description: "Tilts a cover closed."
+related_actions:
+  - cover.open_cover_tilt
+  - cover.stop_cover_tilt
+  - cover.toggle_cover_tilt
+  - cover.set_cover_tilt_position
+---
+
+Use this action to tilt a cover closed, for example to angle the slats of a venetian blind to block light.
+
+{% include actions/ui_header.md %}
+
+To close a cover tilt from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the cover you want to tilt closed.
+6. From the actions shown for that target, select **Close cover tilt**.
+7. Select **Save**.
+
+### Options in the UI
+
+This action has no additional options beyond the target.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `cover.close_cover_tilt`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: cover.close_cover_tilt
+  target:
+    entity_id: cover.living_room_blind
+{% endexample %}
+
+This tilts `cover.living_room_blind` closed.
+
+### Options in YAML
+
+This action has no additional YAML options beyond the target.
+
+{% include actions/targets.md %}
+
+## Good to know
+
+- This action only works with cover entities that support tilting.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: tilt a blind closed at sunset
+
+Tilt a cover closed at sunset, for example to block the low evening sun.
+
+- **Trigger**: Sun: Sunset
+- **Action**: Close cover tilt
+  - **Target**: Living room blind
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  - alias: "Tilt the living room blind closed at sunset"
+    triggers:
+      - trigger: sun
+        event: sunset
+    actions:
+      - action: cover.close_cover_tilt
+        target:
+          entity_id: cover.living_room_blind
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/cover.open_cover.markdown
+++ b/source/_actions/cover.open_cover.markdown
@@ -1,0 +1,84 @@
+---
+title: "Open cover"
+action: cover.open_cover
+domain: cover
+description: "Opens a cover."
+related_actions:
+  - cover.close_cover
+  - cover.stop_cover
+  - cover.toggle
+  - cover.set_cover_position
+---
+
+Use this action to open a cover, such as a roller shutter, blind, awning, or garage door.
+
+{% include actions/ui_header.md %}
+
+To open a cover from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the cover you want to open.
+6. From the actions shown for that target, select **Open cover**.
+7. Select **Save**.
+
+### Options in the UI
+
+This action has no additional options beyond the target.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `cover.open_cover`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: cover.open_cover
+  target:
+    entity_id: cover.living_room_blind
+{% endexample %}
+
+This opens `cover.living_room_blind`.
+
+### Options in YAML
+
+This action has no additional YAML options beyond the target.
+
+{% include actions/targets.md %}
+
+## Good to know
+
+- This action only works with cover entities that support opening.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: open a blind in the morning
+
+Open a cover at a set time, for example to let daylight in each morning.
+
+- **Trigger**: Time: 07:15
+- **Action**: Open cover
+  - **Target**: Living room blind
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  - alias: "Open the living room blind in the morning"
+    triggers:
+      - trigger: time
+        at: "07:15:00"
+    actions:
+      - action: cover.open_cover
+        target:
+          entity_id: cover.living_room_blind
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/cover.open_cover_tilt.markdown
+++ b/source/_actions/cover.open_cover_tilt.markdown
@@ -1,0 +1,84 @@
+---
+title: "Open cover tilt"
+action: cover.open_cover_tilt
+domain: cover
+description: "Tilts a cover open."
+related_actions:
+  - cover.close_cover_tilt
+  - cover.stop_cover_tilt
+  - cover.toggle_cover_tilt
+  - cover.set_cover_tilt_position
+---
+
+Use this action to tilt a cover open, for example to angle the slats of a venetian blind to let light in.
+
+{% include actions/ui_header.md %}
+
+To open a cover tilt from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the cover you want to tilt open.
+6. From the actions shown for that target, select **Open cover tilt**.
+7. Select **Save**.
+
+### Options in the UI
+
+This action has no additional options beyond the target.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `cover.open_cover_tilt`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: cover.open_cover_tilt
+  target:
+    entity_id: cover.living_room_blind
+{% endexample %}
+
+This tilts `cover.living_room_blind` open.
+
+### Options in YAML
+
+This action has no additional YAML options beyond the target.
+
+{% include actions/targets.md %}
+
+## Good to know
+
+- This action only works with cover entities that support tilting.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: tilt a blind open in the morning
+
+Tilt a cover open at a set time, for example to let some daylight in while keeping privacy.
+
+- **Trigger**: Time: 07:15
+- **Action**: Open cover tilt
+  - **Target**: Living room blind
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  - alias: "Tilt the living room blind open in the morning"
+    triggers:
+      - trigger: time
+        at: "07:15:00"
+    actions:
+      - action: cover.open_cover_tilt
+        target:
+          entity_id: cover.living_room_blind
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/cover.set_cover_position.markdown
+++ b/source/_actions/cover.set_cover_position.markdown
@@ -1,0 +1,98 @@
+---
+title: "Set cover position"
+action: cover.set_cover_position
+domain: cover
+description: "Moves a cover to a specific position."
+related_actions:
+  - cover.open_cover
+  - cover.close_cover
+  - cover.stop_cover
+  - cover.toggle
+---
+
+Use this action to move a cover to a specific position, for example to open a blind halfway.
+
+{% include actions/ui_header.md %}
+
+To set a cover position from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the cover you want to move.
+6. From the actions shown for that target, select **Set cover position**.
+7. Set the **Position** you want to apply.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Position:
+  description: The target position as a percentage, from 0 (closed) to 100 (open).
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `cover.set_cover_position`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: cover.set_cover_position
+  target:
+    entity_id: cover.living_room_blind
+  data:
+    position: 50
+{% endexample %}
+
+This moves `cover.living_room_blind` to the halfway position.
+
+### Options in YAML
+
+{% options_yaml %}
+position:
+  description: The target position as a percentage, from 0 (closed) to 100 (open).
+  required: true
+  type: integer
+{% endoptions_yaml %}
+
+{% include actions/targets.md %}
+
+## Good to know
+
+- This action only works with cover entities that support setting a position.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: set a blind to half open in the morning
+
+Move a cover to a specific position at a set time.
+
+- **Trigger**: Time: 07:15
+- **Action**: Set cover position
+  - **Target**: Living room blind
+  - **Position**: 50
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  - alias: "Set the living room blind to half open in the morning"
+    triggers:
+      - trigger: time
+        at: "07:15:00"
+    actions:
+      - action: cover.set_cover_position
+        target:
+          entity_id: cover.living_room_blind
+        data:
+          position: 50
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/cover.set_cover_tilt_position.markdown
+++ b/source/_actions/cover.set_cover_tilt_position.markdown
@@ -1,0 +1,98 @@
+---
+title: "Set cover tilt position"
+action: cover.set_cover_tilt_position
+domain: cover
+description: "Tilts a cover to a specific position."
+related_actions:
+  - cover.open_cover_tilt
+  - cover.close_cover_tilt
+  - cover.stop_cover_tilt
+  - cover.toggle_cover_tilt
+---
+
+Use this action to tilt a cover to a specific position, for example to angle the slats of a venetian blind halfway.
+
+{% include actions/ui_header.md %}
+
+To set a cover tilt position from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the cover you want to tilt.
+6. From the actions shown for that target, select **Set cover tilt position**.
+7. Set the **Tilt position** you want to apply.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Tilt position:
+  description: The target tilt position as a percentage, from 0 (closed) to 100 (open).
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `cover.set_cover_tilt_position`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: cover.set_cover_tilt_position
+  target:
+    entity_id: cover.living_room_blind
+  data:
+    tilt_position: 50
+{% endexample %}
+
+This tilts `cover.living_room_blind` to the halfway position.
+
+### Options in YAML
+
+{% options_yaml %}
+tilt_position:
+  description: The target tilt position as a percentage, from 0 (closed) to 100 (open).
+  required: true
+  type: integer
+{% endoptions_yaml %}
+
+{% include actions/targets.md %}
+
+## Good to know
+
+- This action only works with cover entities that support setting a tilt position.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: tilt a blind halfway in the morning
+
+Tilt a cover to a specific position at a set time.
+
+- **Trigger**: Time: 07:15
+- **Action**: Set cover tilt position
+  - **Target**: Living room blind
+  - **Tilt position**: 50
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  - alias: "Set the living room blind tilt to halfway in the morning"
+    triggers:
+      - trigger: time
+        at: "07:15:00"
+    actions:
+      - action: cover.set_cover_tilt_position
+        target:
+          entity_id: cover.living_room_blind
+        data:
+          tilt_position: 50
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/cover.stop_cover.markdown
+++ b/source/_actions/cover.stop_cover.markdown
@@ -1,0 +1,84 @@
+---
+title: "Stop cover"
+action: cover.stop_cover
+domain: cover
+description: "Stops the movement of a cover."
+related_actions:
+  - cover.open_cover
+  - cover.close_cover
+  - cover.toggle
+  - cover.set_cover_position
+---
+
+Use this action to stop a cover while it is moving, for example to leave a blind partly open.
+
+{% include actions/ui_header.md %}
+
+To stop a cover from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the cover you want to stop.
+6. From the actions shown for that target, select **Stop cover**.
+7. Select **Save**.
+
+### Options in the UI
+
+This action has no additional options beyond the target.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `cover.stop_cover`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: cover.stop_cover
+  target:
+    entity_id: cover.living_room_blind
+{% endexample %}
+
+This stops `cover.living_room_blind`.
+
+### Options in YAML
+
+This action has no additional YAML options beyond the target.
+
+{% include actions/targets.md %}
+
+## Good to know
+
+- This action only works with cover entities that support stopping.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: stop a cover with a button
+
+Stop a cover each time you press a button, for example to halt it at any point.
+
+- **Trigger**: Button is pressed
+- **Action**: Stop cover
+  - **Target**: Living room blind
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  - alias: "Stop the living room blind with a button"
+    triggers:
+      - trigger: state
+        entity_id: input_button.stop_blind
+    actions:
+      - action: cover.stop_cover
+        target:
+          entity_id: cover.living_room_blind
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/cover.stop_cover_tilt.markdown
+++ b/source/_actions/cover.stop_cover_tilt.markdown
@@ -1,0 +1,84 @@
+---
+title: "Stop cover tilt"
+action: cover.stop_cover_tilt
+domain: cover
+description: "Stops the tilting of a cover."
+related_actions:
+  - cover.open_cover_tilt
+  - cover.close_cover_tilt
+  - cover.toggle_cover_tilt
+  - cover.set_cover_tilt_position
+---
+
+Use this action to stop a cover while it is tilting, for example to leave the slats at a partial angle.
+
+{% include actions/ui_header.md %}
+
+To stop a cover tilt from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the cover you want to stop.
+6. From the actions shown for that target, select **Stop cover tilt**.
+7. Select **Save**.
+
+### Options in the UI
+
+This action has no additional options beyond the target.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `cover.stop_cover_tilt`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: cover.stop_cover_tilt
+  target:
+    entity_id: cover.living_room_blind
+{% endexample %}
+
+This stops the tilting of `cover.living_room_blind`.
+
+### Options in YAML
+
+This action has no additional YAML options beyond the target.
+
+{% include actions/targets.md %}
+
+## Good to know
+
+- This action only works with cover entities that support tilting.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: stop a cover tilt with a button
+
+Stop a cover tilt each time you press a button, for example to halt the slats at any angle.
+
+- **Trigger**: Button is pressed
+- **Action**: Stop cover tilt
+  - **Target**: Living room blind
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  - alias: "Stop the living room blind tilt with a button"
+    triggers:
+      - trigger: state
+        entity_id: input_button.stop_blind_tilt
+    actions:
+      - action: cover.stop_cover_tilt
+        target:
+          entity_id: cover.living_room_blind
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/cover.toggle.markdown
+++ b/source/_actions/cover.toggle.markdown
@@ -1,0 +1,84 @@
+---
+title: "Toggle cover"
+action: cover.toggle
+domain: cover
+description: "Toggles a cover open or closed."
+related_actions:
+  - cover.open_cover
+  - cover.close_cover
+  - cover.stop_cover
+  - cover.set_cover_position
+---
+
+Use this action to toggle a cover, opening it if it is closed and closing it if it is open.
+
+{% include actions/ui_header.md %}
+
+To toggle a cover from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the cover you want to toggle.
+6. From the actions shown for that target, select **Toggle cover**.
+7. Select **Save**.
+
+### Options in the UI
+
+This action has no additional options beyond the target.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `cover.toggle`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: cover.toggle
+  target:
+    entity_id: cover.living_room_blind
+{% endexample %}
+
+This toggles `cover.living_room_blind` between open and closed.
+
+### Options in YAML
+
+This action has no additional YAML options beyond the target.
+
+{% include actions/targets.md %}
+
+## Good to know
+
+- This action only works with cover entities that support both opening and closing.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: toggle a cover with a button
+
+Toggle a cover each time you press a button.
+
+- **Trigger**: Button is pressed
+- **Action**: Toggle cover
+  - **Target**: Living room blind
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  - alias: "Toggle the living room blind with a button"
+    triggers:
+      - trigger: state
+        entity_id: input_button.toggle_blind
+    actions:
+      - action: cover.toggle
+        target:
+          entity_id: cover.living_room_blind
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/cover.toggle_cover_tilt.markdown
+++ b/source/_actions/cover.toggle_cover_tilt.markdown
@@ -1,0 +1,84 @@
+---
+title: "Toggle cover tilt"
+action: cover.toggle_cover_tilt
+domain: cover
+description: "Toggles a cover tilt open or closed."
+related_actions:
+  - cover.open_cover_tilt
+  - cover.close_cover_tilt
+  - cover.stop_cover_tilt
+  - cover.set_cover_tilt_position
+---
+
+Use this action to toggle a cover tilt, opening the tilt if it is closed and closing it if it is open.
+
+{% include actions/ui_header.md %}
+
+To toggle a cover tilt from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the cover you want to tilt.
+6. From the actions shown for that target, select **Toggle cover tilt**.
+7. Select **Save**.
+
+### Options in the UI
+
+This action has no additional options beyond the target.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `cover.toggle_cover_tilt`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: cover.toggle_cover_tilt
+  target:
+    entity_id: cover.living_room_blind
+{% endexample %}
+
+This toggles the tilt of `cover.living_room_blind` between open and closed.
+
+### Options in YAML
+
+This action has no additional YAML options beyond the target.
+
+{% include actions/targets.md %}
+
+## Good to know
+
+- This action only works with cover entities that support tilting.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: toggle a cover tilt with a button
+
+Toggle a cover tilt each time you press a button.
+
+- **Trigger**: Button is pressed
+- **Action**: Toggle cover tilt
+  - **Target**: Living room blind
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  - alias: "Toggle the living room blind tilt with a button"
+    triggers:
+      - trigger: state
+        entity_id: input_button.toggle_blind_tilt
+    actions:
+      - action: cover.toggle_cover_tilt
+        target:
+          entity_id: cover.living_room_blind
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/cover.markdown
+++ b/source/_integrations/cover.markdown
@@ -64,76 +64,7 @@ The following device classes are supported for covers.
 
 {% include integrations/conditions.md %}
 
-## Actions
-
-### Cover control actions
-
-Available actions: `cover.open_cover`, `cover.close_cover`, `cover.stop_cover`, `cover.toggle`, `cover.open_cover_tilt`, `cover.close_cover_tilt`, `cover.stop_cover_tilt`, `cover.toggle_tilt`
-
-| Data attribute | Optional | Description                                                                                          |
-| -------------- | -------- | ---------------------------------------------------------------------------------------------------- |
-| `entity_id`    | yes      | String or list of strings that point at `entity_id`'s of covers. Use `entity_id: all` to target all. |
-
-#### Automation example
-
-```yaml
-automation:
-  triggers:
-    - trigger: time
-      at: "07:15:00"
-  actions:
-    - action: cover.open_cover
-      target:
-        entity_id: cover.demo
-```
-
-### Action: Set cover position
-
-The `cover.set_cover_position` action allows you to set cover position of one or multiple covers.
-
-| Data attribute | Optional | Description                                                                                          |
-| -------------- | -------- | ---------------------------------------------------------------------------------------------------- |
-| `entity_id`    | yes      | String or list of strings that point at `entity_id`'s of covers. Use `entity_id: all` to target all. |
-| `position`     | no       | Integer between 0 and 100.                                                                           |
-
-#### Automation example
-
-```yaml
-automation:
-  triggers:
-    - trigger: time
-      at: "07:15:00"
-  actions:
-    - action: cover.set_cover_position
-      target:
-        entity_id: cover.demo
-      data:
-        position: 50
-```
-
-### Action: Set cover tilt position
-
-The `cover.set_cover_tilt_position` action allows you to set cover tilt position of one or multiple covers.
-
-| Data attribute  | Optional | Description                                                                                          |
-| --------------- | -------- | ---------------------------------------------------------------------------------------------------- |
-| `entity_id`     | yes      | String or list of strings that point at `entity_id`'s of covers. Use `entity_id: all` to target all. |
-| `tilt_position` | no       | Integer between 0 and 100.                                                                           |
-
-#### Automation example
-
-```yaml
-automation:
-  triggers:
-    - trigger: time
-      at: "07:15:00"
-  actions:
-    - action: cover.set_cover_tilt_position
-      target:
-        entity_id: cover.demo
-      data:
-        tilt_position: 50
-```
+{% include integrations/actions.md %}
 
 ## Cover automation examples
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Migrates the cover actions into dedicated pages under `source/_actions/`, matching the structure already used by other entity components. The inline action tables on the cover integration page are replaced with the standard actions include.

Along the way this corrects the service name `cover.toggle_tilt` to `cover.toggle_cover_tilt` (the name the core registers) and drops the outdated `entity_id` data attribute, which is the action target.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

