### PR TITLE
Shelly: migrate actions to dedicated pages

### DIFF
--- a/source/_actions/shelly.get_kvs_value.markdown
+++ b/source/_actions/shelly.get_kvs_value.markdown
@@ -1,0 +1,94 @@
+---
+title: "Get Shelly KVS value"
+action: shelly.get_kvs_value
+domain: shelly
+description: "Reads a value from a Shelly device's Key-Value Storage."
+related_actions:
+  - shelly.set_kvs_value
+---
+
+Use this action to read a value from a Shelly device's Key-Value Storage (KVS). KVS is a small store on the device where Shelly scripts keep values. A common use is to pull a value that a device script calculated, such as a measurement, into Home Assistant. The value can be text, a number, a boolean, an empty value, a mapping, or a list.
+
+This action returns its result in a response variable, which you can use in later steps of the same automation or script.
+
+{% include actions/ui_header.md %}
+
+To get a KVS value from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Search for and select **Get Shelly KVS value**.
+6. Set **Device** to the Shelly device, and **Key** to the name of the value you want to read.
+7. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Device:
+  description: The Shelly device to read the value from.
+Key:
+  description: The name of the key to read.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `shelly.get_kvs_value`. Store the result in a response variable so you can use it in later steps:
+
+{% example %}
+action: |
+  action: shelly.get_kvs_value
+  data:
+    device_id: e4c0e031f68a8fbe08c50eda5e189a70
+    key: "my_temperature_value"
+  response_variable: kvs
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+device_id:
+  description: The Shelly device to read the value from.
+  required: true
+  type: string
+key:
+  description: The name of the key to read.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+## Response data
+
+The action returns the stored value in a `value` field. The value can be text, a number, a boolean, an empty value, a mapping, or a list, depending on what the device script stored.
+
+## Example: create a sensor from a KVS value
+
+This example creates a template sensor that reads a temperature value from the KVS key `my_temperature_value` every 10 minutes.
+
+```yaml
+# Example configuration.yaml entry
+template:
+  - trigger:
+      - trigger: time_pattern
+        minutes: "/10"
+    action:
+      - action: shelly.get_kvs_value
+        data:
+          device_id: e4c0e031f68a8fbe08c50eda5e189a70
+          key: "my_temperature_value"
+        response_variable: temperature_variable
+    sensor:
+      - name: "My temperature"
+        state: "{{ temperature_variable.value }}"
+        unit_of_measurement: "°C"
+        device_class: temperature
+```
+
+## Good to know
+
+- KVS actions work only on non-sleeping Shelly generation 2 and later devices.
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/shelly.get_kvs_value.markdown
+++ b/source/_actions/shelly.get_kvs_value.markdown
@@ -69,10 +69,10 @@ This example creates a template sensor that reads a temperature value from the K
 ```yaml
 # Example configuration.yaml entry
 template:
-  - trigger:
+  - triggers:
       - trigger: time_pattern
         minutes: "/10"
-    action:
+    actions:
       - action: shelly.get_kvs_value
         data:
           device_id: e4c0e031f68a8fbe08c50eda5e189a70

--- a/source/_actions/shelly.set_kvs_value.markdown
+++ b/source/_actions/shelly.set_kvs_value.markdown
@@ -1,0 +1,72 @@
+---
+title: "Set Shelly KVS value"
+action: shelly.set_kvs_value
+domain: shelly
+description: "Stores a value in a Shelly device's Key-Value Storage."
+related_actions:
+  - shelly.get_kvs_value
+---
+
+Use this action to store a value in a Shelly device's Key-Value Storage (KVS). KVS is a small store on the device where Shelly scripts keep values. A common use is to pass a value from Home Assistant to a device script, such as a setpoint the script reads on its next run. The value can be text, a number, a boolean, an empty value, a mapping, or a list.
+
+{% include actions/ui_header.md %}
+
+To set a KVS value from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Search for and select **Set Shelly KVS value**.
+6. Set **Device** to the Shelly device, **Key** to the name to store the value under, and **Value** to the value you want to store.
+7. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Device:
+  description: The Shelly device to store the value on.
+Key:
+  description: The name of the key to store the value under.
+Value:
+  description: The value to store. It can be text, a number, a boolean, an empty value, a mapping, or a list.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `shelly.set_kvs_value`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: shelly.set_kvs_value
+  data:
+    device_id: e4c0e031f68a8fbe08c50eda5e189a70
+    key: "target_temperature"
+    value: 21
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+device_id:
+  description: The Shelly device to store the value on.
+  required: true
+  type: string
+key:
+  description: The name of the key to store the value under.
+  required: true
+  type: string
+value:
+  description: The value to store. It can be text, a number, a boolean, an empty value, a mapping, or a list.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+## Good to know
+
+- KVS actions work only on non-sleeping Shelly generation 2 and later devices.
+- Setting a key that already exists overwrites its current value.
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/shelly.markdown
+++ b/source/_integrations/shelly.markdown
@@ -425,57 +425,7 @@ Trigger reboot of device.
 - Reboot
   - triggers the reboot
 
-## Actions
-
-The integration provides the following actions for non-sleeping Gen2+ devices:
-
-### Action: Get KVS value
-
-The `shelly.get_kvs_value` action is used to get a value from the device's Key-Value Storage. The retrieved value can be text, a number, a boolean, a null value, a dictionary, or a list.
-
-- **Data attribute**: `device_id`
-  - **Description**: The ID of the Shelly device to get the KVS value from.
-  - **Optional**: No
-- **Data attribute**: `key`
-  - **Description**: The name of the key for which the KVS value will be retrieved.
-  - **Optional**: No
-
-### Action: Set KVS value
-
-The `shelly.set_kvs_value` action is used to set a value in the device's Key-Value Storage.
-
-- **Data attribute**: `device_id`
-  - **Description**: The ID of the Shelly device to set the KVS value.
-  - **Optional**: No
-- **Data attribute**: `key`
-  - **Description**: The name of the key under which the KVS value will be stored.
-  - **Optional**: No
-- **Data attribute**: `value`
-  - **Description**: Value to set. The value can be text, a number, a boolean, a null value, a dictionary, or a list.
-  - **Optional**: No
-
-### Example: Creating a sensor for the KVS value
-
-The following example creates a temperature sensor that will retrieve a temperature value from the KVS for the key `my_temperature_value` every 10 minutes.
-
-```yaml
-# Example configuration.yaml entry
-template:
-  - trigger:
-      - platform: time_pattern
-        minutes: /10
-    action:
-      - action: shelly.get_kvs_value
-        data:
-          device_id: e4c0e031f68a8fbe08c50eda5e189a70
-          key: my_temperature_value
-        response_variable: temperature_variable
-    sensor:
-      - name: My temperature
-        state: "{{ temperature_variable.value }}"
-        unit_of_measurement: °C
-        device_class: temperature
-```
+{% include integrations/actions.md %}
 
 ## Shelly Thermostatic Radiator Valve (TRV)
 


### PR DESCRIPTION
## Proposed change

Moves the Shelly integration's Key-Value Storage actions out of the integration page and into dedicated pages under `source/_actions/`, replacing the inline block with `{% include integrations/actions.md %}`. The existing KVS template sensor example moves onto the get action page where it belongs.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

