### PR TITLE
ZHA: migrate actions to dedicated pages

### DIFF
--- a/source/_actions/zha.clear_lock_user_code.markdown
+++ b/source/_actions/zha.clear_lock_user_code.markdown
@@ -1,0 +1,64 @@
+---
+title: "Clear a lock user code"
+action: zha.clear_lock_user_code
+domain: zha
+description: "Removes a user code from a slot on a Zigbee lock."
+related_actions:
+  - zha.set_lock_user_code
+  - zha.enable_lock_user_code
+  - zha.disable_lock_user_code
+---
+
+Use this action to remove a user code from a slot on a Zigbee lock. This frees up the slot and permanently deletes the code, for example to revoke a guest's access after their stay.
+
+{% include actions/ui_header.md %}
+
+To clear a lock user code from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the lock with the code you want to clear.
+6. From the actions shown for that target, select **Clear lock user**.
+7. Set the code slot.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Code slot:
+  description: The slot to clear the code from.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `zha.clear_lock_user_code`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: zha.clear_lock_user_code
+  target:
+    entity_id: lock.front_door
+  data:
+    code_slot: 1
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+code_slot:
+  description: The slot to clear the code from.
+  required: true
+  type: integer
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="lock" %}
+
+## Good to know
+
+- Clearing a code is permanent. To use the code again, store it with the [Set a lock user code](/actions/zha.set_lock_user_code/) action. To keep it but turn it off, use the [Disable a lock user code](/actions/zha.disable_lock_user_code/) action instead.
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/zha.disable_lock_user_code.markdown
+++ b/source/_actions/zha.disable_lock_user_code.markdown
@@ -1,0 +1,64 @@
+---
+title: "Disable a lock user code"
+action: zha.disable_lock_user_code
+domain: zha
+description: "Disables a user code in a slot on a Zigbee lock."
+related_actions:
+  - zha.enable_lock_user_code
+  - zha.set_lock_user_code
+  - zha.clear_lock_user_code
+---
+
+Use this action to disable a user code that is stored in a slot on a Zigbee lock. The code stays in the slot, so you can enable it again later. This is handy for temporarily turning off a guest code without removing it, for example between visits.
+
+{% include actions/ui_header.md %}
+
+To disable a lock user code from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the lock with the code you want to disable.
+6. From the actions shown for that target, select **Disable lock user**.
+7. Set the code slot.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Code slot:
+  description: The slot of the code to disable.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `zha.disable_lock_user_code`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: zha.disable_lock_user_code
+  target:
+    entity_id: lock.front_door
+  data:
+    code_slot: 1
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+code_slot:
+  description: The slot of the code to disable.
+  required: true
+  type: integer
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="lock" %}
+
+## Good to know
+
+- The code is kept in the slot. To enable it again, use the [Enable a lock user code](/actions/zha.enable_lock_user_code/) action. To remove it entirely, use the [Clear a lock user code](/actions/zha.clear_lock_user_code/) action.
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/zha.enable_lock_user_code.markdown
+++ b/source/_actions/zha.enable_lock_user_code.markdown
@@ -1,0 +1,64 @@
+---
+title: "Enable a lock user code"
+action: zha.enable_lock_user_code
+domain: zha
+description: "Enables a user code in a slot on a Zigbee lock."
+related_actions:
+  - zha.disable_lock_user_code
+  - zha.set_lock_user_code
+  - zha.clear_lock_user_code
+---
+
+Use this action to enable a user code that is stored in a slot on a Zigbee lock. This lets you turn a code back on after it was disabled, for example to re-activate a guest code for a returning visitor without setting it again.
+
+{% include actions/ui_header.md %}
+
+To enable a lock user code from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the lock with the code you want to enable.
+6. From the actions shown for that target, select **Enable lock user**.
+7. Set the code slot.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Code slot:
+  description: The slot of the code to enable.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `zha.enable_lock_user_code`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: zha.enable_lock_user_code
+  target:
+    entity_id: lock.front_door
+  data:
+    code_slot: 1
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+code_slot:
+  description: The slot of the code to enable.
+  required: true
+  type: integer
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="lock" %}
+
+## Good to know
+
+- The slot must already hold a code. To store a new code, use the [Set a lock user code](/actions/zha.set_lock_user_code/) action.
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/zha.issue_zigbee_cluster_command.markdown
+++ b/source/_actions/zha.issue_zigbee_cluster_command.markdown
@@ -1,0 +1,112 @@
+---
+title: "Issue a Zigbee cluster command"
+action: zha.issue_zigbee_cluster_command
+domain: zha
+description: "Sends a command to a Zigbee cluster on a device."
+related_actions:
+  - zha.issue_zigbee_group_command
+  - zha.set_zigbee_cluster_attribute
+---
+
+Use this action to send a command directly to a Zigbee cluster on a single device. This is a low-level tool for triggering device functions that aren't exposed through the regular entities. You need to know the device's IEEE address, the endpoint, the cluster, and the command you want to send.
+
+Only users with administrator rights can run this action.
+
+{% include actions/ui_header.md %}
+
+To issue a cluster command from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Search for and select **Issue Zigbee cluster command**.
+6. Fill in the device, endpoint, cluster, command, and any parameters.
+7. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+IEEE:
+  description: The IEEE address of the device.
+Endpoint ID:
+  description: The endpoint on the device that holds the cluster.
+Cluster ID:
+  description: The cluster to send the command to.
+Cluster type:
+  description: Whether the cluster is an input (server) or output (client) cluster. Defaults to input.
+  required: false
+Command:
+  description: The ID of the command to send.
+Command type:
+  description: Whether the command is a client or server command.
+Params:
+  description: The parameters to pass to the command, as a mapping of names to values.
+  required: false
+Manufacturer:
+  description: The manufacturer code to use for the command. Use -1 to force no manufacturer code.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `zha.issue_zigbee_cluster_command`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: zha.issue_zigbee_cluster_command
+  data:
+    ieee: "00:0d:6f:00:05:7d:2d:34"
+    endpoint_id: 1
+    cluster_id: 8
+    command: 1
+    command_type: server
+    params:
+      move_mode: 1
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+ieee:
+  description: The IEEE address of the device.
+  required: true
+  type: string
+endpoint_id:
+  description: The endpoint on the device that holds the cluster.
+  required: true
+  type: integer
+cluster_id:
+  description: The cluster to send the command to.
+  required: true
+  type: integer
+cluster_type:
+  description: Whether the cluster is an input (server) or output (client) cluster, set as `in` or `out`. Defaults to `in`.
+  required: false
+  type: string
+command:
+  description: The ID of the command to send.
+  required: true
+  type: integer
+command_type:
+  description: Whether the command is a `client` or `server` command.
+  required: true
+  type: string
+params:
+  description: The parameters to pass to the command, as a mapping of names to values.
+  required: false
+  type: map
+manufacturer:
+  description: The manufacturer code to use for the command. Use -1 to force no manufacturer code.
+  required: false
+  type: integer
+{% endoptions_yaml %}
+
+## Good to know
+
+- You must provide the command parameters through the **Params** field.
+- Cluster, command, and endpoint IDs are specific to each device. You can look them up on the device's page under **Manage clusters**.
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/zha.issue_zigbee_group_command.markdown
+++ b/source/_actions/zha.issue_zigbee_group_command.markdown
@@ -1,0 +1,98 @@
+---
+title: "Issue a Zigbee group command"
+action: zha.issue_zigbee_group_command
+domain: zha
+description: "Sends a command to a Zigbee cluster on a group of devices."
+related_actions:
+  - zha.issue_zigbee_cluster_command
+  - zha.set_zigbee_cluster_attribute
+---
+
+Use this action to send a command to a Zigbee cluster on a whole Zigbee group at once. This is a low-level tool that lets you control all members of a group with a single command, instead of addressing each device individually. You need to know the group's address, the cluster, and the command you want to send.
+
+Only users with administrator rights can run this action.
+
+{% include actions/ui_header.md %}
+
+To issue a group command from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Search for and select **Issue Zigbee group command**.
+6. Fill in the group, cluster, command, and any arguments.
+7. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Group:
+  description: The hexadecimal address of the group to send the command to.
+Cluster ID:
+  description: The cluster to send the command to.
+Cluster type:
+  description: Whether the cluster is an input (server) or output (client) cluster. Defaults to input.
+  required: false
+Command:
+  description: The ID of the command to send.
+Args:
+  description: The arguments to pass to the command, as a list.
+  required: false
+Manufacturer:
+  description: The manufacturer code to use for the command. Use -1 to force no manufacturer code.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `zha.issue_zigbee_group_command`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: zha.issue_zigbee_group_command
+  data:
+    group: "0x0222"
+    cluster_id: 6
+    command: 1
+{% endexample %}
+
+This sends the on command of the on/off cluster to every device in the group.
+
+### Options in YAML
+
+{% options_yaml %}
+group:
+  description: The hexadecimal address of the group to send the command to.
+  required: true
+  type: string
+cluster_id:
+  description: The cluster to send the command to.
+  required: true
+  type: integer
+cluster_type:
+  description: Whether the cluster is an input (server) or output (client) cluster, set as `in` or `out`. Defaults to `in`.
+  required: false
+  type: string
+command:
+  description: The ID of the command to send.
+  required: true
+  type: integer
+args:
+  description: The arguments to pass to the command, as a list.
+  required: false
+  type: list
+manufacturer:
+  description: The manufacturer code to use for the command. Use -1 to force no manufacturer code.
+  required: false
+  type: integer
+{% endoptions_yaml %}
+
+## Good to know
+
+- The group must already exist. You can create Zigbee groups on the ZHA configuration page.
+- Cluster and command IDs are specific to the device type behind the group.
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/zha.permit.markdown
+++ b/source/_actions/zha.permit.markdown
@@ -1,0 +1,92 @@
+---
+title: "Permit devices to join the Zigbee network"
+action: zha.permit
+domain: zha
+description: "Opens the ZHA Zigbee network so new devices can join."
+related_actions:
+  - zha.remove
+---
+
+Use this action to open your Zigbee network for a short time so new devices can join. Most of the time you add devices through the UI with the **Add device** flow, but this action is handy when you want to open the network from an automation or a script, for example with the press of a button.
+
+Only users with administrator rights can run this action.
+
+{% include actions/ui_header.md %}
+
+To open the network for joining from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Search for and select **Permit**.
+6. Optionally, set how long the network stays open and the joining details.
+7. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Duration:
+  description: How long, in seconds, the network stays open for joining. Defaults to 60 seconds.
+  required: false
+IEEE:
+  description: The IEEE address of an existing router device through which the new device should join. Useful when you want a device to join through a specific router.
+  required: false
+Source IEEE:
+  description: The IEEE address of the joining device. Use together with the install code.
+  required: false
+Install code:
+  description: The install code of the joining device. Use together with the source IEEE address.
+  required: false
+QR code:
+  description: A QR code that contains both the IEEE address and the install code of the joining device.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `zha.permit`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: zha.permit
+  data:
+    duration: 120
+{% endexample %}
+
+This opens the network for new devices to join for 120 seconds.
+
+### Options in YAML
+
+{% options_yaml %}
+duration:
+  description: How long, in seconds, the network stays open for joining. Defaults to 60 seconds.
+  required: false
+  type: integer
+ieee:
+  description: The IEEE address of an existing router device through which the new device should join.
+  required: false
+  type: string
+source_ieee:
+  description: The IEEE address of the joining device. Use together with the install code.
+  required: false
+  type: string
+install_code:
+  description: The install code of the joining device. Use together with the source IEEE address.
+  required: false
+  type: string
+qr_code:
+  description: A QR code that contains both the IEEE address and the install code of the joining device.
+  required: false
+  type: string
+{% endoptions_yaml %}
+
+## Good to know
+
+- To join a device that uses an install code, provide either the QR code, or the source IEEE address and install code together.
+- QR install codes are supported from Aqara, Bosch, Consciot, and Embrighten.
+- For everyday device pairing, the **Add device** flow in the UI is the easier path.
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/zha.remove.markdown
+++ b/source/_actions/zha.remove.markdown
@@ -1,0 +1,59 @@
+---
+title: "Remove a device from the Zigbee network"
+action: zha.remove
+domain: zha
+description: "Removes a node from the ZHA Zigbee network."
+related_actions:
+  - zha.permit
+---
+
+Use this action to remove a device from your Zigbee network by its IEEE address. You can find the IEEE address on the device's page in Home Assistant. This is useful when you want to remove a device from an automation or a script, rather than through the UI.
+
+Only users with administrator rights can run this action.
+
+{% include actions/ui_header.md %}
+
+To remove a device from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Search for and select **Remove**.
+6. Set **IEEE** to the IEEE address of the device you want to remove.
+7. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+IEEE:
+  description: The IEEE address of the device to remove.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `zha.remove`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: zha.remove
+  data:
+    ieee: "00:0d:6f:00:05:7d:2d:34"
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+ieee:
+  description: The IEEE address of the device to remove.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+## Good to know
+
+- Removing a device is not reversible. To use the device again, you need to pair it back to the network.
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/zha.set_lock_user_code.markdown
+++ b/source/_actions/zha.set_lock_user_code.markdown
@@ -1,0 +1,72 @@
+---
+title: "Set a lock user code"
+action: zha.set_lock_user_code
+domain: zha
+description: "Stores a user code in a slot on a Zigbee lock."
+related_actions:
+  - zha.enable_lock_user_code
+  - zha.disable_lock_user_code
+  - zha.clear_lock_user_code
+---
+
+Use this action to store a user code in a slot on a Zigbee lock. This lets you set or change a PIN code from an automation or a script, for example to hand out a temporary code to a guest and change it after they leave.
+
+{% include actions/ui_header.md %}
+
+To set a lock user code from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the lock you want to set a code on.
+6. From the actions shown for that target, select **Set lock user code**.
+7. Set the code slot and the code.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Code slot:
+  description: The slot to store the code in.
+Code:
+  description: The code to store in the slot.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `zha.set_lock_user_code`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: zha.set_lock_user_code
+  target:
+    entity_id: lock.front_door
+  data:
+    code_slot: 1
+    user_code: "1234"
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+code_slot:
+  description: The slot to store the code in.
+  required: true
+  type: integer
+user_code:
+  description: The code to store in the slot.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="lock" %}
+
+## Good to know
+
+- The number of available slots and the allowed code length depend on the lock. For example, a Kwikset 954 supports slots 1 to 32 and codes of 4 to 8 digits.
+- Setting a code in a slot that already has one overwrites the existing code.
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/zha.set_zigbee_cluster_attribute.markdown
+++ b/source/_actions/zha.set_zigbee_cluster_attribute.markdown
@@ -1,0 +1,103 @@
+---
+title: "Set a Zigbee cluster attribute"
+action: zha.set_zigbee_cluster_attribute
+domain: zha
+description: "Writes a value to a Zigbee cluster attribute on a device."
+related_actions:
+  - zha.issue_zigbee_cluster_command
+  - zha.issue_zigbee_group_command
+---
+
+Use this action to write a value directly to a Zigbee cluster attribute on a device. This is a low-level tool for fine-tuning device behavior or working around device quirks that aren't exposed through the regular entities. You need to know the device's IEEE address, the endpoint, the cluster, and the attribute you want to change.
+
+Only users with administrator rights can run this action.
+
+{% include actions/ui_header.md %}
+
+To set a cluster attribute from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Search for and select **Set Zigbee cluster attribute**.
+6. Fill in the device, endpoint, cluster, attribute, and value.
+7. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+IEEE:
+  description: The IEEE address of the device.
+Endpoint ID:
+  description: The endpoint on the device that holds the cluster.
+Cluster ID:
+  description: The cluster that holds the attribute.
+Cluster type:
+  description: Whether the cluster is an input (server) or output (client) cluster. Defaults to input.
+  required: false
+Attribute:
+  description: The ID of the attribute to write.
+Value:
+  description: The value to write to the attribute.
+Manufacturer:
+  description: The manufacturer code to use for the write. Use -1 to force no manufacturer code.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `zha.set_zigbee_cluster_attribute`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: zha.set_zigbee_cluster_attribute
+  data:
+    ieee: "00:0d:6f:00:05:7d:2d:34"
+    endpoint_id: 1
+    cluster_id: 8
+    attribute: 17
+    value: 50
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+ieee:
+  description: The IEEE address of the device.
+  required: true
+  type: string
+endpoint_id:
+  description: The endpoint on the device that holds the cluster.
+  required: true
+  type: integer
+cluster_id:
+  description: The cluster that holds the attribute.
+  required: true
+  type: integer
+cluster_type:
+  description: Whether the cluster is an input (server) or output (client) cluster, set as `in` or `out`. Defaults to `in`.
+  required: false
+  type: string
+attribute:
+  description: The ID of the attribute to write.
+  required: true
+  type: integer
+value:
+  description: The value to write to the attribute.
+  required: true
+  type: integer
+manufacturer:
+  description: The manufacturer code to use for the write. Use -1 to force no manufacturer code.
+  required: false
+  type: integer
+{% endoptions_yaml %}
+
+## Good to know
+
+- Cluster, attribute, and endpoint IDs are specific to each device. You can look them up on the device's page under **Manage clusters**.
+- Writing the wrong value to an attribute can cause a device to behave unexpectedly. Double-check the values before you run the action.
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/zha.warning_device_squawk.markdown
+++ b/source/_actions/zha.warning_device_squawk.markdown
@@ -1,0 +1,81 @@
+---
+title: "Make a warning device squawk"
+action: zha.warning_device_squawk
+domain: zha
+description: "Emits a short audible and visible pulse on a Zigbee warning device."
+related_actions:
+  - zha.warning_device_warn
+---
+
+Use this action to make a Zigbee warning device, such as a siren, emit a short pulse called a squawk. A squawk is a quick beep and flash, often used to confirm that a system was armed or disarmed. You identify the device by its IEEE address.
+
+Only users with administrator rights can run this action.
+
+{% include actions/ui_header.md %}
+
+To make a warning device squawk from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Search for and select **Warning device squawk**.
+6. Set the device and, optionally, the squawk mode, strobe, and level.
+7. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+IEEE:
+  description: The IEEE address of the warning device.
+Mode:
+  description: The squawk mode, which sets the kind of sound the device makes. Defaults to 0.
+  required: false
+Strobe:
+  description: Whether the device also flashes its strobe during the squawk. Use 1 to flash, 0 for sound only. Defaults to 1.
+  required: false
+Level:
+  description: The loudness of the squawk, from 0 (low) to 3 (high). Defaults to 2.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `zha.warning_device_squawk`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: zha.warning_device_squawk
+  data:
+    ieee: "00:0d:6f:00:05:7d:2d:34"
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+ieee:
+  description: The IEEE address of the warning device.
+  required: true
+  type: string
+mode:
+  description: The squawk mode, which sets the kind of sound the device makes, from 0 to 1. Defaults to 0.
+  required: false
+  type: integer
+strobe:
+  description: Whether the device also flashes its strobe during the squawk. Use 1 to flash, 0 for sound only. Defaults to 1.
+  required: false
+  type: integer
+level:
+  description: The loudness of the squawk, from 0 (low) to 3 (high). Defaults to 2.
+  required: false
+  type: integer
+{% endoptions_yaml %}
+
+## Good to know
+
+- A squawk has no effect while the device is already running an active warning.
+- The exact sound for each mode depends on the device.
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/zha.warning_device_warn.markdown
+++ b/source/_actions/zha.warning_device_warn.markdown
@@ -1,0 +1,133 @@
+---
+title: "Start an alert on a warning device"
+action: zha.warning_device_warn
+domain: zha
+description: "Starts a siren and strobe alert on a Zigbee warning device."
+related_actions:
+  - zha.warning_device_squawk
+---
+
+Use this action to start a full alert on a Zigbee warning device, such as a siren. The device alerts the surrounding area with sound and, optionally, a flashing strobe for a set duration. You identify the device by its IEEE address. A common use is to sound a siren when a motion sensor detects someone while you're away.
+
+Only users with administrator rights can run this action.
+
+{% include actions/ui_header.md %}
+
+To start an alert from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Search for and select **Warning device starts alert**.
+6. Set the device and, optionally, the mode, strobe, level, duration, and strobe details.
+7. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+IEEE:
+  description: The IEEE address of the warning device.
+Mode:
+  description: The warning mode, which sets the kind of alarm sound, from 0 to 6. Defaults to 3.
+  required: false
+Strobe:
+  description: Whether the device also flashes its strobe during the alert. Use 1 to flash, 0 for sound only. Defaults to 1.
+  required: false
+Level:
+  description: The loudness of the siren, from 0 (low) to 3 (high). Defaults to 2.
+  required: false
+Duration:
+  description: How long, in seconds, the alert lasts. Defaults to 5 seconds.
+  required: false
+Duty cycle:
+  description: How much of each second the strobe stays on, from 0 to 100 in steps of 10. For example, 40 flashes on for 4 tenths of a second and off for 6 tenths. Defaults to 0.
+  required: false
+Intensity:
+  description: The brightness of the strobe, from 0 (low) to 3 (high). Defaults to 2.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `zha.warning_device_warn`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: zha.warning_device_warn
+  data:
+    ieee: "00:0d:6f:00:05:7d:2d:34"
+    duration: 10
+{% endexample %}
+
+This sounds the siren for 10 seconds.
+
+### Options in YAML
+
+{% options_yaml %}
+ieee:
+  description: The IEEE address of the warning device.
+  required: true
+  type: string
+mode:
+  description: The warning mode, which sets the kind of alarm sound, from 0 to 6. Defaults to 3.
+  required: false
+  type: integer
+strobe:
+  description: Whether the device also flashes its strobe during the alert. Use 1 to flash, 0 for sound only. Defaults to 1.
+  required: false
+  type: integer
+level:
+  description: The loudness of the siren, from 0 (low) to 3 (high). Defaults to 2.
+  required: false
+  type: integer
+duration:
+  description: How long, in seconds, the alert lasts. Defaults to 5 seconds.
+  required: false
+  type: integer
+duty_cycle:
+  description: How much of each second the strobe stays on, from 0 to 100 in steps of 10. Defaults to 0.
+  required: false
+  type: integer
+intensity:
+  description: The brightness of the strobe, from 0 (low) to 3 (high). Defaults to 2.
+  required: false
+  type: integer
+{% endoptions_yaml %}
+
+## Good to know
+
+- If both the mode and the strobe are set to 0, the duration is ignored and nothing happens.
+- The exact sound for each mode depends on the device.
+
+{% include actions/more_examples.md %}
+
+### Automation: sound the siren when motion is detected while away
+
+Start the siren for 30 seconds when a motion sensor turns on and nobody is home.
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  - alias: "Sound the siren on motion while away"
+    triggers:
+      - trigger: state
+        entity_id: binary_sensor.hallway_motion
+        to: "on"
+    conditions:
+      - condition: state
+        entity_id: group.family
+        state: "not_home"
+    actions:
+      - action: zha.warning_device_warn
+        data:
+          ieee: "00:0d:6f:00:05:7d:2d:34"
+          duration: 30
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/zha.markdown
+++ b/source/_integrations/zha.markdown
@@ -452,76 +452,7 @@ Some devices can be auto-discovered, which can simplify the ZHA setup process. T
 
 Additional devices in the [Compatible hardware](#compatible-hardware) section may be discoverable, however, only devices that have been confirmed discoverable are listed above.
 
-## Actions
-
-### Action: Permit
-
-The `zha.permit` action opens the network for joining new devices.
-
-To add new devices to the network, select the **Actions** tab in **Developer tools** and type `zha.permit` in the **Action** dropdown box. Next, follow the device instructions for adding, scanning, or performing a factory reset.
-
-| Data       | Optional | Description                                                                    |
-| ---------- | -------- | ------------------------------------------------------------------------------ |
-| `duration` | yes      | For how long to allow new devices to join, default 60s                         |
-| `ieee`     | yes      | The IEEE address of an existing device via which the new device is to be added |
-
-To join a new device using an install code (ZB3 devices) use the following data attributes (must use parameters only
-from the same group:
-
-| Data           | Parameter Group | Description                                                         |
-| -------------- | --------------- | ------------------------------------------------------------------- |
-| `src_ieee`     | install_code    | The IEEE address of the joining ZB3 device. Use with `install_code` |
-| `install_code` | install_code    | Install Code of the joining device. Use with `src_ieee`             |
-| `qr_code`      | qr_code         | QR code containing IEEE and Install Code of the joining ZB3 device  |
-
-{% note %}
-  Currently `qr_code` supports QR Install Codes from:
-    - Aqara
-    - Bosch
-    - Consciot
-    - Embrighten
-{% endnote %}
-
-### Action: Remove
-
-The `zha.remove` action removes an existing device from the network. You can find the IEEE address of the device on the device card of Zigbee devices. An example of an IEEE address data parameter format is `00:0d::6f:00:05:7d:2d:34`.
-
-| Data   | Optional | Description                          |
-| ------ | -------- | ------------------------------------ |
-| `ieee` | no       | IEEE address of the device to remove |
-
-### Action: Set lock user code
-
-The `zha.set_lock_user_code` action sets a lock code on a Zigbee lock.
-
-| Data        | Optional | Description                                                                |
-| ----------- | -------- | -------------------------------------------------------------------------- |
-| `code_slot` | no       | Which lock code slot to store the code. For example, 1-32 will work for Kwikset 954 |
-| `user_code` | no       | Code to set on the lock. For example, Kwikset accepts numbers 4-8 digits in length  |
-
-### Action: Clear lock user code
-
-The `zha.clear_lock_user_code` action clears a lock code from a Zigbee lock.
-
-| Data        | Optional | Description                   |
-| ----------- | -------- | ----------------------------- |
-| `code_slot` | no       | Which lock code slot to clear |
-
-### Action: Enable lock user code
-
-The `zha.enable_lock_user_code` action enables a lock code on a Zigbee lock.
-
-| Data        | Optional | Description                    |
-| ----------- | -------- | ------------------------------ |
-| `code_slot` | no       | Which lock code slot to enable |
-
-### Action: Disable lock user code
-
-The `zha.disable_lock_user_code` action disables a lock code on a Zigbee lock.
-
-| Data        | Optional | Description                     |
-| ----------- | -------- | ------------------------------- |
-| `code_slot` | no       | Which lock code slot to disable |
+{% include integrations/actions.md %}
 
 ## Zigbee groups and binding devices
 


### PR DESCRIPTION
## Proposed change

Moves the ZHA actions from the inline block on the integration page into dedicated pages under `source/_actions/`, listed through `{% include integrations/actions.md %}`.

Alongside the actions that were already documented (permit, remove, and the four lock user-code actions), this adds pages for the previously undocumented `set_zigbee_cluster_attribute`, `issue_zigbee_cluster_command`, `issue_zigbee_group_command`, `warning_device_squawk`, and `warning_device_warn` actions. Each action's options, defaults, and required fields were verified against the integration's code. The `reconfigure_device` entry in `services.yaml` is intentionally left out, as it is only exposed as a websocket command (the device page reconfigure button), not as a callable action.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

