### PR TITLE
Hue: migrate actions to dedicated pages

### DIFF
--- a/source/_actions/hue.activate_scene.markdown
+++ b/source/_actions/hue.activate_scene.markdown
@@ -1,0 +1,88 @@
+---
+title: "Activate Hue scene"
+action: hue.activate_scene
+domain: hue
+description: "Activates a Hue scene with extra control over options like dynamic mode and brightness."
+related_actions:
+  - hue.hue_activate_scene
+---
+
+Use this action to activate a Hue scene with more control than the standard scene action gives you. On top of turning the scene on, you can start its dynamic color palette, set how fast that palette cycles, adjust the brightness, and choose how long the lights take to transition. A common use is to start a slow, dynamic scene in the evening and switch to a brighter static scene in the morning.
+
+This action targets the Hue scene {% term entity %} you want to activate. These scene entities are created automatically from the scenes you set up in the Hue app.
+
+{% include actions/ui_header.md %}
+
+To activate a Hue scene from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Hue scene you want to activate.
+6. From the actions shown for that target, select **Activate Hue scene**.
+7. Optionally, set the transition, dynamic mode, speed, and brightness.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Transition:
+  description: How long, in seconds, the lights take to reach the scene's state.
+  required: false
+Dynamic:
+  description: Start the scene's dynamic color palette, where the scene supports it.
+  required: false
+Speed:
+  description: How fast the dynamic color palette cycles.
+  required: false
+Brightness:
+  description: The brightness to apply to the scene.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `hue.activate_scene`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: hue.activate_scene
+  target:
+    entity_id: scene.living_room_energize
+{% endexample %}
+
+This activates the `scene.living_room_energize` Hue scene.
+
+### Options in YAML
+
+{% options_yaml %}
+transition:
+  description: How long, in seconds, the lights take to reach the scene's state.
+  required: false
+  type: integer
+dynamic:
+  description: Start the scene's dynamic color palette, where the scene supports it.
+  required: false
+  type: boolean
+  default: false
+speed:
+  description: How fast the dynamic color palette cycles, from 0 to 100.
+  required: false
+  type: integer
+brightness:
+  description: The brightness to apply to the scene, from 1 to 255.
+  required: false
+  type: integer
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="scene" %}
+
+## Good to know
+
+- Dynamic mode and speed only have an effect on scenes that support a dynamic color palette.
+- Use this action when you need the extra options. To simply turn a scene on, the standard [scene action](/integrations/scene/) is enough.
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/hue.hue_activate_scene.markdown
+++ b/source/_actions/hue.hue_activate_scene.markdown
@@ -7,7 +7,7 @@ related_actions:
   - hue.activate_scene
 ---
 
-Use this action to activate a Hue scene by typing its group (room) name and scene name exactly as they appear in the Hue app. This is mainly useful on legacy V1 Hue bridges (round shape), where scene entities are not created automatically, so the standard [scene action](/integrations/scene/) and the [Activate Hue scene](/actions/hue.activate_scene/) action are not available.
+Use this action to activate a Hue scene by typing its group (room) name and scene name exactly as they appear in the Hue app. This is mainly useful on legacy V1 Hue bridges (round shape), where scene entities are not created automatically, so you cannot use the standard [scene action](/integrations/scene/) or the [Activate Hue scene](/actions/hue.activate_scene/) action to activate Hue scenes.
 
 On a V2 bridge (square shape), use the [Activate Hue scene](/actions/hue.activate_scene/) action instead, as it targets scene entities directly and offers more options.
 

--- a/source/_actions/hue.hue_activate_scene.markdown
+++ b/source/_actions/hue.hue_activate_scene.markdown
@@ -1,0 +1,79 @@
+---
+title: "Activate scene"
+action: hue.hue_activate_scene
+domain: hue
+description: "Activates a Hue scene by its group and scene name as stored in the Hue app."
+related_actions:
+  - hue.activate_scene
+---
+
+Use this action to activate a Hue scene by typing its group (room) name and scene name exactly as they appear in the Hue app. This is mainly useful on legacy V1 Hue bridges (round shape), where scene entities are not created automatically, so the standard [scene action](/integrations/scene/) and the [Activate Hue scene](/actions/hue.activate_scene/) action are not available.
+
+On a V2 bridge (square shape), use the [Activate Hue scene](/actions/hue.activate_scene/) action instead, as it targets scene entities directly and offers more options.
+
+{% include actions/ui_header.md %}
+
+To activate a scene by name from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Search for and select **Activate scene**.
+6. Set **Group** to the room name and **Scene** to the scene name, both exactly as they appear in the Hue app.
+7. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Group:
+  description: The name of the Hue group or room, exactly as it appears in the Hue app.
+Scene:
+  description: The name of the Hue scene, exactly as it appears in the Hue app.
+Dynamic:
+  description: Start the scene's dynamic color palette. This works on V2 bridges with scenes that support it.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `hue.hue_activate_scene`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: hue.hue_activate_scene
+  data:
+    group_name: "Living room"
+    scene_name: "Energize"
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+group_name:
+  description: The name of the Hue group or room, exactly as it appears in the Hue app.
+  required: true
+  type: string
+scene_name:
+  description: The name of the Hue scene, exactly as it appears in the Hue app.
+  required: true
+  type: string
+transition:
+  description: How long, in seconds, the lights take to reach the scene's state.
+  required: false
+  type: integer
+dynamic:
+  description: Start the scene's dynamic color palette. This works on V2 bridges with scenes that support it.
+  required: false
+  type: boolean
+  default: false
+{% endoptions_yaml %}
+
+## Good to know
+
+- The group and scene names must match the names in the Hue app exactly, including capitalization.
+- If no bridge can activate the scene, the action does nothing and a warning is logged. Double-check the names if a scene does not activate.
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/hue.markdown
+++ b/source/_integrations/hue.markdown
@@ -44,32 +44,6 @@ You can create, edit, and delete Hue scenes from the official Hue app on iOS and
 
 Using Hue scenes is recommended when you want to control multiple lights at once. If you control multiple lights individually or use Home Assistant scenes, each command is sent to each light one by one. A Hue scene sends commands to all lights at once in an optimized way, resulting in a smoother experience.
 
