### PR TITLE
Utility Meter: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/utility_meter.calibrate.markdown
+++ b/source/_actions/utility_meter.calibrate.markdown
@@ -55,8 +55,8 @@ value:
 
 ## Good to know
 
+- If your meter does not use tariffs, you can reset it by running this action with `value: 0`.
 - Calibrate each tariff sensor separately. If your meter tracks several tariffs, target the specific sensor you want to set.
-
 {% include actions/stuck.md %}
 
 {% include actions/related.md %}

--- a/source/_actions/utility_meter.calibrate.markdown
+++ b/source/_actions/utility_meter.calibrate.markdown
@@ -1,0 +1,62 @@
+---
+title: "Calibrate a utility meter"
+action: utility_meter.calibrate
+domain: utility_meter
+description: "Sets a utility meter sensor to a specific value."
+related_actions:
+  - utility_meter.reset
+---
+
+Use this action to calibrate a utility meter by setting one of its sensors to a specific value. This is handy when you want the meter to match a real-world reading, for example to line it up with the number printed on your physical energy or water meter.
+
+{% include actions/ui_header.md %}
+
+To calibrate a utility meter from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the utility meter sensor you want to calibrate.
+6. From the actions shown for that target, select **Calibrate**.
+7. Set the **Value** to calibrate the sensor with.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Value:
+  description: The value to set the meter sensor to.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `utility_meter.calibrate`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: utility_meter.calibrate
+  target:
+    entity_id: sensor.energy_monthly
+  data:
+    value: 100
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+value:
+  description: The value to set the meter sensor to.
+  required: true
+  type: float
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="sensor" %}
+
+## Good to know
+
+- Calibrate each tariff sensor separately. If your meter tracks several tariffs, target the specific sensor you want to set.
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/utility_meter.reset.markdown
+++ b/source/_actions/utility_meter.reset.markdown
@@ -1,0 +1,51 @@
+---
+title: "Reset a utility meter"
+action: utility_meter.reset
+domain: utility_meter
+description: "Resets all counters of a utility meter back to zero."
+related_actions:
+  - utility_meter.calibrate
+---
+
+Use this action to reset a utility meter. All sensors tracking tariffs for that meter are set back to zero, and the previous value is stored so you can still compare against it. This is handy when you want to start a fresh billing period on demand, for example at the start of a new contract.
+
+{% note %}
+This action targets the meter's tariff select entity, which only exists when you have configured tariffs for the meter.
+{% endnote %}
+
+{% include actions/ui_header.md %}
+
+To reset a utility meter from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the utility meter you want to reset.
+6. From the actions shown for that target, select **Reset**.
+7. Select **Save**.
+
+### Options in the UI
+
+This action has no options.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `utility_meter.reset`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: utility_meter.reset
+  target:
+    entity_id: select.energy
+{% endexample %}
+
+{% include actions/targets.md domain="select" %}
+
+## Good to know
+
+- Resetting stores the previous meter value in an attribute, so you can still compare the last period against the new one.
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/utility_meter.markdown
+++ b/source/_integrations/utility_meter.markdown
@@ -151,26 +151,7 @@ offset:
   minutes: 0
 ```
 
-## Actions
-
-Some of the actions are only available if tariffs are configured.
-
-### Action: Reset
-
-The `utility_meter.reset` action resets the Utility Meter. All sensors tracking tariffs will be reset to 0.
-
-| Data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `entity_id` | no | String or list of strings that point at `entity_id`s of utility_meters.
-
-### Action: Calibrate
-
-The `utility_meter.calibrate` action calibrates the Utility Meter by changing the value of a given sensor.
-
-| Data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `entity_id` | no | String or list of strings that point at `entity_id`s of utility_meters.
-| `value` | no | Number | Value to calibrate the sensor with | 
+{% include integrations/actions.md %}
 
 ## Advanced configuration
 

--- a/source/_integrations/utility_meter.markdown
+++ b/source/_integrations/utility_meter.markdown
@@ -151,6 +151,8 @@ offset:
   minutes: 0
 ```
 
+Some actions are only available if you have configured tariffs for the meter.
+
 {% include integrations/actions.md %}
 
 ## Advanced configuration


### PR DESCRIPTION
## Proposed change

Migrates the Utility Meter integration's actions out of the inline `## Actions` block on the integration page and into dedicated pages under `source/_actions/`, one file per action, in line with the ongoing action documentation migration. The inline block is replaced with `{% include integrations/actions.md %}`, which auto-lists the dedicated pages.

The two actions are `utility_meter.reset` (targets the meter's tariff select entity) and `utility_meter.calibrate` (targets a meter sensor, with a required value). Each page documents the intent, a UI walkthrough, YAML options, and targets. Fixed the calibrate value type to a number (it accepts decimals) and dropped the outdated `entity_id` data attribute, since it is the action's target.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

