### PR TITLE
Counter: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/counter.decrement.markdown
+++ b/source/_actions/counter.decrement.markdown
@@ -1,0 +1,87 @@
+---
+title: "Decrement counter"
+action: counter.decrement
+domain: counter
+description: "Decreases a counter by its step size."
+related_actions:
+  - counter.increment
+  - counter.reset
+  - counter.set_value
+---
+
+Use this action to decrease a counter by its configured step size, for example to count down a stock of supplies as they are used. The step size defaults to 1, but you can set a different step when you create the counter.
+
+If the counter has a minimum, it stops at that minimum and does not go lower.
+
+{% include actions/ui_header.md %}
+
+To decrement a counter from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the counter you want to decrease.
+6. From the actions shown for that target, select **Decrement counter**.
+7. Select **Save**.
+
+### Options in the UI
+
+This action has no additional options beyond the target.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `counter.decrement`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: counter.decrement
+  target:
+    entity_id: counter.dishwasher_tablets
+{% endexample %}
+
+This decreases `counter.dishwasher_tablets` by its step size.
+
+### Options in YAML
+
+This action has no additional YAML options beyond the target.
+
+{% include actions/targets.md %}
+
+## Good to know
+
+- The counter goes down by its step size, not always by 1. The step is whatever you set when you created the counter.
+- When the counter reaches its minimum, it stays there and does not decrease further.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: count down a stock of supplies
+
+Decrease a counter each time something is used, for example to keep track of how many dishwasher tablets you have left.
+
+- **Trigger**: Dishwasher finishes a cycle
+- **Action**: Decrement counter
+  - **Target**: Dishwasher tablets
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  - alias: "Count down dishwasher tablets"
+    triggers:
+      - trigger: state
+        entity_id: sensor.dishwasher
+        to: "finished"
+    actions:
+      - action: counter.decrement
+        target:
+          entity_id: counter.dishwasher_tablets
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/counter.increment.markdown
+++ b/source/_actions/counter.increment.markdown
@@ -1,0 +1,87 @@
+---
+title: "Increment counter"
+action: counter.increment
+domain: counter
+description: "Increases a counter by its step size."
+related_actions:
+  - counter.decrement
+  - counter.reset
+  - counter.set_value
+---
+
+Use this action to increase a counter by its configured step size, for example to count how often something happens, like a door opening or a routine running. The step size defaults to 1, but you can set a different step when you create the counter.
+
+If the counter has a maximum, it stops at that maximum and does not go higher.
+
+{% include actions/ui_header.md %}
+
+To increment a counter from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the counter you want to increase.
+6. From the actions shown for that target, select **Increment counter**.
+7. Select **Save**.
+
+### Options in the UI
+
+This action has no additional options beyond the target.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `counter.increment`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: counter.increment
+  target:
+    entity_id: counter.front_door_openings
+{% endexample %}
+
+This increases `counter.front_door_openings` by its step size.
+
+### Options in YAML
+
+This action has no additional YAML options beyond the target.
+
+{% include actions/targets.md %}
+
+## Good to know
+
+- The counter goes up by its step size, not always by 1. The step is whatever you set when you created the counter.
+- When the counter reaches its maximum, it stays there and does not increase further.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: count how often the front door opens
+
+Increase a counter each time a sensor reports an event, for example to count how many times the front door opens.
+
+- **Trigger**: Front door contact sensor opens
+- **Action**: Increment counter
+  - **Target**: Front door openings
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  - alias: "Count front door openings"
+    triggers:
+      - trigger: state
+        entity_id: binary_sensor.front_door
+        to: "on"
+    actions:
+      - action: counter.increment
+        target:
+          entity_id: counter.front_door_openings
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/counter.reset.markdown
+++ b/source/_actions/counter.reset.markdown
@@ -1,0 +1,85 @@
+---
+title: "Reset counter"
+action: counter.reset
+domain: counter
+description: "Resets a counter to its initial value."
+related_actions:
+  - counter.increment
+  - counter.decrement
+  - counter.set_value
+---
+
+Use this action to set a counter back to its initial value, for example to start a new counting cycle. The initial value is the one you set when you created the counter, and it defaults to 0.
+
+A common use is resetting a daily counter at midnight so it starts fresh each day.
+
+{% include actions/ui_header.md %}
+
+To reset a counter from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the counter you want to reset.
+6. From the actions shown for that target, select **Reset counter**.
+7. Select **Save**.
+
+### Options in the UI
+
+This action has no additional options beyond the target.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `counter.reset`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: counter.reset
+  target:
+    entity_id: counter.daily_reminders
+{% endexample %}
+
+This sets `counter.daily_reminders` back to its initial value.
+
+### Options in YAML
+
+This action has no additional YAML options beyond the target.
+
+{% include actions/targets.md %}
+
+## Good to know
+
+- The counter returns to its initial value, which is the value you set when you created it. It is not always 0.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: reset a daily counter at midnight
+
+Set a counter back to its initial value at a set time, for example to start counting from zero again each day.
+
+- **Trigger**: Time: 00:00
+- **Action**: Reset counter
+  - **Target**: Daily reminders
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  - alias: "Reset the daily reminder counter at midnight"
+    triggers:
+      - trigger: time
+        at: "00:00:00"
+    actions:
+      - action: counter.reset
+        target:
+          entity_id: counter.daily_reminders
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/counter.set_value.markdown
+++ b/source/_actions/counter.set_value.markdown
@@ -1,0 +1,98 @@
+---
+title: "Set counter value"
+action: counter.set_value
+domain: counter
+description: "Sets a counter to a specific value."
+related_actions:
+  - counter.increment
+  - counter.decrement
+  - counter.reset
+---
+
+Use this action to set a counter to a specific value, instead of stepping it up or down. This is handy when you know the exact number you want, for example to restock a supplies counter after you buy a new pack.
+
+{% include actions/ui_header.md %}
+
+To set a counter to a specific value from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the counter you want to set.
+6. From the actions shown for that target, select **Set counter value**.
+7. Set the **Value** you want to apply.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Value:
+  description: The value to set the counter to. Must be 0 or a positive whole number.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `counter.set_value`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: counter.set_value
+  target:
+    entity_id: counter.paper_towels
+  data:
+    value: 12
+{% endexample %}
+
+This sets `counter.paper_towels` to 12.
+
+### Options in YAML
+
+{% options_yaml %}
+value:
+  description: The value to set the counter to. Must be 0 or a positive whole number.
+  required: true
+  type: integer
+{% endoptions_yaml %}
+
+{% include actions/targets.md %}
+
+## Good to know
+
+- The value must be 0 or a positive whole number.
+- The value must be a multiple of the counter's step size, and within the configured minimum and maximum. If it isn't, the action fails.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: restock a supplies counter
+
+Set a counter to a known amount when you restock, for example to reset a paper towel count after buying a new pack.
+
+- **Trigger**: Restock button pressed
+- **Action**: Set counter value
+  - **Target**: Paper towels
+  - **Value**: 12
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  - alias: "Restock the paper towel counter"
+    triggers:
+      - trigger: state
+        entity_id: input_button.paper_towels_restocked
+    actions:
+      - action: counter.set_value
+        target:
+          entity_id: counter.paper_towels
+        data:
+          value: 12
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/counter.markdown
+++ b/source/_integrations/counter.markdown
@@ -88,52 +88,7 @@ If `restore` is set to `true`, the `initial` value is only used when no previous
 
 {% include integrations/conditions.md %}
 
