### PR TITLE
webOS TV: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/webostv.button.markdown
+++ b/source/_actions/webostv.button.markdown
@@ -1,0 +1,64 @@
+---
+title: "Button"
+action: webostv.button
+domain: webostv
+description: "Simulates a button press on the remote of an LG webOS TV."
+related_actions:
+  - webostv.command
+  - webostv.select_sound_output
+---
+
+Use this action to simulate a press of a button on the remote of your LG webOS TV. This is handy when you want to navigate the on-screen menus from an automation or script, for example to open the home menu or move the selection with the arrow keys.
+
+{% include actions/ui_header.md %}
+
+To press a button from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the TV you want to control.
+6. From the actions shown for that target, select **Button**.
+7. Set the **Button** you want to press.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Button:
+  description: "The name of the button to press. Known values are: LEFT, RIGHT, DOWN, UP, HOME, MENU, BACK, ENTER, DASH, INFO, ASTERISK, CC, EXIT, MUTE, RED, GREEN, BLUE, YELLOW, VOLUMEUP, VOLUMEDOWN, CHANNELUP, CHANNELDOWN, PLAY, PAUSE, and 0 to 9. Other buttons supported by your TV may also work."
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `webostv.button`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: webostv.button
+  target:
+    entity_id: media_player.lg_webos_tv
+  data:
+    button: "HOME"
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+button:
+  description: "The name of the button to press. Known values are: LEFT, RIGHT, DOWN, UP, HOME, MENU, BACK, ENTER, DASH, INFO, ASTERISK, CC, EXIT, MUTE, RED, GREEN, BLUE, YELLOW, VOLUMEUP, VOLUMEDOWN, CHANNELUP, CHANNELDOWN, PLAY, PAUSE, and 0 to 9. Other buttons supported by your TV may also work."
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="media_player" %}
+
+## Good to know
+
+- The button names match the keys on the TV remote. The list above covers the commonly known buttons, but your TV may accept other button names as well.
+- To send a generic command to the TV instead of a button press, use the [Command](/actions/webostv.command/) action.
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/webostv.button.markdown
+++ b/source/_actions/webostv.button.markdown
@@ -27,7 +27,7 @@ To press a button from an automation or a script:
 
 {% options_ui %}
 Button:
-  description: "The name of the button to press. Known values are: LEFT, RIGHT, DOWN, UP, HOME, MENU, BACK, ENTER, DASH, INFO, ASTERISK, CC, EXIT, MUTE, RED, GREEN, BLUE, YELLOW, VOLUMEUP, VOLUMEDOWN, CHANNELUP, CHANNELDOWN, PLAY, PAUSE, and 0 to 9. Other buttons supported by your TV may also work."
+  description: "The name of the button to press. Known values are: LEFT, RIGHT, DOWN, UP, HOME, MENU, BACK, ENTER, DASH, INFO, ASTERISK, CC, EXIT, MUTE, RED, GREEN, BLUE, YELLOW, VOLUMEUP, VOLUMEDOWN, CHANNELUP, CHANNELDOWN, PLAY, PAUSE, NETFLIX, GUIDE, AMAZON, and 0 to 9. Other buttons supported by your TV may also work."
 {% endoptions_ui %}
 
 {% include actions/yaml_header.md %}
@@ -47,7 +47,7 @@ action: |
 
 {% options_yaml %}
 button:
-  description: "The name of the button to press. Known values are: LEFT, RIGHT, DOWN, UP, HOME, MENU, BACK, ENTER, DASH, INFO, ASTERISK, CC, EXIT, MUTE, RED, GREEN, BLUE, YELLOW, VOLUMEUP, VOLUMEDOWN, CHANNELUP, CHANNELDOWN, PLAY, PAUSE, and 0 to 9. Other buttons supported by your TV may also work."
+  description: "The name of the button to press. Known values are: LEFT, RIGHT, DOWN, UP, HOME, MENU, BACK, ENTER, DASH, INFO, ASTERISK, CC, EXIT, MUTE, RED, GREEN, BLUE, YELLOW, VOLUMEUP, VOLUMEDOWN, CHANNELUP, CHANNELDOWN, PLAY, PAUSE, NETFLIX, GUIDE, AMAZON, and 0 to 9. Other buttons supported by your TV may also work."
   required: true
   type: string
 {% endoptions_yaml %}