-### Action: Activate scene
-
-The `hue.activate_scene` action lets you activate a Hue scene and set properties like dynamic mode or brightness at the same time.
-
-- **Data attribute**: `entity_id`
-  - **Description**: The entity ID of the Hue scene to activate.
-  - **Required**: Yes
-
-- **Data attribute**: `transition`
-  - **Description**: Transition duration in seconds to bring devices to the state defined in the scene.
-  - **Required**: No
-
-- **Data attribute**: `dynamic`
-  - **Description**: Enable (`true`) or disable (`false`) dynamic mode for the scene.
-  - **Required**: No
-
-- **Data attribute**: `speed`
-  - **Description**: The speed of the dynamic palette for this scene.
-  - **Required**: No
-
-- **Data attribute**: `brightness`
-  - **Description**: The brightness for this scene.
-  - **Required**: No
-
-You can use this action, for example, to start or stop dynamic mode on a scene.
-
 ## Configuration options
 
 After setting up the integration, the following options can be configured by going to {% my integrations title="**Settings** > **Devices & services**" %}, selecting the **Philips Hue** integration, and selecting **Configure**.
@@ -102,7 +76,7 @@ The Hue API limits each device to one event per second. This means that button e
 
 Signify released a newer version of the Hue bridge (square shape), and the legacy V1 bridge (round shape) is now end of life and no longer supported by Signify. Home Assistant will continue to support the V1 Hue bridge as long as it is technically possible, with the following limitations:
 
-- Scene entities are not automatically created for V1 bridges. To activate a Hue scene on a V1 bridge from Home Assistant, use the action described below.
+- Scene entities are not automatically created for V1 bridges. To activate a Hue scene on a V1 bridge from Home Assistant, use the **Activate scene** action and refer to the scene by its group and scene name.
 - State updates for devices on V1 bridges are not received instantly but polled on an interval.
 - Light entities for Hue rooms are not automatically created for V1 bridges. You can opt in to creating room entities in the integration's options.
 
@@ -110,6 +84,8 @@ To activate a scene on a V1 bridge:
 
 1. Go to **Scripts** and select **Add New Script** > **Add Action** > **Philips Hue: Activate Scene**.
 2. Select the room name in the **Group** field and the scene name in the **Scene** field.
+
+{% include integrations/actions.md %}
 
 ## Data updates
 

--- a/source/_integrations/hue.markdown
+++ b/source/_integrations/hue.markdown
@@ -76,7 +76,7 @@ The Hue API limits each device to one event per second. This means that button e
 
 Signify released a newer version of the Hue bridge (square shape), and the legacy V1 bridge (round shape) is now end of life and no longer supported by Signify. Home Assistant will continue to support the V1 Hue bridge as long as it is technically possible, with the following limitations:
 
-- Scene entities are not automatically created for V1 bridges. To activate a Hue scene on a V1 bridge from Home Assistant, use the **Activate scene** action and refer to the scene by its group and scene name.
+- Scene entities are not automatically created for V1 bridges. To activate a Hue scene on a V1 bridge from Home Assistant, use the [**Philips Hue: Activate scene** action](/actions/hue.hue_activate_scene/) and refer to the scene by its group and scene name.
 - State updates for devices on V1 bridges are not received instantly but polled on an interval.
 - Light entities for Hue rooms are not automatically created for V1 bridges. You can opt in to creating room entities in the integration's options.
 


### PR DESCRIPTION
## Proposed change

Moves the Philips Hue actions from the inline block on the integration page into dedicated pages under `source/_actions/`, listed through `{% include integrations/actions.md %}`.

This covers the modern `hue.activate_scene` entity service and adds a separate page for the legacy `hue.hue_activate_scene` action, which is still used to activate scenes by name on V1 bridges. Details were verified against the integration's code.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

