### PR TITLE
Add Yoto ambient color selects documentation

### DIFF
--- a/source/_integrations/yoto.markdown
+++ b/source/_integrations/yoto.markdown
@@ -4,6 +4,7 @@ description: Instructions on how to integrate Yoto players with Home Assistant.
 ha_category:
   - Binary Sensor
   - Media Player
+  - Select
   - Sensor
   - Time
 ha_iot_class: Cloud Push
@@ -17,6 +18,7 @@ ha_domain: yoto
 ha_platforms:
   - binary_sensor
   - media_player
+  - select
   - sensor
   - time
 ha_integration_type: hub
@@ -102,12 +104,19 @@ data:
   media_content_id: "yoto://card/abc123/01/02"
 ```
 
-### Day and night mode
+### Time
 
-Yoto players can switch between a day display and a night display. Each player provides two time entities that let you set when each mode starts:
+Yoto players can switch between a day display and a night display. Set when each mode starts:
 
 - **Day mode start**: The time the player switches to day mode.
 - **Night mode start**: The time the player switches to night mode.
+
+### Selects
+
+Set the player's ambient light color for each mode, picked from a fixed palette. Available on players with an ambient light:
+
+- **Day mode color**: The ambient light color in day mode.
+- **Night mode color**: The ambient light color in night mode.
 
 ### Binary sensors
 


### PR DESCRIPTION
## Proposed change

Document the `select` config entities added in [home-assistant/core#173909](https://github.com/home-assistant/core/pull/173909): the ambient light color for day and night mode (**Day mode color** and **Night mode color**), available on players with an ambient light.

Follows the integration docs template, with a per-platform section (`### Selects`). Also renames the existing `### Day and night mode` section to `### Time` so the entity sections are consistent by platform.

This PR is independent of the other Yoto entity PRs (#46239, #46240). They each add their own platform section, so they can be merged in any order.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/173909
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
