### PR TITLE
Timer: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/timer.cancel.markdown
+++ b/source/_actions/timer.cancel.markdown
@@ -21,7 +21,7 @@ To cancel a timer from an automation or a script:
 3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
 4. In the **Then do** section, select **Add action**.
 5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the timer you want to cancel.
-6. From the actions shown for that target, select **Cancel timer**.
+6. From the actions shown for that target, select **Timer: Cancel timer**.
 7. Select **Save**.
 
 ### Options in the UI

--- a/source/_actions/timer.cancel.markdown
+++ b/source/_actions/timer.cancel.markdown
@@ -1,0 +1,50 @@
+---
+title: "Cancel a timer"
+action: timer.cancel
+domain: timer
+description: "Cancels a running or paused timer without firing the finished event."
+related_actions:
+  - timer.start
+  - timer.pause
+  - timer.finish
+  - timer.change
+---
+
+Use this action to cancel a running or paused timer. The timer resets to its last initial value, and the timer finished event does not fire. This is handy when you want to stop a countdown without triggering whatever the timer was supposed to set off.
+
+{% include actions/ui_header.md %}
+
+To cancel a timer from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the timer you want to cancel.
+6. From the actions shown for that target, select **Cancel timer**.
+7. Select **Save**.
+
+### Options in the UI
+
+This action has no options.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `timer.cancel`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: timer.cancel
+  target:
+    entity_id: timer.laundry
+{% endexample %}
+
+{% include actions/targets.md domain="timer" %}
+
+## Good to know
+
+- Canceling does not fire the `timer.finished` event. To end a timer early and fire that event, use the [Finish a timer](/actions/timer.finish/) action instead.
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/timer.change.markdown
+++ b/source/_actions/timer.change.markdown
@@ -1,0 +1,77 @@
+---
+title: "Change a timer"
+action: timer.change
+domain: timer
+description: "Adds or subtracts time on a running timer."
+related_actions:
+  - timer.start
+  - timer.pause
+  - timer.cancel
+  - timer.finish
+---
+
+Use this action to change a running timer by adding or subtracting time. This is handy when you want to extend or shorten a countdown that is already running, for example to add a few more minutes to a cooking timer without restarting it.
+
+{% include actions/ui_header.md %}
+
+To change a timer from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the timer you want to change.
+6. From the actions shown for that target, select **Change timer**.
+7. Set the **Duration** to add or subtract.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Duration:
+  description: The duration to add to or subtract from the running timer, as a number of seconds or in `HH:MM:SS` format. Use a negative value to subtract time.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `timer.change`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: timer.change
+  target:
+    entity_id: timer.laundry
+  data:
+    duration: "00:01:00"
+{% endexample %}
+
+To subtract time, use a negative duration:
+
+{% example %}
+action: |
+  action: timer.change
+  target:
+    entity_id: timer.laundry
+  data:
+    duration: -60
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+duration:
+  description: The duration to add to or subtract from the running timer, as a number of seconds or in `HH:MM:SS` format. Use a negative value to subtract time.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="timer" %}
+
+## Good to know
+
+- You cannot extend a timer beyond the duration set when it was started.
+- The timer must be running for this action to have an effect.
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/timer.change.markdown
+++ b/source/_actions/timer.change.markdown
@@ -21,7 +21,7 @@ To change a timer from an automation or a script:
 3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
 4. In the **Then do** section, select **Add action**.
 5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the timer you want to change.
-6. From the actions shown for that target, select **Change timer**.
+6. From the actions shown for that target, select **Timer: Change timer**.
 7. Set the **Duration** to add or subtract.
 8. Select **Save**.
 

--- a/source/_actions/timer.finish.markdown
+++ b/source/_actions/timer.finish.markdown
@@ -1,0 +1,50 @@
+---
+title: "Finish a timer"
+action: timer.finish
+domain: timer
+description: "Finishes a running or paused timer earlier than scheduled."
+related_actions:
+  - timer.start
+  - timer.pause
+  - timer.cancel
+  - timer.change
+---
+
+Use this action to finish a running or paused timer earlier than scheduled. The timer ends right away and fires its finished event, just as it would when the countdown reaches zero. This is handy when you want to trigger the timer's outcome immediately, for example to skip the rest of a countdown.
+
+{% include actions/ui_header.md %}
+
+To finish a timer from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the timer you want to finish.
+6. From the actions shown for that target, select **Finish timer**.
+7. Select **Save**.
+
+### Options in the UI
+
+This action has no options.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `timer.finish`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: timer.finish
+  target:
+    entity_id: timer.laundry
+{% endexample %}
+
+{% include actions/targets.md domain="timer" %}
+
+## Good to know
+
+- Finishing fires the `timer.finished` event. To stop a timer without firing that event, use the [Cancel a timer](/actions/timer.cancel/) action instead.
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/timer.finish.markdown
+++ b/source/_actions/timer.finish.markdown
@@ -21,7 +21,7 @@ To finish a timer from an automation or a script:
 3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
 4. In the **Then do** section, select **Add action**.
 5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the timer you want to finish.