-## Actions
-
-Available actions: `increment`, `decrement`, `reset`, and `set_value`.
-
-### Action: Increment
-
-The `counter.increment` action allows you to increment the counter with 1 or the given value for the steps.
-
-| Data attribute | Optional | Description                                                           |
-| ---------------------- | -------- | --------------------------------------------------------------------- |
-| `entity_id`            | no       | Name of the entity to take action, for example, `counter.my_custom_counter`. |
-
-### Action: Decrement
-
-The `counter.decrement` action allows you to decrement the counter with 1 or the given value for the steps.
-
-| Data attribute | Optional | Description                                                           |
-| ---------------------- | -------- | --------------------------------------------------------------------- |
-| `entity_id`            | no       | Name of the entity to take action, for example, `counter.my_custom_counter`. |
-
-### Action: Reset
-
-The `counter.reset` action allows you to reset the counter to its initial value.
-
-| Data attribute | Optional | Description                                                           |
-| ---------------------- | -------- | --------------------------------------------------------------------- |
-| `entity_id`            | no       | Name of the entity to take action, for example, `counter.my_custom_counter`. |
-
-### Action: Set value
-
-The `counter.set_value` action allows you to set the counter to a specific value.
-
-| Data attribute | Optional | Description                                                           |
-| ---------------------- | -------- | --------------------------------------------------------------------- |
-| `entity_id`            | no       | Name of the entity to take action, for example, `counter.my_custom_counter`. |
-| `value`                | yes      | Set the counter to the given value.                                   |
-
-### Use the action
-
-Go to {% my developer_services title="**Settings** > **Developer tools** > **Actions**" %}. Choose **counter** from the list of **Domains**, select the **Actions**, enter something like the sample below into the **data** field, and select **Perform action**.
-
-```json
-{
-  "entity_id": "counter.my_custom_counter"
-}
-```
+{% include integrations/actions.md %}
 
 ## Counter automation examples
 


### PR DESCRIPTION
## Proposed change

<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Migrates the Counter integration's action documentation into dedicated pages under `source/_actions/`, one file per action, and replaces the inline action block on the integration page with `{% include integrations/actions.md %}`. Each action was verified against the core codebase, with intent, options, and examples captured per action.

## Type of change

<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

