### PR TITLE
Shopping list: migrate actions to dedicated pages

### DIFF
--- a/source/_actions/shopping_list.add_item.markdown
+++ b/source/_actions/shopping_list.add_item.markdown
@@ -1,0 +1,87 @@
+---
+title: "Add shopping list item"
+action: shopping_list.add_item
+domain: shopping_list
+description: "Adds an item to the shopping list."
+related_actions:
+  - shopping_list.remove_item
+  - shopping_list.complete_item
+  - shopping_list.clear_completed_items
+---
+
+Use this action to add an item to your shopping list. A common use is to add something automatically when Home Assistant notices you are running low, for example adding batteries to the list when a device reports a low battery.
+
+{% include actions/ui_header.md %}
+
+To add an item from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Search for and select **Add shopping list item**.
+6. Enter the **Name** of the item to add.
+7. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Name:
+  description: The name of the item to add.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `shopping_list.add_item`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: shopping_list.add_item
+  data:
+    name: "Milk"
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+name:
+  description: The name of the item to add.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+## Good to know
+
+- The item is added to the single shopping list that this integration provides.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: add batteries when a device runs low
+
+Add batteries to your shopping list automatically when a device reports a low battery level.
+
+- **Trigger**: A battery level drops below 10%
+- **Action**: Add shopping list item
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  alias: "Buy batteries when the remote is low"
+  triggers:
+    - trigger: numeric_state
+      entity_id: sensor.remote_battery
+      below: 10
+  actions:
+    - action: shopping_list.add_item
+      data:
+        name: "Batteries"
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/shopping_list.clear_completed_items.markdown
+++ b/source/_actions/shopping_list.clear_completed_items.markdown
@@ -1,0 +1,72 @@
+---
+title: "Clear completed shopping list items"
+action: shopping_list.clear_completed_items
+domain: shopping_list
+description: "Removes completed items from the shopping list."
+related_actions:
+  - shopping_list.complete_item
+  - shopping_list.complete_all
+---
+
+Use this action to remove all completed items from your shopping list, leaving only the items you still need. A common use is to tidy up the list automatically after a shopping trip.
+
+{% include actions/ui_header.md %}
+
+To clear completed items from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Search for and select **Clear completed shopping list items**.
+6. Select **Save**.
+
+### Options in the UI
+
+This action has no options.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `shopping_list.clear_completed_items`. It takes no options:
+
+{% example %}
+action: |
+  action: shopping_list.clear_completed_items
+{% endexample %}
+
+### Options in YAML
+
+This action has no options.
+
+{% include actions/more_examples.md %}
+
+### Automation: clean up the list when you leave the store
+
+Clear the items you ticked off as soon as you leave the supermarket, so your list is ready for next time.
+
+- **Trigger**: You leave the supermarket zone
+- **Action**: Clear completed shopping list items
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  alias: "Tidy shopping list after shopping"
+  triggers:
+    - trigger: zone
+      entity_id: person.me
+      zone: zone.supermarket
+      event: leave
+  actions:
+    - action: shopping_list.clear_completed_items
+{% endexample %}
+
+{% enddetails %}
+
+## Good to know
+
+- Only completed items are removed. Items you have not ticked off stay on the list.
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/shopping_list.complete_all.markdown
+++ b/source/_actions/shopping_list.complete_all.markdown
@@ -1,0 +1,48 @@
+---
+title: "Complete all shopping list items"
+action: shopping_list.complete_all
+domain: shopping_list
+description: "Marks all items as completed in the shopping list."
+related_actions:
+  - shopping_list.incomplete_all
+  - shopping_list.complete_item
+  - shopping_list.clear_completed_items
+---
+
+Use this action to mark every item on your shopping list as completed at once, without removing them from the list. A common use is to tick off the whole list after you finish shopping, ready to clear it later.
+
+{% include actions/ui_header.md %}
+
+To complete all items from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Search for and select **Complete all shopping list items**.
+6. Select **Save**.
+
+### Options in the UI
+
+This action has no options.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `shopping_list.complete_all`. It takes no options:
+
+{% example %}
+action: |
+  action: shopping_list.complete_all
+{% endexample %}
+
+### Options in YAML
+
+This action has no options.
+
+## Good to know
+
+- The items stay on the list. To remove the completed ones afterwards, use [Clear completed shopping list items](/actions/shopping_list.clear_completed_items/).
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/shopping_list.complete_item.markdown
+++ b/source/_actions/shopping_list.complete_item.markdown
@@ -1,0 +1,62 @@
+---
+title: "Complete shopping list item"
+action: shopping_list.complete_item
+domain: shopping_list
+description: "Marks the first item with matching name as completed in the shopping list."
+related_actions:
+  - shopping_list.incomplete_item
+  - shopping_list.complete_all
+  - shopping_list.clear_completed_items
+---
+
+Use this action to mark an item as completed without removing it from the list. It marks the first item whose name matches, so you can tick something off as you put it in your basket while keeping it on the list for next time.
+
+{% include actions/ui_header.md %}
+
+To complete an item from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Search for and select **Complete shopping list item**.
+6. Enter the **Name** of the item to mark as completed.
+7. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Name:
+  description: The name of the item to mark as completed.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `shopping_list.complete_item`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: shopping_list.complete_item
+  data:
+    name: "Milk"
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+name:
+  description: The name of the item to mark as completed.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+## Good to know
+
+- This action keeps the item on the list. To remove it instead, use [Remove shopping list item](/actions/shopping_list.remove_item/).
+- To clear out all completed items at once, use [Clear completed shopping list items](/actions/shopping_list.clear_completed_items/).
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/shopping_list.incomplete_all.markdown
+++ b/source/_actions/shopping_list.incomplete_all.markdown
@@ -1,0 +1,47 @@
+---
+title: "Incomplete all shopping list items"
+action: shopping_list.incomplete_all
+domain: shopping_list
+description: "Marks all items as incomplete in the shopping list."
+related_actions:
+  - shopping_list.complete_all
+  - shopping_list.incomplete_item
+---
+
+Use this action to mark every item on your shopping list as incomplete at once. A common use is to reset a recurring list, for example a weekly groceries list, so all the items are active again.
+
+{% include actions/ui_header.md %}
+
+To mark all items as incomplete from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Search for and select **Incomplete all shopping list items**.
+6. Select **Save**.
+
+### Options in the UI
+
+This action has no options.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `shopping_list.incomplete_all`. It takes no options:
+
+{% example %}
+action: |
+  action: shopping_list.incomplete_all
+{% endexample %}
+
+### Options in YAML
+
+This action has no options.
+
+## Good to know
+
+- This is the counterpart of [Complete all shopping list items](/actions/shopping_list.complete_all/).
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/shopping_list.incomplete_item.markdown
+++ b/source/_actions/shopping_list.incomplete_item.markdown
@@ -1,0 +1,61 @@
+---
+title: "Incomplete shopping list item"
+action: shopping_list.incomplete_item
+domain: shopping_list
+description: "Marks the first item with matching name as incomplete in the shopping list."
+related_actions:
+  - shopping_list.complete_item
+  - shopping_list.incomplete_all
+---
+
+Use this action to mark a completed item as incomplete again. It marks the first item whose name matches, so it is useful when you need to buy something again that you had already ticked off.
+
+{% include actions/ui_header.md %}
+
+To mark an item as incomplete from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Search for and select **Incomplete shopping list item**.
+6. Enter the **Name** of the item to mark as incomplete.
+7. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Name:
+  description: The name of the item to mark as incomplete.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `shopping_list.incomplete_item`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: shopping_list.incomplete_item
+  data:
+    name: "Milk"
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+name:
+  description: The name of the item to mark as incomplete.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+## Good to know
+
+- This is the counterpart of [Complete shopping list item](/actions/shopping_list.complete_item/).
+- To mark every item as incomplete at once, use [Incomplete all shopping list items](/actions/shopping_list.incomplete_all/).
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/shopping_list.remove_item.markdown
+++ b/source/_actions/shopping_list.remove_item.markdown
@@ -1,0 +1,62 @@
+---
+title: "Remove shopping list item"
+action: shopping_list.remove_item
+domain: shopping_list
+description: "Removes the first item with matching name from the shopping list."
+related_actions:
+  - shopping_list.add_item
+  - shopping_list.complete_item
+  - shopping_list.clear_completed_items
+---
+
+Use this action to remove an item from your shopping list. It removes the first item whose name matches, so it is handy for taking something off the list once you no longer need it.
+
+{% include actions/ui_header.md %}
+
+To remove an item from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Search for and select **Remove shopping list item**.
+6. Enter the **Name** of the item to remove.
+7. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Name:
+  description: The name of the item to remove.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `shopping_list.remove_item`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: shopping_list.remove_item
+  data:
+    name: "Milk"
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+name:
+  description: The name of the item to remove.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+## Good to know
+
+- If more than one item has the same name, only the first match is removed.
+- To take an item off the list but keep a record of it, use [Complete shopping list item](/actions/shopping_list.complete_item/) instead.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/shopping_list.sort.markdown
+++ b/source/_actions/shopping_list.sort.markdown
@@ -1,0 +1,58 @@
+---
+title: "Sort shopping list items"
+action: shopping_list.sort
+domain: shopping_list
+description: "Sorts all items by name in the shopping list."
+related_actions:
+  - shopping_list.add_item
+  - shopping_list.complete_all
+---
+
+Use this action to sort every item on your shopping list by name. A common use is to keep a long list tidy and predictable, so related items end up next to each other and are easier to find while you shop.
+
+{% include actions/ui_header.md %}
+
+To sort the list from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Search for and select **Sort shopping list**.
+6. To sort from Z to A instead of A to Z, turn on **Sort reverse**.
+7. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Sort reverse:
+  description: Sort the list in reverse (descending) order, from Z to A. By default, the list is sorted from A to Z.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `shopping_list.sort`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: shopping_list.sort
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+reverse:
+  description: Sort the list in reverse (descending) order, from Z to A. By default, the list is sorted from A to Z.
+  required: false
+  type: boolean
+  default: false
+{% endoptions_yaml %}
+
+## Good to know
+
+- Sorting orders items by name. It does not separate completed items from items you still need.
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/shopping_list.markdown
+++ b/source/_integrations/shopping_list.markdown
@@ -20,61 +20,7 @@ Your shopping list will be accessible from the sidebar, and you can optionally a
 
 {% include integrations/config_flow.md %}
 
