### PR TITLE
Tuya: migrate actions to dedicated pages

### DIFF
--- a/source/_actions/tuya.get_feeder_meal_plan.markdown
+++ b/source/_actions/tuya.get_feeder_meal_plan.markdown
@@ -1,0 +1,69 @@
+---
+title: "Get feeder meal plan data"
+action: tuya.get_feeder_meal_plan
+domain: tuya
+description: "Retrieves the feeding schedule from a Tuya pet feeder."
+related_actions:
+  - tuya.set_feeder_meal_plan
+---
+
+Use this action to read the feeding schedule from a Tuya pet feeder. A common use is to check the current schedule before you change it, so you can build the new plan on top of what is already there.
+
+This action returns its result in a response variable, which you can use in later steps of the same automation or script.
+
+{% include actions/ui_header.md %}
+
+To get a feeder meal plan from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Search for and select **Get feeder meal plan data**.
+6. Set **Device** to the Tuya feeder you want to read.
+7. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Device:
+  description: The Tuya feeder to read the meal plan from.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `tuya.get_feeder_meal_plan`. Store the result in a response variable so you can use it in later steps:
+
+{% example %}
+action: |
+  action: tuya.get_feeder_meal_plan
+  data:
+    device_id: 1234567890abcdef1234567890abcdef
+  response_variable: feeder_plan
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+device_id:
+  description: The Tuya feeder to read the meal plan from.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+## Response data
+
+The action returns the feeder's meal plan in a `meal_plan` field. The meal plan is a list of scheduled feedings, each with the following:
+
+- `days`: The days of the week the feeding runs on.
+- `time`: The time of day the feeding runs, in `HH:MM` format.
+- `portion`: The amount of food to dispense.
+- `enabled`: Whether the scheduled feeding is active.
+
+## Good to know
+
+- Only Tuya feeders that support meal plans work with this action. For other devices, the action reports that the meal plan is not supported.
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/tuya.set_feeder_meal_plan.markdown
+++ b/source/_actions/tuya.set_feeder_meal_plan.markdown
@@ -1,0 +1,90 @@
+---
+title: "Set feeder meal plan data"
+action: tuya.set_feeder_meal_plan
+domain: tuya
+description: "Sets the feeding schedule on a Tuya pet feeder."
+related_actions:
+  - tuya.get_feeder_meal_plan
+---
+
+Use this action to set the feeding schedule on a Tuya pet feeder. You provide one or more scheduled feedings, each with the days, time, portion, and whether it is active. A common use is to adjust feeding times and portions from an automation, for example to feed a little earlier on weekends.
+
+The meal plan you provide replaces the feeder's current schedule, so include every feeding you want to keep.
+
+{% include actions/ui_header.md %}
+
+To set a feeder meal plan from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Search for and select **Set feeder meal plan data**.
+6. Set **Device** to the Tuya feeder you want to manage.
+7. Under **Meal plan**, add one or more feedings, each with its days, time, portion, and whether it is enabled.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Device:
+  description: The Tuya feeder to set the meal plan on.
+Meal plan:
+  description: One or more scheduled feedings. For each feeding, set the days of the week, the time, the portion, and whether it is enabled.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `tuya.set_feeder_meal_plan`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: tuya.set_feeder_meal_plan
+  data:
+    device_id: 1234567890abcdef1234567890abcdef
+    meal_plan:
+      - days:
+          - monday
+          - tuesday
+          - wednesday
+          - thursday
+          - friday
+        time: "08:00"
+        portion: 2
+        enabled: true
+      - days:
+          - saturday
+          - sunday
+        time: "09:30"
+        portion: 3
+        enabled: true
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+device_id:
+  description: The Tuya feeder to set the meal plan on.
+  required: true
+  type: string
+meal_plan:
+  description: A list of scheduled feedings to apply to the feeder.
+  required: true
+  type: list
+{% endoptions_yaml %}
+
+Each feeding in the `meal_plan` list accepts the following:
+
+- `days` (optional, list): The days of the week the feeding runs on, in lowercase, such as `monday`. Omit to run every day.
+- `time` (required, string): The time of day the feeding runs, in `HH:MM` format. Always quote this value so it is read as text.
+- `portion` (required, integer): The amount of food to dispense.
+- `enabled` (required, boolean): Whether the scheduled feeding is active.
+
+## Good to know
+
+- The meal plan you set replaces the feeder's current schedule. Include every feeding you want to keep, not just the ones you are changing.
+- To read the current schedule first, use the [Get feeder meal plan data](/actions/tuya.get_feeder_meal_plan/) action.
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/tuya.markdown
+++ b/source/_integrations/tuya.markdown
@@ -93,48 +93,7 @@ After adding new devices to your Tuya account through the Smart Life or Tuya Sma
 
 Tuya supports scenes in their app. These allow triggering some of the more complex modes of various devices such as light changing effects. Scenes created in the Tuya app will automatically appear in the Scenes list in Home Assistant the next time the integration updates.
 
-## Actions
-
-The **Tuya** integration provide actions to manage the meal plan for feeders. 
-
-### Action: Get feeder meal plan
-
-The `tuya.get_feeder_meal_plan` action retrieves the meal plan data from a Tuya feeder device.
-- **Data attribute**: `device_id`
-  - **Description**: The device ID of the Tuya feeder to retrieve the meal plan from.
-  - **Optional**: No
-
-### Action: Set feeder meal plan
-
-The `tuya.set_feeder_meal_plan` action set the mealplan data from a Tuya feeder device.
-- **Data attribute**: `device_id`
-  - **Description**: The device ID of the Tuya feeder to retrieve the meal plan from.
-  - **Optional**: No
-- **Data attribute**: `meal_plan`
-  - **Description**: The decoded data to update the feeder's meal plan. Take a list of dictionary of attributes.
-  - **Optional**: No
-  - **Attributes**:
-    - days: List[String] with monday-sunday. Indexed with monday as first day of week.
-    - time: String with HH:MM format
-    - portion: Numeric with number of portions
-    - enabled: Enable or disable the schedule.
-
-This action returns [response data](/docs/scripts/perform-actions#use-templates-to-handle-response-data) containing the meal plan for the specified feeder device.
-
-#### Example
-
-```yaml
-action: tuya.set_feeder_meal_plan
-data:
-  device_id: "1234567890abcdef"
-  meal_plan:
-    - days:
-        - Monday
-        - Tuesday
-      time: 10:00
-      portions: 2
-      enabled: true
-```
+{% include integrations/actions.md %}
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Proposed change

Moves the Tuya integration's feeder meal plan actions out of the integration page and into dedicated pages under `source/_actions/`, replacing the inline block with `{% include integrations/actions.md %}`. Along the way it corrects a few errors in the old documentation: the field is `portion` (not `portions`), the day names must be lowercase, the `time` value needs to be quoted, and the response data belongs to the get action rather than the set action.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

