### PR TITLE
UniFi Network: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/unifi.reconnect_client.markdown
+++ b/source/_actions/unifi.reconnect_client.markdown
@@ -1,0 +1,91 @@
+---
+title: "Reconnect wireless client"
+action: unifi.reconnect_client
+domain: unifi
+description: "Tries to get a wireless client to reconnect to the UniFi network."
+related_actions:
+  - unifi.remove_clients
+---
+
+Use this action to ask a wireless client to reconnect to your UniFi network, for example to nudge a device that has dropped off Wi-Fi or is stuck on a weaker access point.
+
+This action only works for wireless clients. Wired clients are skipped.
+
+{% include actions/ui_header.md %}
+
+To reconnect a wireless client from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the list of actions, search for and select **Reconnect wireless client**.
+6. Select the UniFi wireless client device you want to reconnect.
+7. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Device:
+  description: The wireless client device that should reconnect to the network.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `unifi.reconnect_client`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: unifi.reconnect_client
+  data:
+    device_id: a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+device_id:
+  description: The device ID of the wireless client that should reconnect to the network.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+## Good to know
+
+- This action only works for wireless clients. Wired clients are left untouched.
+- The device must be a client known to your UniFi Network application.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: reconnect a flaky device when it drops off Wi-Fi
+
+If a wireless device keeps losing its connection, you can ask it to reconnect automatically when it becomes unavailable for a few minutes.
+
+- **Trigger**: Smart plug unavailable for 5 minutes
+- **Action**: Reconnect wireless client
+  - **Device**: Garden smart plug
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  alias: "Reconnect the garden smart plug when it drops off"
+  triggers:
+    - trigger: state
+      entity_id: switch.garden_smart_plug
+      to: "unavailable"
+      for:
+        minutes: 5
+  actions:
+    - action: unifi.reconnect_client
+      data:
+        device_id: a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/unifi.remove_clients.markdown
+++ b/source/_actions/unifi.remove_clients.markdown
@@ -1,0 +1,81 @@
+---
+title: "Remove clients from the UniFi Network"
+action: unifi.remove_clients
+domain: unifi
+description: "Cleans up short-lived clients from the UniFi Network application."
+related_actions:
+  - unifi.reconnect_client
+---
+
+Use this action to clean up clients that briefly connected to your UniFi Network application, for example to keep your client list tidy after visitors or passing devices show up. It removes clients that only appeared for a short time and that you have not given a name or fixed address.
+
+A client is removed only when both of the following are true:
+
+- The time between when it was first seen and last seen is less than 15 minutes.
+- It has no fixed IP address, hostname, or name configured.
+
+{% include actions/ui_header.md %}
+
+To remove short-lived clients from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the list of actions, search for and select **Remove clients from the UniFi Network**.
+6. Select **Save**.
+
+### Options in the UI
+
+This action has no options.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `unifi.remove_clients`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: unifi.remove_clients
+{% endexample %}
+
+### Options in YAML
+
+This action has no options.
+
+## Good to know
+
+- Clients you have named or given a fixed IP address or hostname are never removed.
+- The action runs across every loaded UniFi Network application you have set up in Home Assistant.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: tidy up short-lived clients every week
+
+Run the cleanup on a schedule so your client list stays manageable over time.
+
+- **Trigger**: Time: Sunday at 03:00
+- **Action**: Remove clients from the UniFi Network
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  alias: "Weekly UniFi client cleanup"
+  triggers:
+    - trigger: time
+      at: "03:00:00"
+  conditions:
+    - condition: time
+      weekday:
+        - sun
+  actions:
+    - action: unifi.remove_clients
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/unifi.markdown
+++ b/source/_integrations/unifi.markdown
@@ -162,19 +162,7 @@ If Home Assistant and the UniFi Network application are running on separate mach
 
 [Related Issue](https://github.com/home-assistant/home-assistant/issues/10507)
 
-## Actions
-
-### Action: Reconnect client
-
-The `unifi.reconnect_client` action tries to get a wireless client to reconnect to the network.
-
-| Data attribute | Optional | Description                                                                 |
-| ---------------------- | -------- | --------------------------------------------------------------------------- |
-| `device_id`            | No       | String representing a device ID related to a UniFi Network {% term integration %} .     |
-
-### Action: Remove clients
-
-The `unifi.remove_clients` action cleans up clients on the UniFi Network application that have only been associated with the Network application for a short period of time. The difference between first seen and last seen needs to be less than 15 minutes and the client cannot have a fixed IP, hostname or name associated with it.
+{% include integrations/actions.md %}
 
 ## Switch
 


### PR DESCRIPTION
## Proposed change

<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Migrates the UniFi Network integration's action documentation into dedicated pages under `source/_actions/`, one file per action, and replaces the inline action block on the integration page with `{% include integrations/actions.md %}`. Each action was verified against the core codebase, with intent, options, and examples captured.

## Type of change

<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

