### PR TITLE
Google Calendar: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/google.create_event.markdown
+++ b/source/_actions/google.create_event.markdown
@@ -1,0 +1,154 @@
+---
+title: "Create event in Google Calendar"
+action: google.create_event
+domain: google
+description: "Adds a new event to a Google calendar."
+related_actions:
+  - calendar.create_event
+  - calendar.get_events
+---
+
+Use this action to add a new event to one of your Google calendars, for example to block out time or record that something happened.
+
+This action is only available when you have granted Home Assistant read-write access to your calendars in the integration options. With read-only access, you cannot create events.
+
+{% include actions/ui_header.md %}
+
+To create a Google Calendar event from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Google calendar you want to add the event to.
+6. From the actions shown for that target, select **Create event in Google Calendar**.
+7. Set the **Summary** and the start and end of the event.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Summary:
+  description: The title of the event.
+Description:
+  description: A longer description of the event than the summary provides.
+  required: false
+Start time:
+  description: The date and time the event should start.
+  required: false
+End time:
+  description: The date and time the event should end.
+  required: false
+Start date:
+  description: The date an all-day event should start.
+  required: false
+End date:
+  description: The date an all-day event should end.
+  required: false
+In:
+  description: Create the event a number of days or weeks from now.
+  required: false
+Location:
+  description: The location of the event.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `google.create_event`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: google.create_event
+  target:
+    entity_id: calendar.personal
+  data:
+    summary: "Bowling night"
+    start_date_time: "2024-03-10 20:00:00"
+    end_date_time: "2024-03-10 23:00:00"
+    location: "Bowling center"
+{% endexample %}
+
+This adds a Bowling night event to `calendar.personal`.
+
+### Options in YAML
+
+{% options_yaml %}
+summary:
+  description: The title of the event.
+  required: true
+  type: string
+description:
+  description: A longer description of the event than the summary provides.
+  required: false
+  type: string
+start_date_time:
+  description: The date and time the event should start, such as 2024-03-10 20:00:00.
+  required: false
+  type: string
+end_date_time:
+  description: The date and time the event should end, such as 2024-03-10 23:00:00.
+  required: false
+  type: string
+start_date:
+  description: The date an all-day event should start, such as 2024-03-10.
+  required: false
+  type: string
+end_date:
+  description: The date an all-day event should end, such as 2024-03-11.
+  required: false
+  type: string
+in:
+  description: "Create the event a number of days or weeks from now, such as days: 2 or weeks: 2."
+  required: false
+  type: map
+location:
+  description: The location of the event.
+  required: false
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="calendar" %}
+
+## Good to know
+
+- This action only works when you have given Home Assistant read-write access to your calendars in the integration options.
+- Set the timing of the event in one of three ways: a start and end time, a start and end date for an all-day event, or `in` to create it a number of days or weeks from now.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: log when the washing machine finishes
+
+When the washing machine finishes, record it on a calendar so you have a history of when laundry was done.
+
+- **Trigger**: Washing machine power drops to idle
+- **Action**: Create event in Google Calendar
+  - **Target**: Home log
+  - **Summary**: Laundry finished
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  alias: "Log when the washing machine finishes"
+  triggers:
+    - trigger: state
+      entity_id: sensor.washing_machine_status
+      to: idle
+  actions:
+    - action: google.create_event
+      target:
+        entity_id: calendar.home_log
+      data:
+        summary: "Laundry finished"
+        start_date_time: "2024-03-10 18:00:00"
+        end_date_time: "2024-03-10 18:01:00"
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/google.create_event.markdown
+++ b/source/_actions/google.create_event.markdown
@@ -2,13 +2,13 @@
 title: "Create event in Google Calendar"
 action: google.create_event
 domain: google
-description: "Adds a new event to a Google calendar."
+description: "Adds a new event to a calendar in Google Calendar."
 related_actions:
   - calendar.create_event
   - calendar.get_events
 ---
 
-Use this action to add a new event to one of your Google calendars, for example to block out time or record that something happened.
+Use this action to add a new event to one of your calendars in Google Calendar, for example to block out time or record that something happened.
 
 This action is only available when you have granted Home Assistant read-write access to your calendars in the integration options. With read-only access, you cannot create events.
 
@@ -20,7 +20,7 @@ To create a Google Calendar event from an automation or a script:
 2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
 3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
 4. In the **Then do** section, select **Add action**.
-5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Google calendar you want to add the event to.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the calendar you want to add the event to.
 6. From the actions shown for that target, select **Create event in Google Calendar**.
 7. Set the **Summary** and the start and end of the event.
 8. Select **Save**.

--- a/source/_integrations/google.markdown
+++ b/source/_integrations/google.markdown
@@ -80,46 +80,7 @@ Using the entity state and attributes is more error prone and less flexible than
 
 {% enddetails %}
 
-### Action: Create event
-
-The `google.create_event` action allows you to create a new calendar event in a calendar.
-
-{% details "Create event action details" %}
-
-{% note %}
-This will only be available if you have given Home Assistant `read-write` access in configuration options.
-{% endnote %}
-
-A calendar `target` is selected with a [Target Selector](/docs/blueprint/selectors/#target-selector) and the `data` payload supports the following fields:
-
-| Data attribute | Optional | Description                                         | Example             |
-| ---------------------- | -------- | --------------------------------------------------- | ------------------- |
-| `summary`              | no       | Acts as the title of the event.                     | Bowling             |
-| `description`          | yes      | The description of the event.                       | Birthday bowling    |
-| `start_date_time`      | yes      | The date and time the event should start.           | 2019-03-10 20:00:00 |
-| `end_date_time`        | yes      | The date and time the event should end.             | 2019-03-10 23:00:00 |
-| `start_date`           | yes      | The date the whole day event should start.          | 2019-03-10          |
-| `end_date`             | yes      | The date the whole day event should end.            | 2019-03-11          |
-| `in`                   | yes      | Days or weeks that you want to create the event in. | "days": 2           |
-| `location`             | yes      | The location of the event.                          | Bowling center      |
-
-{% important %}
-You either use `start_date_time` and `end_date_time`, or `start_date` and `end_date`, or `in`.
-{% endimportant %}
-
-This is a full example of an action in YAML:
-
-```yaml
-action: google.create_event
-target:
-  entity_id: calendar.device_automation_schedules
-data:
-  summary: "Example"
-  start_date: "2022-10-1"
-  end_date: "2022-10-2"
-```
-
-{% enddetails %}
+{% include integrations/actions.md %}
 
 ## More configuration
 


### PR DESCRIPTION
## Proposed change

<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Migrates the Google Calendar integration's create event action documentation into a dedicated page under `source/_actions/`, and replaces the inline action block on the integration page with `{% include integrations/actions.md %}`. The action was verified against the core codebase, with intent, options, and an example captured.

## Type of change

<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

