### PR TITLE
Command Line: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/command_line.reload.markdown
+++ b/source/_actions/command_line.reload.markdown
@@ -1,0 +1,81 @@
+---
+title: Reload Command Line
+action: command_line.reload
+domain: command_line
+description: "Reloads the Command Line configuration from your YAML configuration."
+---
+
+The **Reload Command Line** action reloads all Command Line entities from your YAML configuration. Use it after you change your Command Line setup in `configuration.yaml` and want Home Assistant to apply those changes without a restart.
+
+Only users with administrator rights can run this action.
+
+{% include actions/ui_header.md %}
+
+To use this action in an automation or script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create** to start a new one.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Reload Command Line**.
+6. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+This action has no additional options in the UI.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `command_line.reload`:
+
+{% example %}
+action: |
+  action: command_line.reload
+{% endexample %}
+
+This reloads all Command Line entities defined in your YAML configuration.
+
+### Options in YAML
+
+This action has no additional options in YAML.
+
+## Good to know
+
+- This action reloads every Command Line sensor, binary sensor, cover, switch, and notify entity defined in your YAML configuration.
+- Because all Command Line entities are configured in YAML, there are no UI-managed entities to worry about.
+- If you have not changed your YAML, running this action does not make any visible changes.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: reload after editing your YAML
+
+If you edit your Command Line configuration and toggle a helper to apply the change, you can reload without restarting Home Assistant.
+
+- **Trigger**: A user-created helper turns on
+- **Action**: Reload Command Line
+
+{% details "YAML example for reloading Command Line from a helper" %}
+
+{% example %}
+automation: |
+  alias: "Reload Command Line from a helper"
+  triggers:
+    - trigger: state
+      entity_id: input_boolean.reload_command_line
+      to: "on"
+  actions:
+    - action: command_line.reload
+    - action: input_boolean.turn_off
+      target:
+        entity_id: input_boolean.reload_command_line
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/command_line.markdown
+++ b/source/_integrations/command_line.markdown
@@ -739,12 +739,4 @@ command_line:
 - Replace admin and password with an "Admin" privileged Foscam user
 - Replace ipaddress with the local IP address of your Foscam
 
-## Actions
-
-Available actions: `reload`.
-
-### Action: Reload
-
-The `command_line.reload` action allows you to reload all `command_line` entities.
-
-This action takes no data attributes.
+{% include integrations/actions.md %}


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Migrates the Command Line `reload` action from an inline block on the integration page into a dedicated action page under `source/_actions/`, so it is auto-listed through the actions include. Also notes that the action is admin-only, which the previous inline documentation did not mention.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

