### PR TITLE
Home Connect: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/home_connect.change_setting.markdown
+++ b/source/_actions/home_connect.change_setting.markdown
@@ -61,9 +61,9 @@ key:
   required: true
   type: string
 value:
-  description: The value to set for the setting. The accepted value depends on the setting.
+  description: The value to set for the setting. The accepted value depends on the setting and can be text, a number, or a toggle (`true` or `false`).
   required: true
-  type: [string, integer, boolean]
+  type: string
 {% endoptions_yaml %}
 
 ## Good to know

--- a/source/_actions/home_connect.change_setting.markdown
+++ b/source/_actions/home_connect.change_setting.markdown
@@ -1,0 +1,108 @@
+---
+title: "Change setting"
+action: home_connect.change_setting
+domain: home_connect
+description: "Changes a setting on a Home Connect appliance."
+related_actions:
+  - home_connect.set_program_and_options
+  - home_connect.start_selected_program
+---
+
+Use this action to change a setting on a Home Connect appliance, for example to turn on the child lock or switch the appliance into a different mode. You pick the appliance, the setting you want to change, and the value to set.
+
+Settings are identified by their Home Connect key, such as `BSH.Common.Setting.ChildLock`. The value can be text, a number, or a toggle, depending on what the setting expects.
+
+{% include actions/ui_header.md %}
+
+To change a setting from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the list of actions, search for and select **Change setting**.
+6. Select the appliance you want to change.
+7. Enter the key of the setting and the value to set.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Device:
+  description: The Home Connect appliance you want to change.
+Key:
+  description: "The key of the setting to change, such as `BSH.Common.Setting.ChildLock`."
+Value:
+  description: The value to set for the setting. The accepted value depends on the setting.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `home_connect.change_setting`. A basic example that turns on the child lock looks like this:
+
+{% example %}
+action: |
+  action: home_connect.change_setting
+  data:
+    device_id: a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6
+    key: "BSH.Common.Setting.ChildLock"
+    value: true
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+device_id:
+  description: The device ID of the Home Connect appliance you want to change.
+  required: true
+  type: string
+key:
+  description: "The key of the setting to change, such as `BSH.Common.Setting.ChildLock`."
+  required: true
+  type: string
+value:
+  description: The value to set for the setting. The accepted value depends on the setting.
+  required: true
+  type: [string, integer, boolean]
+{% endoptions_yaml %}
+
+## Good to know
+
+- Which settings you can change depends on your appliance. The Home Connect API does not always match the Home Connect app, so some settings available in the app may not work through Home Assistant.
+- The value must match the type the setting expects. A toggle uses `true` or `false`, while other settings expect text or a number.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: lock the appliance controls when you leave home
+
+Turn on the child lock on your oven when everyone leaves, so the controls can't be changed while you're away.
+
+- **Trigger**: Everyone leaves home
+- **Action**: Change setting
+  - **Key**: `BSH.Common.Setting.ChildLock`
+  - **Value**: `true`
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  alias: "Lock the oven controls when away"
+  triggers:
+    - trigger: state
+      entity_id: zone.home
+      to: "0"
+  actions:
+    - action: home_connect.change_setting
+      data:
+        device_id: a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6
+        key: "BSH.Common.Setting.ChildLock"
+        value: true
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/home_connect.change_setting.markdown
+++ b/source/_actions/home_connect.change_setting.markdown
@@ -10,7 +10,7 @@ related_actions:
 
 Use this action to change a setting on a Home Connect appliance, for example to turn on the child lock or switch the appliance into a different mode. You pick the appliance, the setting you want to change, and the value to set.
 
-Settings are identified by their Home Connect key, such as `BSH.Common.Setting.ChildLock`. The value can be text, a number, or a toggle, depending on what the setting expects.
+Settings are identified by their Home Connect key, such as `BSH.Common.Setting.ChildLock`. The value can be text, an integer, or a toggle, depending on what the setting expects.
 
 {% include actions/ui_header.md %}
 
@@ -69,7 +69,7 @@ value:
 ## Good to know
 
 - Which settings you can change depends on your appliance. The Home Connect API does not always match the Home Connect app, so some settings available in the app may not work through Home Assistant.