--- a/source/_actions/webostv.command.markdown
+++ b/source/_actions/webostv.command.markdown
@@ -1,0 +1,79 @@
+---
+title: "Command"
+action: webostv.command
+domain: webostv
+description: "Sends a generic command to an LG webOS TV."
+related_actions:
+  - webostv.button
+  - webostv.select_sound_output
+---
+
+Use this action to send a generic command to your LG webOS TV. This is handy when you want to control something that doesn't have its own action, for example to open an app or call a specific endpoint on the TV.
+
+You provide the endpoint of the command and, when needed, a payload with extra details. The full list of known endpoints is available in the [aiowebostv endpoints reference](https://github.com/home-assistant-libs/aiowebostv/blob/main/aiowebostv/endpoints.py).
+
+{% include actions/ui_header.md %}
+
+To send a command from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the TV you want to control.
+6. From the actions shown for that target, select **Command**.
+7. Set the **Command** and, if needed, a **Payload**.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Command:
+  description: The endpoint of the command to send, for example system.launcher/open.
+Payload:
+  description: An optional payload to send with the command, as one or more key-value pairs.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `webostv.command`. A basic example that opens a web page looks like this:
+
+{% example %}
+action: |
+  action: webostv.command
+  target:
+    entity_id: media_player.lg_webos_tv
+  data:
+    command: "system.launcher/open"
+    payload:
+      target: "https://www.google.com"
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+command:
+  description: The endpoint of the command to send, for example system.launcher/open.
+  required: true
+  type: string
+payload:
+  description: An optional payload to send with the command, as one or more key-value pairs.
+  required: false
+  type: map
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="media_player" %}
+
+## Response data
+
+This action can return the raw response from the TV. The contents depend on the command you send, so the fields vary from one endpoint to another. To capture the response, set a `response_variable` and use it in a later step.
+
+## Good to know
+
+- The available endpoints and their payloads are defined by the TV, not by Home Assistant. See the [aiowebostv endpoints reference](https://github.com/home-assistant-libs/aiowebostv/blob/main/aiowebostv/endpoints.py) for known endpoints.
+- To simulate a remote button press instead of sending an endpoint, use the [Button](/actions/webostv.button/) action.
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/webostv.select_sound_output.markdown
+++ b/source/_actions/webostv.select_sound_output.markdown
@@ -1,0 +1,68 @@
+---
+title: "Select sound output"
+action: webostv.select_sound_output
+domain: webostv
+description: "Changes the active sound output of an LG webOS TV."
+related_actions:
+  - webostv.button
+  - webostv.command
+---
+
+Use this action to change the active sound output of your LG webOS TV. This is handy when you want to switch where the audio plays, for example from the built-in TV speakers to a connected soundbar.
+
+{% include actions/ui_header.md %}
+
+To change the sound output from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the TV you want to control.
+6. From the actions shown for that target, select **Select sound output**.
+7. Set the **Sound output** you want to switch to.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Sound output:
+  description: The name of the sound output to switch to, for example tv_speaker or external_speaker.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `webostv.select_sound_output`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: webostv.select_sound_output
+  target:
+    entity_id: media_player.lg_webos_tv
+  data:
+    sound_output: "external_speaker"
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+sound_output:
+  description: The name of the sound output to switch to, for example tv_speaker or external_speaker.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="media_player" %}
+
+## Response data
+
+This action can return the raw response from the TV, confirming the change. The exact fields depend on your TV. To capture the response, set a `response_variable` and use it in a later step.
+
+## Good to know
+
+- The available sound outputs depend on your TV and what is connected to it. Common values are `tv_speaker`, `external_speaker`, `external_optical`, `external_arc`, and `headphone`.
+- You can see the current sound output in the state attributes of the media player entity, under `sound_output`.
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/webostv.markdown
+++ b/source/_integrations/webostv.markdown
@@ -66,13 +66,12 @@ This usually only works if the TV is connected to the same network. Routing the 
 
 ## Notifications
 
-The `notify` platform allows you to send notifications to an LG webOS TV. You can override the icon for individual notifications by providing a path to an alternative icon image.
+The `notify` platform allows you to send notifications to an LG webOS TV. Each TV gets its own action, named after the TV, such as `notify.livingroom_tv`. The action name selects which TV receives the notification, so you don't target an entity. You can override the icon for individual notifications by providing a path to an alternative icon image.
 
 This notification action takes the following options:
 
-- `entity_id`: The webOS TV media player to send the notification to.
 - `message`: The message to display on the TV.