-6. From the actions shown for that target, select **Finish timer**.
+6. From the actions shown for that target, select **Timer: Finish timer**.
 7. Select **Save**.
 
 ### Options in the UI

--- a/source/_actions/timer.pause.markdown
+++ b/source/_actions/timer.pause.markdown
@@ -21,7 +21,7 @@ To pause a timer from an automation or a script:
 3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
 4. In the **Then do** section, select **Add action**.
 5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the timer you want to pause.
-6. From the actions shown for that target, select **Pause timer**.
+6. From the actions shown for that target, select **Timer: Pause timer**.
 7. Select **Save**.
 
 ### Options in the UI

--- a/source/_actions/timer.pause.markdown
+++ b/source/_actions/timer.pause.markdown
@@ -1,0 +1,50 @@
+---
+title: "Pause a timer"
+action: timer.pause
+domain: timer
+description: "Pauses a running timer, keeping the remaining time."
+related_actions:
+  - timer.start
+  - timer.cancel
+  - timer.finish
+  - timer.change
+---
+
+Use this action to pause a running timer. The remaining time is kept, so you can continue later. This is handy when you need to interrupt a countdown briefly, for example pausing a workout timer between sets.
+
+{% include actions/ui_header.md %}
+
+To pause a timer from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the timer you want to pause.
+6. From the actions shown for that target, select **Pause timer**.
+7. Select **Save**.
+
+### Options in the UI
+
+This action has no options.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `timer.pause`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: timer.pause
+  target:
+    entity_id: timer.laundry
+{% endexample %}
+
+{% include actions/targets.md domain="timer" %}
+
+## Good to know
+
+- To continue a paused timer, use the [Start a timer](/actions/timer.start/) action without a duration. It resumes with the time that was left.
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/timer.reload.markdown
+++ b/source/_actions/timer.reload.markdown
@@ -23,7 +23,7 @@ To reload timers from an automation or a script:
 2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
 3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
 4. In the **Then do** section, select **Add action**.
-5. From the list of actions, search for and select **Reload timers**.
+5. From the list of actions, search for and select **Timer: Reload timers**.
 6. Select **Save**.
 
 ### Options in the UI
@@ -45,7 +45,7 @@ This action has no options.
 
 ## Good to know
 
-- The **Reload timers** action applies only to timers configured in YAML. Timers created from the UI are stored in Home Assistant, so reloading does not add, update, or remove them.
+- The **Timer: Reload timers** action applies only to timers configured in YAML. Timers created from the UI are stored in Home Assistant, so reloading does not add, update, or remove them.
 
 {% include actions/stuck.md %}
 

--- a/source/_actions/timer.reload.markdown
+++ b/source/_actions/timer.reload.markdown
@@ -1,0 +1,52 @@
+---
+title: "Reload timers"
+action: timer.reload
+domain: timer
+description: "Reloads timers from the YAML configuration."
+related_actions:
+  - timer.start
+  - timer.pause
+  - timer.cancel
+  - timer.finish
+  - timer.change
+---
+
+Use this action to reload your timers from the YAML configuration. This is handy when you have changed your YAML-defined timers and want Home Assistant to apply those changes without restarting.
+
+Only users with administrator rights can run this action.
+
+{% include actions/ui_header.md %}
+
+To reload timers from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the list of actions, search for and select **Reload timers**.
+6. Select **Save**.
+
+### Options in the UI
+
+This action has no options.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `timer.reload`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: timer.reload
+{% endexample %}
+
+### Options in YAML
+
+This action has no options.
+
+## Good to know
+
+- The **Reload timers** action applies only to timers configured in YAML. Timers created from the UI are stored in Home Assistant, so reloading does not add, update, or remove them.
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/timer.start.markdown
+++ b/source/_actions/timer.start.markdown
@@ -21,7 +21,7 @@ To start a timer from an automation or a script:
 3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
 4. In the **Then do** section, select **Add action**.
 5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the timer you want to start.
-6. From the actions shown for that target, select **Start timer**.
+6. From the actions shown for that target, select **Timer: Start timer**.
 7. Optionally, set a **Duration** to start the timer with.
 8. Select **Save**.
 