-- The value must match the type the setting expects. A toggle uses `true` or `false`, while other settings expect text or a number.
+- The value must match the type the setting expects. A toggle uses `true` or `false`, while other settings expect text or an integer.
 
 {% include actions/try_it.md %}
 

--- a/source/_actions/home_connect.set_program_and_options.markdown
+++ b/source/_actions/home_connect.set_program_and_options.markdown
@@ -8,7 +8,7 @@ related_actions:
   - home_connect.change_setting
 ---
 
-Use this action to start or select a program on a Home Connect appliance, for example to start an eco dishwasher cycle or pick a coffee program ready to brew. If you leave the program out, the action instead sets options on the program that is already active or selected, so you can tweak a running cycle.
+Use this action to start or select a program on a Home Connect appliance, for example to start an eco dishwasher cycle or pick a coffee program ready to brew. If you omit the program, the action instead sets options on the program that is already active or selected, so you can tweak a running cycle.
 
 You always pick the appliance and whether the action affects the active or the selected program. After that, you either choose a program, set one or more options, or both. The available options depend on the type of appliance, so a washer and a coffee maker show different choices.
 
@@ -42,7 +42,8 @@ Program:
   required: false
 {% endoptions_ui %}
 
-In addition, the UI shows option groups for each appliance type. Only the options that apply to your appliance are used. See [Program options](#program-options) for the full list.
+In addition, the UI shows option groups for each appliance type. Only the options that apply to your appliance are used.
+For the full list, see [Program options](#program-options).
 
 {% include actions/yaml_header.md %}
 
@@ -74,7 +75,8 @@ program:
   type: string
 {% endoptions_yaml %}
 
-In addition, you can pass program options as extra keys in the `data` section. Only the options that apply to your appliance are used. See [Program options](#program-options) for the full list.
+In addition, you can pass program options as extra keys in the `data` section. Only the options that apply to your appliance are used.
+For the full list, see [Program options](#program-options).
 
 ### Program options
 

--- a/source/_actions/home_connect.set_program_and_options.markdown
+++ b/source/_actions/home_connect.set_program_and_options.markdown
@@ -1,0 +1,202 @@
+---
+title: "Set program and options"
+action: home_connect.set_program_and_options
+domain: home_connect
+description: "Starts or selects a program on a Home Connect appliance, or sets the options for the active or selected program."
+related_actions:
+  - home_connect.start_selected_program
+  - home_connect.change_setting
+---
+
+Use this action to start or select a program on a Home Connect appliance, for example to start an eco dishwasher cycle or pick a coffee program ready to brew. If you leave the program out, the action instead sets options on the program that is already active or selected, so you can tweak a running cycle.
+
+You always pick the appliance and whether the action affects the active or the selected program. After that, you either choose a program, set one or more options, or both. The available options depend on the type of appliance, so a washer and a coffee maker show different choices.
+
+{% important %}
+You need to provide either a program or at least one option. If you provide neither, the action does nothing and reports an error.
+{% endimportant %}
+
+{% include actions/ui_header.md %}
+
+To set a program and options from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the list of actions, search for and select **Set program and options**.
+6. Select the appliance you want to control.
+7. Under **Affects to**, choose whether the action affects the active or the selected program.
+8. Optionally, choose a program and set any options for your appliance.
+9. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Device:
+  description: The Home Connect appliance you want to control.
+Affects to:
+  description: Whether the action affects the active program (the one currently running) or the selected program (the one queued to run). Choose **Active program** or **Selected program**.
+Program:
+  description: The program to start or select. When set, the appliance starts or selects this program depending on the **Affects to** value. When left empty, the action only sets options on the active or selected program.
+  required: false
+{% endoptions_ui %}
+
+In addition, the UI shows option groups for each appliance type. Only the options that apply to your appliance are used. See [Program options](#program-options) for the full list.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `home_connect.set_program_and_options`. A basic example that starts an eco dishwasher program looks like this:
+
+{% example %}
+action: |
+  action: home_connect.set_program_and_options
+  data:
+    device_id: a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6
+    affects_to: active_program
+    program: dishcare_dishwasher_program_eco_50
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+device_id:
+  description: The device ID of the Home Connect appliance you want to control.
+  required: true
+  type: string
+affects_to:
+  description: Whether the action affects the active program or the selected program. Use `active_program` or `selected_program`.
+  required: true
+  type: string
+program:
+  description: The program to start or select. When set, the appliance starts or selects this program depending on the `affects_to` value. When left out, the action only sets options on the active or selected program.
+  required: false
+  type: string
+{% endoptions_yaml %}
+
+In addition, you can pass program options as extra keys in the `data` section. Only the options that apply to your appliance are used. See [Program options](#program-options) for the full list.
+
+### Program options
+
+The options you can set depend on the type of appliance. In the UI, they appear in collapsible groups. In YAML, you add them as extra keys in the `data` section.
+
+Air conditioner options:
+
+- `heating_ventilation_air_conditioning_air_conditioner_option_fan_speed_percentage`: the fan speed as a percentage (1 to 100).
+- `heating_ventilation_air_conditioning_air_conditioner_option_fan_speed_mode`: the fan speed mode, manual or automatic.
+
+Cleaning robot options:
+
+- `consumer_products_cleaning_robot_option_reference_map_id`: which reference map to use.
+- `consumer_products_cleaning_robot_option_cleaning_mode`: the preferred cleaning mode.
+- `consumer_products_cleaning_robot_option_suction_power`: the suction power.
+
+Coffee maker options:
+
+- `consumer_products_coffee_maker_option_bean_amount`: the amount of coffee beans used.
+- `consumer_products_coffee_maker_option_fill_quantity`: the amount of water used, in milliliters.
+- `consumer_products_coffee_maker_option_coffee_temperature`: the coffee temperature.
+- `consumer_products_coffee_maker_option_bean_container_selection`: the preferred bean container.
+- `consumer_products_coffee_maker_option_flow_rate`: the water-coffee contact time, which affects coffee intensity.
+- `consumer_products_coffee_maker_option_multiple_beverages`: whether double dispensing is enabled.
+- `consumer_products_coffee_maker_option_coffee_milk_ratio`: the amount of milk.
+- `consumer_products_coffee_maker_option_hot_water_temperature`: the hot water temperature, suitable for the type of tea.
+
+Dishwasher options:
+
+- `b_s_h_common_option_start_in_relative`: when the program should start, in seconds from now.
+- `dishcare_dishwasher_option_intensiv_zone`: higher spray pressure on the lower basket for very dirty pots and pans.
+- `dishcare_dishwasher_option_brilliance_dry`: a special drying cycle for more shine on glasses and plastic items.
+- `dishcare_dishwasher_option_vario_speed_plus`: reduces the program run time by up to 66% with the usual cleaning and drying.
+- `dishcare_dishwasher_option_silence_on_demand`: extra silent mode for a selected period of time.
+- `dishcare_dishwasher_option_half_load`: economical cleaning for smaller loads, saving energy, water, and time.
+- `dishcare_dishwasher_option_extra_dry`: improved drying for glasses and plasticware.
+- `dishcare_dishwasher_option_hygiene_plus`: cleaning at increased temperature for maximum hygienic cleanliness.
+- `dishcare_dishwasher_option_eco_dry`: opens the door automatically for energy efficient drying.
+- `dishcare_dishwasher_option_zeolite_dry`: a special drying cycle for improved drying of glasses, plates, and plasticware.
+
+Dryer options:
+
+- `laundry_care_dryer_option_drying_target`: the drying target, such as iron dry, cupboard dry, or extra dry.
+
+Hood options:
+
+- `cooking_common_option_hood_venting_level`: the required fan setting.
+- `cooking_common_option_hood_intensive_level`: the intensive setting.
+
+Oven options:
+
+- `cooking_oven_option_setpoint_temperature`: the target cavity temperature the oven holds.
+- `b_s_h_common_option_duration`: the run time of the program, after which the appliance stops.
+- `cooking_oven_option_fast_pre_heat`: heats the cooking compartment quickly. The setpoint temperature must be at least 100 °C (212 °F), or this option is not activated.
+
+Warming drawer options:
+
+- `cooking_oven_option_warming_level`: the level of the warming drawer.
+
+Washer options:
+
+- `laundry_care_washer_option_temperature`: the temperature of the washing program.
+- `laundry_care_washer_option_spin_speed`: the spin speed of the program.
+- `laundry_care_washer_option_stains`: the type of stains to treat.
+- `b_s_h_common_option_finish_in_relative`: when the program should end, in seconds from now.
+- `laundry_care_common_option_silent_mode`: activates silent mode.
+- `laundry_care_washer_option_i_dos_1_active`: activates the i-Dos 1 detergent feed.
+- `laundry_care_washer_option_i_dos_2_active`: activates the i-Dos 2 detergent feed.
+- `laundry_care_washer_option_intensive_plus`: intensive washing for heavily soiled laundry.
+- `laundry_care_washer_option_less_ironing`: treats laundry gently to reduce creasing.
+- `laundry_care_washer_option_mini_load`: activates the mini load option.
+- `laundry_care_washer_option_prewash`: adds a prewash cycle to the program.
+- `laundry_care_washer_option_rinse_hold`: activates the rinse hold option.
+- `laundry_care_washer_option_soak`: activates soaking.
+- `laundry_care_washer_option_water_plus`: activates the water plus option.
+- `laundry_care_common_option_vario_perfect`: saves energy (Eco Perfect) or time (Speed Perfect).
+
+## Good to know
+
+- The available programs and options depend on your appliance, and not every appliance supports every option listed here. The Home Connect API does not always match the Home Connect app, so some choices available in the app may not work through Home Assistant.
+- The `affects_to` value decides whether you change the program that is running now or the one queued to run next.
+- The relative timing options, such as start in relative and finish in relative, are set in seconds. For example, a value of 9000 means in 2 hours and 30 minutes.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: start the dishwasher overnight when electricity is cheap
+
+Because electricity is often cheaper at night, this automation starts a quiet eco program when the price drops, but only between 22:00 and 06:00.
+
+- **Trigger**: Electricity price drops to your night rate
+- **Condition**: The dishwasher door is closed
+- **Action**: Set program and options
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  alias: "Start the dishwasher when electricity is cheap"
+  triggers:
+    - trigger: numeric_state
+      entity_id: sensor.electricity_price
+      below: 0.10
+  conditions:
+    - condition: state
+      entity_id: binary_sensor.dishwasher_door
+      state: "off"
+    - condition: time
+      after: "22:00:00"
+      before: "06:00:00"
+  actions:
+    - action: home_connect.set_program_and_options
+      data:
+        device_id: a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6
+        affects_to: active_program
+        program: dishcare_dishwasher_program_eco_50
+        dishcare_dishwasher_option_silence_on_demand: true
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/home_connect.start_selected_program.markdown
+++ b/source/_actions/home_connect.start_selected_program.markdown
@@ -1,0 +1,106 @@
+---
+title: "Start selected program"
+action: home_connect.start_selected_program
+domain: home_connect
+description: "Starts the program that is already selected on a Home Connect appliance."
+related_actions:
+  - home_connect.set_program_and_options
+  - home_connect.change_setting
+---
+
+Use this action to start the program that is already selected on a Home Connect appliance, for example to begin a cycle you set up earlier on the appliance itself. You can pass start-only options to apply them as the program begins. You can also use this action to update those start-only options on a program that is already active but waiting on a delayed start.
+
+If a program is currently running, the action starts that one again with your options. If nothing is running, it starts the program that is selected on the appliance.
+
+{% include actions/ui_header.md %}
+
+To start the selected program from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the list of actions, search for and select **Start selected program**.
+6. Select the appliance you want to start.
+7. Optionally, set when the program should start or finish.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Device:
+  description: The Home Connect appliance whose selected program you want to start.
+Start in relative:
+  description: When the program should start, in seconds from now. For example, 9000 means in 2 hours and 30 minutes.
+  required: false
+Finish in relative:
+  description: When the program should end, in seconds from now. For example, 9000 means in 2 hours and 30 minutes.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `home_connect.start_selected_program`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: home_connect.start_selected_program
+  data:
+    device_id: a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+device_id:
+  description: The device ID of the Home Connect appliance whose selected program you want to start.
+  required: true
+  type: string
+b_s_h_common_option_start_in_relative:
+  description: When the program should start, in seconds from now. For example, 9000 means in 2 hours and 30 minutes.
+  required: false
+  type: integer
+b_s_h_common_option_finish_in_relative:
+  description: When the program should end, in seconds from now. For example, 9000 means in 2 hours and 30 minutes.
+  required: false
+  type: integer
+{% endoptions_yaml %}
+
+## Good to know
+
+- This action only starts a program that is already selected. To choose a program first, use the [Set program and options](/actions/home_connect.set_program_and_options/) action.
+- The start and finish timing options are start-only. They are applied when the program begins, or when you update a program that is waiting on a delayed start.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: start the selected program with a delayed finish
+
+Start whatever program is selected on your washer, set to finish in two hours so the laundry is ready when you get home.
+
+- **Trigger**: You leave home
+- **Action**: Start selected program
+  - **Finish in relative**: 7200 seconds
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  alias: "Start the washer to finish in two hours"
+  triggers:
+    - trigger: state
+      entity_id: person.you
+      to: "not_home"
+  actions:
+    - action: home_connect.start_selected_program
+      data:
+        device_id: a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6
+        b_s_h_common_option_finish_in_relative: 7200
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/home_connect.markdown
+++ b/source/_integrations/home_connect.markdown
@@ -1078,76 +1078,7 @@ Some devices only have the state `on` and turn off is not supported by the appli
 
 {% enddetails %}
 
-## Actions
-
-The Home Connect integration makes various actions available.
-Available actions: `set_program_and_options`, and `change_setting`
-
-### Action: Set program and options
-
-The `home_connect.set_program_and_options` action starts or selects a program. If the `program` attribute is not set, this action sets the options for the active or the selected program.
-
-| Data attribute    | Optional | Description                                      |
-|---------------------------|----------|--------------------------------------------------|
-| `device_id` | no | ID of the device. |
-| `affects_to` | no | Selects if the program affected by the action should be the active or the selected program. |
-| `program` | yes | Program to select. If set, it will start or select a program depending on `affects_to`. |
-| `heating_ventilation_air_conditioning_air_conditioner_option_fan_speed_percentage` | yes | Setting to adjust the venting levels of the air conditioner as percentage. |
-| `heating_ventilation_air_conditioning_air_conditioner_option_fan_speed_mode` | yes | Setting to adjust the fan speed mode to Manual or Automatic. |
-| `consumer_products_cleaning_robot_option_reference_map_id` | yes | Defines which reference map is to be used. |
-| `consumer_products_cleaning_robot_option_cleaning_mode` | yes | Defines the favoured cleaning mode. |
-| `consumer_products_cleaning_robot_option_suction_power` | yes | Defines the suction power. |
-| `consumer_products_coffee_maker_option_bean_amount` | yes | Describes the amount of coffee beans used in a coffee machine program. |
-| `consumer_products_coffee_maker_option_fill_quantity` | yes | Describes the amount of water (in ml) used in a coffee machine program. |
-| `consumer_products_coffee_maker_option_coffee_temperature` | yes | Describes the coffee temperature used in a coffee machine program. |
-| `consumer_products_coffee_maker_option_bean_container_selection` | yes | Defines the preferred bean container. |
-| `consumer_products_coffee_maker_option_flow_rate` | yes | Defines the water-coffee contact time. The duration extends to coffee intensity. |
-| `consumer_products_coffee_maker_option_multiple_beverages` | yes | Defines if double dispensing is enabled. |
-| `consumer_products_coffee_maker_option_coffee_milk_ratio` | yes | Defines the amount of milk. |
-| `consumer_products_coffee_maker_option_hot_water_temperature` | yes | Defines the temperature suitable for the type of tea. |
-| `b_s_h_common_option_start_in_relative` | yes | Defines when the program should start, in seconds from now. For example: a value of 9000 means in 2 h 30 min. |
-| `dishcare_dishwasher_option_intensiv_zone` | yes | Defines if the cleaning is done with higher spray pressure on the lower basket for very dirty pots and pans. |
-| `dishcare_dishwasher_option_brilliance_dry` | yes | Defines if the program sequence is optimized with a special drying cycle to ensure more shine on glasses and plastic items. |
-| `dishcare_dishwasher_option_vario_speed_plus` | yes | Defines if the program duration is shortened dynamically (up to 66% less run time) with the usual optimum cleaning and drying. |
-| `dishcare_dishwasher_option_silence_on_demand` | yes | Defines if the extra silent mode is activated for a selected period of time. |
-| `dishcare_dishwasher_option_half_load` | yes | Defines if economical cleaning is enabled for smaller loads. This reduces energy and water consumption and also saves time. The utensils can be placed in the upper and lower baskets. |
-| `dishcare_dishwasher_option_extra_dry` | yes | Defines if improved drying for glasses and plasticware is enabled. |
-| `dishcare_dishwasher_option_hygiene_plus` | yes | Defines if the cleaning is done with increased temperatures. This ensures maximum hygienic cleanliness for regular use. |
-| `dishcare_dishwasher_option_eco_dry` | yes | Defines if the door is opened automatically for extra energy efficient and effective drying. |
-| `dishcare_dishwasher_option_zeolite_dry` | yes | Defines if the program sequence is optimized with special drying cycle ensures improved drying for glasses, plates and plasticware. |
-| `laundry_care_dryer_option_drying_target` | yes | Describes the drying target for a dryer program. For example: Iron Dry, Cupboard Dry, Extra Dry. |
-| `cooking_common_option_hood_venting_level` | yes | Defines the required fan setting. |
-| `cooking_common_option_hood_intensive_level` | yes | Defines the intensive setting. |
-| `cooking_oven_option_setpoint_temperature` | yes | Defines the target cavity temperature, which will be held by the oven. |
-| `b_s_h_common_option_duration` | yes | Defines the run-time of the program. Afterwards, the appliance is stopped. |
-| `cooking_oven_option_fast_pre_heat` | yes | Defines if the cooking compartment is heated up quickly. Please note that the setpoint temperature has to be equal to or higher than 100 °C or 212 °F. Otherwise, the fast pre-heat option is not activated. |
-| `cooking_oven_option_warming_level` | yes | Defines the level of the warming drawer. |
-| `laundry_care_washer_option_temperature` | yes | Defines the temperature of the washing program. |
-| `laundry_care_washer_option_spin_speed` | yes | Defines the spin speed of a washer program. |
-| `b_s_h_common_option_finish_in_relative` | yes | Defines when the program should end, in seconds from now. For example: a value of 9000 means in 2 h 30 min. |
-| `laundry_care_washer_option_i_dos_1_active` | yes | Defines if the detergent feed is activated / deactivated. (i-Dos content 1) |
-| `laundry_care_washer_option_i_dos_2_active` | yes | Defines if the detergent feed is activated / deactivated. (i-Dos content 2) |
-| `laundry_care_common_option_vario_perfect` | yes | Defines if a cycle saves energy (Eco Perfect) or time (Speed Perfect). |
-
-### Action: Start selected program
-
-The `home_connect.start_selected_program` action starts the program that is already selected using the specified options. You can specify start-only options to set them when starting the program. You can also use it to update the start-only options for a program that is already active but delayed (so that the operation state is "delayed start").
-
-| Data attribute    | Optional | Description                                      |
-|---------------------------|----------|--------------------------------------------------|
-| `device_id` | no | ID of the device. |
-| `b_s_h_common_option_finish_in_relative` | yes | Defines when the program should end, in seconds from now. For example: a value of 9000 means in 2 h 30 min. |
-| `b_s_h_common_option_start_in_relative` | yes | Defines when the program should start, in seconds from now. For example: a value of 9000 means in 2 h 30 min. |
-
-### Action: Change setting
-
-The `home_connect.change_setting` action changes a setting.
-
-| Data attribute    | Optional | Description                                      |
-|---------------------------|----------|--------------------------------------------------|
-| `device_id` | no | Id of a device associated with the home appliance. |
-| `key` | no | Key of the setting. |
-| `value` | no | Value of the setting. |
+{% include integrations/actions.md %}
 
 ## Automation examples
 


### PR DESCRIPTION
## Proposed change

Moves the Home Connect actions (`set_program_and_options`, `start_selected_program`, and `change_setting`) out of the integration page and into dedicated pages under `source/_actions/`, replacing the inline block with `{% include integrations/actions.md %}`. This is part of the ongoing migration of inline integration actions to dedicated action pages, giving each action its own UI walkthrough, YAML reference, and examples.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