-- `icon`: An optional icon to show with the notification.
+- `icon`: An optional icon to show with the notification. In YAML, pass it inside the nested `data:` block, as shown in the example below.
 
 ```yaml
 automation:

--- a/source/_integrations/webostv.markdown
+++ b/source/_integrations/webostv.markdown
@@ -62,70 +62,17 @@ A common setup for webOS 3.0 and higher is to use Wake-on-LAN. For this to work,
 This usually only works if the TV is connected to the same network. Routing the Wake-on-LAN packet to a different subnet requires special configuration on your router or may not be possible.
 {% endimportant %}
 
-## Actions
+{% include integrations/actions.md %}
 
-The integration provides the following actions.
+## Notifications
 
-### Action: Select sound output
+The `notify` platform allows you to send notifications to an LG webOS TV. You can override the icon for individual notifications by providing a path to an alternative icon image.
 
-The `webostv.select_sound_output` action is used to select the active sound output.
-The current sound output of the TV can be found under the state attributes.
+This notification action takes the following options:
 
-| Data attribute | Optional | Description                             |
-| ---------------------- | -------- | --------------------------------------- |
-| `entity_id`            | no       | Target a specific webostv media player. |
-| `sound_output`         | no       | Name of the sound output to switch to.  |
-
-### Action: Button press
-
-The `webostv.button` action is used to simulate a button press.
-
-| Data attribute | Optional | Description                                                                                                                                                                                                                                                                            |
-| ---------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `entity_id`            | no       | Target a specific webostv media player.                                                                                                                                                                                                                                                |
-| `button`               | no       | Name of the button. Known possible values are `LEFT`, `RIGHT`, `DOWN`, `UP`, `HOME`, `MENU`, `BACK`, `ENTER`, `DASH`, `INFO`, `ASTERISK`, `CC`, `EXIT`, `MUTE`, `RED`, `GREEN`, `BLUE`, `YELLOW`, `VOLUMEUP`, `VOLUMEDOWN`, `CHANNELUP`, `CHANNELDOWN`, `PLAY`, `PAUSE`, `NETFLIX`, `GUIDE`, `AMAZON`, `0`, `1`, `2`, `3`, `4`, `5`, `6`, `7`, `8`, `9` |
-
-### Action: Generic command
-
-The `webostv.command` action is used to send a generic command to the TV.
-
-| Data attribute | Optional | Description                                                                                                                                                                          |
-| ---------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `entity_id`            | no       | Target a specific webostv media player.                                                                                                                                              |
-| `command`              | no       | Endpoint for the command, e.g.,  `system.launcher/open`.  The full list of known endpoints is available at <https://github.com/home-assistant-libs/aiowebostv/blob/main/aiowebostv/endpoints.py> |
-| `payload`             | yes      | An optional payload to provide to the endpoint in the format of key value pair(s). |
-
-```yaml
-script:
-  home_button:
-    sequence:
-      - action: webostv.button
-        target:
-          entity_id:  media_player.lg_webos_tv
-        data:
-          button: "HOME"
-
-  open_google_command:
-    sequence:
-      - action: webostv.command
-        target:
-          entity_id:  media_player.lg_webos_tv
-        data:
-          command: "system.launcher/open"
-          payload:
-            target: https://www.google.com
-```
-
-### Action: Notify
-
-The `notify` platform allows you to send notifications to a LG webOS TV.
-The icon can be overridden for individual notifications by providing a path to an alternative icon image to use:
-
-| Data attribute | Optional | Description                             |
-| ---------------------- | -------- | --------------------------------------- |
-| `entity_id`            | no       | Target a specific webostv media player. |
-| `message`         | no       | Message to be displayed on the TV.  |
-| `icon`         | yes       | Optional icon to be shown with the notification.  |
+- `entity_id`: The webOS TV media player to send the notification to.
+- `message`: The message to display on the TV.
+- `icon`: An optional icon to show with the notification.
 
 ```yaml
 automation:


### PR DESCRIPTION
## Proposed change

Migrates the `webostv` actions from the inline block on the integration page into dedicated pages under `source/_actions/`, one per action (`webostv.button`, `webostv.command`, `webostv.select_sound_output`), and replaces the inline block with `{% include integrations/actions.md %}`.

This is part of the ongoing effort to move integration actions into their own pages, giving each action clearer intent, UI and YAML guidance, options, and examples. The `notify` platform documentation stays on the integration page, now under its own **Notifications** heading with the options as a list instead of a table.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