-## Actions
-
-You can add or remove items from your shopping list by using the following actions.
-
-### Action: Add item
-
-The `shopping_list.add_item` action adds an item to the shopping list.
-
-| Data attribute | Optional | Description                              |
-| ---------------------- | -------- | ---------------------------------------- |
-| `name`                 | no       | Name of the item to add. Example: "Milk" |
-
-### Action: Remove item
-
-The `shopping_list.remove_item` action removes the first item with matching name from the shopping list.
-
-| Data attribute | Optional | Description                                 |
-| ---------------------- | -------- | ------------------------------------------- |
-| `name`                 | no       | Name of the item to remove. Example: "Milk" |
-
-### Action: Complete item
-
-The `shopping_list.complete_item` action marks the first item with matching name as completed in the shopping list. It does not remove the item.
-
-| Data attribute | Optional | Description                                            |
-| ---------------------- | -------- | ------------------------------------------------------ |
-| `name`                 | no       | Name of the item to mark as completed. Example: "Milk" |
-
-### Action: Incomplete item
-
-The `shopping_list.incomplete_item` action marks the first item with matching name as incomplete in the shopping list.
-
-| Data attribute | Optional | Description                                             |
-| ---------------------- | -------- | ------------------------------------------------------- |
-| `name`                 | no       | Name of the item to mark as incomplete. Example: "Milk" |
-
-### Action: Complete all
-
-The `shopping_list.complete_all` action marks all items as completed in the shopping list (without removing them from the list).
-
-### Action: Incomplete all
-
-The `shopping_list.incomplete_all` action marks all items as incomplete in the shopping list.
-
-### Action: Clear completed items
-
-The `shopping_list.clear_completed_items` action clears completed items from the shopping list.
-
-### Action: Sort
-
-The `shopping_list.sort` action sorts all items by name in the shopping list.
-
-| Data attribute | Optional | Description                                                         |
-| ---------------------- | -------- | ------------------------------------------------------------------- |
-| `reverse`              | yes      | Whether to sort in reverse (_descending_) order. (default: `False`) |
+{% include integrations/actions.md %}
 
 ## Using in automations
 


### PR DESCRIPTION
## Proposed change

Migrate the Shopping list actions from the inline tables on the integration page into dedicated pages under `source/_actions/`, and replace them with the shared `{% include integrations/actions.md %}`.

Each action now has its own page with intent, UI steps, YAML usage, and grounded automation examples. The `shopping_list_updated` event documentation under "Using in automations" is kept on the integration page.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