--- a/source/_actions/timer.start.markdown
+++ b/source/_actions/timer.start.markdown
@@ -1,0 +1,67 @@
+---
+title: "Start a timer"
+action: timer.start
+domain: timer
+description: "Starts a timer, or restarts it with a new duration."
+related_actions:
+  - timer.pause
+  - timer.cancel
+  - timer.finish
+  - timer.change
+---
+
+Use this action to start a timer, or to restart one with a new duration. If you don't give a duration, the timer restarts with its configured value, or continues a paused timer with the time that was left. This is the action you use to begin counting down, for example to start a cooking timer or to resume one you paused earlier.
+
+{% include actions/ui_header.md %}
+
+To start a timer from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the timer you want to start.
+6. From the actions shown for that target, select **Start timer**.
+7. Optionally, set a **Duration** to start the timer with.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Duration:
+  description: The duration to start the timer with, as a number of seconds or in `HH:MM:SS` format. If omitted, the timer uses its configured duration or the remaining time of a paused timer.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `timer.start`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: timer.start
+  target:
+    entity_id: timer.laundry
+  data:
+    duration: "00:05:00"
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+duration:
+  description: The duration to start the timer with, as a number of seconds or in `HH:MM:SS` format. If omitted, the timer uses its configured duration or the remaining time of a paused timer.
+  required: false
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="timer" %}
+
+## Good to know
+
+- To resume a paused timer, start it again without a duration. It continues with the time that was left.
+- When you start a running timer with a new duration, that duration applies until the timer finishes or is canceled, after which it resets to its configured value.
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/timer.markdown
+++ b/source/_integrations/timer.markdown
@@ -93,64 +93,7 @@ Use a timer when you want a countdown that can be started, paused, changed, canc
 
 {% include integrations/conditions.md %}
 
-## Actions
-
-### Action: Start
-
-The `timer.start` action starts or restarts a timer with the provided duration. If no duration is given, it will either restart with its initial value, or continue a paused timer with the remaining duration. If a new duration is provided, this will be the duration for the timer until it finishes or is canceled, which then will reset the duration back to the original configured value. The duration can be specified as a number of seconds or the easier to read `01:23:45` format.
-You can also use `entity_id: all` and all active timers will be started.
-
-| Data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `entity_id`            |      no  | Name of the entity to take action, e.g., `timer.timer0`. |
-| `duration`             |      yes | Duration in seconds or `01:23:45` format until the timer finishes. |
-
-### Action: Change
-
-The `timer.change` action changes an active timer. This changes the duration of the timer with the duration given. You can also use `entity_id: all` and all active timers will be changed. You cannot extend the duration beyond that set by `timer.start`.
-
-| Data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `entity_id`            |      no  | Name of the entity to take action, e.g., `timer.timer0`. |
-| `duration`             |      no  | Duration in seconds or `00:00:00` to add or subtract from the running timer. |
-
-### Action: Pause
-
-The `timer.pause` action pauses a running timer. This will retain the remaining duration for later continuation. To resume a timer use the `timer.start` action without passing a duration. You can also use `entity_id: all` and all active timers will be paused.
-
-| Data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `entity_id`            |      no  | Name of the entity to take action, e.g., `timer.timer0`. |
-
-### Action: Cancel
-
-The `timer.cancel` action cancels a running or paused timer. This resets the duration to the last known initial value without firing the `timer.finished` event. You can also use `entity_id: all` and all active and paused timers will be canceled.
-
-| Data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `entity_id`            |      no  | Name of the entity to take action, e.g., `timer.timer0`. |
-
-### Action: Finish
-
-The `timer.finish` action manually finishes a running or paused timer earlier than scheduled. You can also use `entity_id: all` and all active and paused timers will be finished.
-
-| Data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `entity_id`            |      no  | Name of the entity to take action, e.g., `timer.timer0`. |
-
-### Action: Reload
-
-The `timer.reload` action reloads `timer`'s configuration without restarting Home Assistant itself. This action takes no data attributes.
-
-{% important %}
-The **Reload timers** action applies only to timers configured in YAML.
-When you run it, Home Assistant re-reads the timers from your YAML configuration and applies changes there.
-Timers created from the UI are stored in Home Assistant, so reload does not add, update, or remove them.
-{% endimportant %}
-
-### Using the action
-
-Go to {% my developer_services title="**Settings** > **Developer tools** > **Actions**" %} and select the `timer.start` action, then click the **Fill Example Data** button. Now change the `entity_id` and `duration` and select **Perform action** button.
+{% include integrations/actions.md %}
 
 ## Timer automation examples
 


### PR DESCRIPTION
## Proposed change

Migrates the `timer` actions from the inline block on the integration page into dedicated pages under `source/_actions/`, one per action (`timer.start`, `timer.change`, `timer.pause`, `timer.cancel`, `timer.finish`, `timer.reload`), and replaces the inline block with `{% include integrations/actions.md %}`.

This is part of the ongoing effort to move integration actions into their own pages, giving each action clearer intent, UI and YAML guidance, options, and examples.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

