### PR TITLE
Logger: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/logger.set_default_level.markdown
+++ b/source/_actions/logger.set_default_level.markdown
@@ -2,7 +2,7 @@
 title: "Set logger default level"
 action: logger.set_default_level
 domain: logger
-description: "Sets the default log level for integrations."
+description: "Sets the default log level for loggers without an explicit level."
 related_actions:
   - logger.set_level
 ---
@@ -19,7 +19,7 @@ To set the default log level from an automation or a script:
 2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
 3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
 4. In the **Then do** section, select **Add action**.
-5. From the list of actions, search for and select **Set logger default level**.
+5. From the list of actions, search for and select **Logger: Set logger default level**.
 6. Set the **Level** you want to use as the default.
 7. Select **Save**.
 

--- a/source/_actions/logger.set_default_level.markdown
+++ b/source/_actions/logger.set_default_level.markdown
@@ -1,0 +1,60 @@
+---
+title: "Set logger default level"
+action: logger.set_default_level
+domain: logger
+description: "Sets the default log level for integrations."
+related_actions:
+  - logger.set_level
+---
+
+Use this action to set the default log level. This level applies to integrations that don't have a log level of their own. This is handy when you want to see more or less detail in your logs across the board, for example raising everything to debug while you investigate a problem.
+
+Only users with administrator rights can run this action.
+
+{% include actions/ui_header.md %}
+
+To set the default log level from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the list of actions, search for and select **Set logger default level**.
+6. Set the **Level** you want to use as the default.
+7. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Level:
+  description: "The default severity level for integrations without their own level. One of: debug, info, warning, error, fatal, or critical."
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `logger.set_default_level`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: logger.set_default_level
+  data:
+    level: info
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+level:
+  description: "The default severity level for integrations without their own level. One of: debug, info, warning, error, fatal, or critical."
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+## Good to know
+
+- This level applies only to integrations that don't have a specific level set. To set the level for one or more specific integrations, use the [Set logger level](/actions/logger.set_level/) action.
+- The default level resets when you restart Home Assistant, unless you set a default in your configuration.
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/logger.set_level.markdown
+++ b/source/_actions/logger.set_level.markdown
@@ -1,0 +1,59 @@
+---
+title: "Set logger level"
+action: logger.set_level
+domain: logger
+description: "Sets the log level for one or more integrations."
+related_actions:
+  - logger.set_default_level
+---
+
+Use this action to set the log level for one or more specific integrations. This is handy when you want more detail from just one integration, for example raising a single integration to debug while you troubleshoot it, without making the rest of your logs noisy.
+
+Only users with administrator rights can run this action.
+
+{% include actions/ui_header.md %}
+
+To set the log level for specific integrations from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the list of actions, search for and select **Set logger level**.
+6. Select **Edit in YAML** and provide one or more logger names with the level for each.
+7. Select **Save**.
+
+### Options in the UI
+
+This action does not have fixed options. You provide one or more logger names, each with the level to set for it.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `logger.set_level`. Provide one or more logger names with the level for each:
+
+{% example %}
+action: |
+  action: logger.set_level
+  data:
+    homeassistant.core: fatal
+    homeassistant.components.mqtt: warning
+    homeassistant.components.smartthings.light: info
+    custom_components.my_integration: debug
+    aiohttp: error
+{% endexample %}
+
+### Options in YAML
+
+This action does not have fixed options. Instead, you provide one or more entries, where each key is a logger name and each value is the level to set for it.
+
+- The logger name follows the module path, such as `homeassistant.components.mqtt` for an integration, `custom_components.my_integration` for a custom integration, or a library name like `aiohttp`.
+- The level is one of: `debug`, `info`, `warning`, `error`, `fatal`, or `critical`.
+
+## Good to know
+
+- The levels you set here apply on top of the default level. To change the default for integrations without their own level, use the [Set logger default level](/actions/logger.set_default_level/) action.
+- The levels you set reset when you restart Home Assistant, unless you set them in your configuration.
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/logger.set_level.markdown
+++ b/source/_actions/logger.set_level.markdown
@@ -19,7 +19,7 @@ To set the log level for specific integrations from an automation or a script:
 2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
 3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
 4. In the **Then do** section, select **Add action**.
-5. From the list of actions, search for and select **Set logger level**.
+5. From the list of actions, search for and select **Logger: Set logger level**.
 6. Select **Edit in YAML** and provide one or more logger names with the level for each.
 7. Select **Save**.
 

--- a/source/_integrations/logger.markdown
+++ b/source/_integrations/logger.markdown
@@ -138,37 +138,7 @@ logger:
 To learn more about Regular Expression, see the [Python documentation](https://docs.python.org/3/library/re.html)
 {% endnote %}
 
-## Actions
-
-### Action: Set default level
-
-The `logger.set_default_level` action alters the default log level (for integrations without a specified log
-level).
-
-An example call might look like this:
-
-```yaml
-action: logger.set_default_level
-data:
-  level: info
-```
-
-### Action: Set level
-
-The `logger.set_level` action alters the log level for one or several integrations.
-It accepts the same format as `logs` in the configuration.
-
-An example call might look like this:
-
-```yaml
-action: logger.set_level
-data:
-  homeassistant.core: fatal
-  homeassistant.components.mqtt: warning
-  homeassistant.components.smartthings.light: info
-  custom_components.my_integration: debug
-  aiohttp: error
-```
+{% include integrations/actions.md %}
 
 ## Viewing logs
 


### PR DESCRIPTION
## Proposed change

Migrates the `logger` actions from the inline block on the integration page into dedicated pages under `source/_actions/`, one per action (`logger.set_default_level`, `logger.set_level`), and replaces the inline block with `{% include integrations/actions.md %}`.

This is part of the ongoing effort to move integration actions into their own pages, giving each action clearer intent, UI and YAML guidance, options, and examples. Both actions are documented as requiring administrator rights, matching the core implementation.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

