### PR TITLE
Netatmo: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/netatmo.clear_temperature_setting.markdown
+++ b/source/_actions/netatmo.clear_temperature_setting.markdown
@@ -49,4 +49,6 @@ This clears any manual temperature setting on `climate.living_room`.
 
 {% include actions/try_it.md %}
 
+{% include actions/stuck.md %}
+
 {% include actions/related.md %}

--- a/source/_actions/netatmo.clear_temperature_setting.markdown
+++ b/source/_actions/netatmo.clear_temperature_setting.markdown
@@ -1,0 +1,52 @@
+---
+title: "Clear temperature setting"
+action: netatmo.clear_temperature_setting
+domain: netatmo
+description: "Clears a manual temperature setting on a Netatmo climate device."
+related_actions:
+  - netatmo.set_temperature_with_end_datetime
+  - netatmo.set_temperature_with_time_period
+  - netatmo.set_preset_mode_with_end_datetime
+  - netatmo.set_schedule
+---
+
+Use this action to clear any manual temperature setting on a Netatmo climate device. The device reverts to its current preset or schedule.
+
+{% include actions/ui_header.md %}
+
+To clear a temperature setting from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Netatmo climate device you want to control.
+6. From the actions shown for that target, select **Clear temperature setting**.
+7. Select **Save**.
+
+### Options in the UI
+
+This action has no additional options in the UI.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `netatmo.clear_temperature_setting`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: netatmo.clear_temperature_setting
+  target:
+    entity_id: climate.living_room
+{% endexample %}
+
+This clears any manual temperature setting on `climate.living_room`.
+
+{% include actions/targets.md %}
+
+## Good to know
+
+- After clearing the setting, the device follows its current preset or schedule again. This is handy to undo a manual temperature set earlier in an automation.
+
+{% include actions/try_it.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/netatmo.register_webhook.markdown
+++ b/source/_actions/netatmo.register_webhook.markdown
@@ -1,0 +1,49 @@
+---
+title: "Register webhook"
+action: netatmo.register_webhook
+domain: netatmo
+description: "Manually registers the Netatmo webhook with the Netatmo backend."
+related_actions:
+  - netatmo.unregister_webhook
+---
+
+Use this action to manually register the Netatmo webhook with the Netatmo backend. The webhook lets Netatmo push instant events to Home Assistant. Home Assistant normally registers it for you, so you only need this action to recover from a connection issue.
+
+{% include actions/ui_header.md %}
+
+To register the webhook from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Netatmo: Register webhook**.
+6. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+This action has no additional options in the UI.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `netatmo.register_webhook`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: netatmo.register_webhook
+{% endexample %}
+
+This registers the webhook with the Netatmo backend.
+
+## Good to know
+
+- Home Assistant registers the webhook automatically. Use this action only to recover after a connection problem, such as when events stop arriving.
+- The webhook needs your Home Assistant instance to be reachable from the internet. For more details, see the [Netatmo integration documentation](/integrations/netatmo/).
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/netatmo.set_camera_light.markdown
+++ b/source/_actions/netatmo.set_camera_light.markdown
@@ -1,0 +1,103 @@
+---
+title: "Set camera light mode"
+action: netatmo.set_camera_light
+domain: netatmo
+description: "Sets the light mode of a Netatmo Outdoor camera."
+related_actions:
+  - netatmo.set_persons_home
+  - netatmo.set_person_away
+---
+
+Use this action to set the light mode of a Netatmo Outdoor camera. You can turn the floodlight on or off, or set it to automatic so it switches on when motion is detected.
+
+{% include actions/ui_header.md %}
+
+To set the camera light mode from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Netatmo Outdoor camera you want to control.
+6. From the actions shown for that target, select **Set camera light mode**.
+7. Set the **Camera light mode** you want.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Camera light mode:
+  description: The light mode to set. Choose on, off, or auto.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `netatmo.set_camera_light`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: netatmo.set_camera_light
+  target:
+    entity_id: camera.front_door
+  data:
+    camera_light_mode: "on"
+{% endexample %}
+
+This turns on the floodlight of `camera.front_door`.
+
+### Options in YAML
+
+{% options_yaml %}
+camera_light_mode:
+  description: The light mode to set. Choose `on`, `off`, or `auto`.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/targets.md %}
+
+## Good to know
+
+- This action is only available for the Netatmo Outdoor camera, which has a built-in floodlight.
+- In `auto` mode, the light switches on by itself when the camera detects motion.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: turn on the floodlight when motion is detected at night
+
+Light up the front of the house when the camera spots motion after dark.
+
+- **Trigger**: Motion detected by the front door camera
+- **Condition**: Sun is below the horizon
+- **Action**: Set camera light mode
+  - **Target**: Front door camera
+  - **Camera light mode**: on
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  - alias: "Turn on the floodlight on night-time motion"
+    triggers:
+      - trigger: state
+        entity_id: binary_sensor.front_door_motion
+        to: "on"
+    conditions:
+      - condition: state
+        entity_id: sun.sun
+        state: below_horizon
+    actions:
+      - action: netatmo.set_camera_light
+        target:
+          entity_id: camera.front_door
+        data:
+          camera_light_mode: "on"
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/netatmo.set_person_away.markdown
+++ b/source/_actions/netatmo.set_person_away.markdown
@@ -1,0 +1,66 @@
+---
+title: "Set person away"
+action: netatmo.set_person_away
+domain: netatmo
+description: "Marks a person as away for a Netatmo Indoor camera."
+related_actions:
+  - netatmo.set_persons_home
+  - netatmo.set_camera_light
+---
+
+Use this action to mark a person as away for a Netatmo Indoor (Welcome) camera. If you don't provide a name, the whole home is marked as empty.
+
+{% include actions/ui_header.md %}
+
+To mark a person as away from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Netatmo Indoor camera you want to control.
+6. From the actions shown for that target, select **Set person away**.
+7. _Optional_: Enter the **Person** you want to mark as away. Leave it empty to mark the whole home as empty.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Person:
+  description: The name of the person to mark as away. It must match a person known by the camera. Leave empty to mark the whole home as empty.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `netatmo.set_person_away`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: netatmo.set_person_away
+  target:
+    entity_id: camera.living_room
+  data:
+    person: Bob
+{% endexample %}
+
+This marks Bob as away for `camera.living_room`.
+
+### Options in YAML
+
+{% options_yaml %}
+person:
+  description: The name of the person to mark as away. It must match a person known by the camera. Omit to mark the whole home as empty.
+  required: false
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/targets.md %}
+
+## Good to know
+
+- If you leave the person empty, the whole home is marked as empty instead of a single person being marked as away.
+
+{% include actions/try_it.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/netatmo.set_person_away.markdown
+++ b/source/_actions/netatmo.set_person_away.markdown
@@ -63,4 +63,6 @@ person:
 
 {% include actions/try_it.md %}
 
+{% include actions/stuck.md %}
+
 {% include actions/related.md %}

--- a/source/_actions/netatmo.set_persons_home.markdown
+++ b/source/_actions/netatmo.set_persons_home.markdown
@@ -1,0 +1,67 @@
+---
+title: "Set persons at home"
+action: netatmo.set_persons_home
+domain: netatmo
+description: "Marks a list of people as at home for a Netatmo Indoor camera."
+related_actions:
+  - netatmo.set_person_away
+  - netatmo.set_camera_light
+---
+
+Use this action to mark one or more people as at home for a Netatmo Indoor (Welcome) camera. The names you provide must match people the camera already knows.
+
+{% include actions/ui_header.md %}
+
+To mark people as at home from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Netatmo Indoor camera you want to control.
+6. From the actions shown for that target, select **Set persons at home**.
+7. Enter the **Persons** you want to mark as at home.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Persons:
+  description: A list of names to mark as at home. Each name must match a person known by the camera.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `netatmo.set_persons_home`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: netatmo.set_persons_home
+  target:
+    entity_id: camera.living_room
+  data:
+    persons:
+      - Alice
+      - Bob
+{% endexample %}
+
+This marks Alice and Bob as at home for `camera.living_room`.
+
+### Options in YAML
+
+{% options_yaml %}
+persons:
+  description: A list of names to mark as at home. Each name must match a person known by the camera.
+  required: true
+  type: list
+{% endoptions_yaml %}
+
+{% include actions/targets.md %}
+
+## Good to know
+
+- You add and name people in the Netatmo app. The names you use here must match those known faces exactly.
+
+{% include actions/try_it.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/netatmo.set_persons_home.markdown
+++ b/source/_actions/netatmo.set_persons_home.markdown
@@ -64,4 +64,6 @@ persons:
 
 {% include actions/try_it.md %}
 
+{% include actions/stuck.md %}
+
 {% include actions/related.md %}

--- a/source/_actions/netatmo.set_preset_mode_with_end_datetime.markdown
+++ b/source/_actions/netatmo.set_preset_mode_with_end_datetime.markdown
@@ -71,4 +71,6 @@ end_datetime:
 
 {% include actions/try_it.md %}
 
+{% include actions/stuck.md %}
+
 {% include actions/related.md %}

--- a/source/_actions/netatmo.set_preset_mode_with_end_datetime.markdown
+++ b/source/_actions/netatmo.set_preset_mode_with_end_datetime.markdown
@@ -1,0 +1,74 @@
+---
+title: "Set preset mode with end date & time"
+action: netatmo.set_preset_mode_with_end_datetime
+domain: netatmo
+description: "Sets a preset mode for a Netatmo climate device until a chosen date and time."
+related_actions:
+  - netatmo.set_schedule
+  - netatmo.set_temperature_with_end_datetime
+  - netatmo.set_temperature_with_time_period
+  - netatmo.clear_temperature_setting
+---
+
+Use this action to put a Netatmo climate device into a preset mode, such as away or frost guard, until a date and time you choose. When that moment is reached, the device returns to its regular schedule.
+
+{% include actions/ui_header.md %}
+
+To set a preset mode with an end date and time from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Netatmo climate device you want to control.
+6. From the actions shown for that target, select **Set preset mode with end date & time**.
+7. Set the **Preset mode** and the **End date & time**.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Preset mode:
+  description: The preset mode to set. Available presets are away and frost guard.
+End date & time:
+  description: The date and time until which the preset mode stays active.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `netatmo.set_preset_mode_with_end_datetime`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: netatmo.set_preset_mode_with_end_datetime
+  target:
+    entity_id: climate.living_room
+  data:
+    preset_mode: away
+    end_datetime: "2025-04-20 05:04:20"
+{% endexample %}
+
+This sets `climate.living_room` to the away preset until the given date and time.
+
+### Options in YAML
+
+{% options_yaml %}
+preset_mode:
+  description: The preset mode to set. Available presets are `away` and `frost_guard`.
+  required: true
+  type: string
+end_datetime:
+  description: The date and time until which the preset mode stays active.
+  required: true
+  type: datetime
+{% endoptions_yaml %}
+
+{% include actions/targets.md %}
+
+## Good to know
+
+- When the end date and time is reached, the climate device returns to its active schedule.
+
+{% include actions/try_it.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/netatmo.set_schedule.markdown
+++ b/source/_actions/netatmo.set_schedule.markdown
@@ -1,0 +1,99 @@
+---
+title: "Set heating schedule"
+action: netatmo.set_schedule
+domain: netatmo
+description: "Activates a heating schedule for a Netatmo climate device."
+related_actions:
+  - netatmo.set_preset_mode_with_end_datetime
+  - netatmo.set_temperature_with_end_datetime
+  - netatmo.set_temperature_with_time_period
+  - netatmo.clear_temperature_setting
+---
+
+Use this action to switch a Netatmo climate device to one of the heating schedules you created in the Netatmo app. The schedule name you provide must match a schedule configured at Netatmo.
+
+{% include actions/ui_header.md %}
+
+To activate a heating schedule from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Netatmo climate device you want to control.
+6. From the actions shown for that target, select **Set heating schedule**.
+7. Enter the **Schedule name** you want to activate.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Schedule name:
+  description: The name of the schedule to activate. It must match a schedule configured at Netatmo.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `netatmo.set_schedule`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: netatmo.set_schedule
+  target:
+    entity_id: climate.living_room
+  data:
+    schedule_name: Standard
+{% endexample %}
+
+This activates the schedule named `Standard` for `climate.living_room`.
+
+### Options in YAML
+
+{% options_yaml %}
+schedule_name:
+  description: The name of the schedule to activate. It must match a schedule configured at Netatmo.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/targets.md %}
+
+## Good to know
+
+- You create and name heating schedules in the Netatmo app. The name you use here must match one of those schedules exactly.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: switch to your away schedule when everyone leaves
+
+Activate an energy-saving schedule when nobody is home.
+
+- **Trigger**: Everyone leaves home
+- **Action**: Set heating schedule
+  - **Target**: Living room thermostat
+  - **Schedule name**: Away
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  - alias: "Switch to the away schedule when everyone leaves"
+    triggers:
+      - trigger: state
+        entity_id: zone.home
+        to: "0"
+    actions:
+      - action: netatmo.set_schedule
+        target:
+          entity_id: climate.living_room
+        data:
+          schedule_name: Away
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/netatmo.set_temperature_with_end_datetime.markdown
+++ b/source/_actions/netatmo.set_temperature_with_end_datetime.markdown
@@ -71,4 +71,6 @@ end_datetime:
 
 {% include actions/try_it.md %}
 
+{% include actions/stuck.md %}
+
 {% include actions/related.md %}

--- a/source/_actions/netatmo.set_temperature_with_end_datetime.markdown
+++ b/source/_actions/netatmo.set_temperature_with_end_datetime.markdown
@@ -1,0 +1,74 @@
+---
+title: "Set temperature with end date & time"
+action: netatmo.set_temperature_with_end_datetime
+domain: netatmo
+description: "Sets a target temperature for a Netatmo climate device until a chosen date and time."
+related_actions:
+  - netatmo.set_temperature_with_time_period
+  - netatmo.set_preset_mode_with_end_datetime
+  - netatmo.set_schedule
+  - netatmo.clear_temperature_setting
+---
+
+Use this action to set a target temperature for a Netatmo climate device that stays active until a date and time you choose. When that moment is reached, the device returns to its regular schedule.
+
+{% include actions/ui_header.md %}
+
+To set a temperature with an end date and time from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Netatmo climate device you want to control.
+6. From the actions shown for that target, select **Set temperature with end date & time**.
+7. Set the **Target temperature** and the **End date & time**.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Target temperature:
+  description: The target temperature for the device, between 7 and 30 degrees.
+End date & time:
+  description: The date and time until which the target temperature stays active.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `netatmo.set_temperature_with_end_datetime`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: netatmo.set_temperature_with_end_datetime
+  target:
+    entity_id: climate.living_room
+  data:
+    target_temperature: 19.5
+    end_datetime: "2025-04-20 05:04:20"
+{% endexample %}
+
+This sets `climate.living_room` to 19.5 degrees until the given date and time.
+
+### Options in YAML
+
+{% options_yaml %}
+target_temperature:
+  description: The target temperature for the device, between 7 and 30 degrees.
+  required: true
+  type: float
+end_datetime:
+  description: The date and time until which the target temperature stays active.
+  required: true
+  type: datetime
+{% endoptions_yaml %}
+
+{% include actions/targets.md %}
+
+## Good to know
+
+- When the end date and time is reached, the climate device returns to its active schedule.
+
+{% include actions/try_it.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/netatmo.set_temperature_with_time_period.markdown
+++ b/source/_actions/netatmo.set_temperature_with_time_period.markdown
@@ -1,0 +1,75 @@
+---
+title: "Set temperature with time period"
+action: netatmo.set_temperature_with_time_period
+domain: netatmo
+description: "Sets a target temperature for a Netatmo climate device for a chosen length of time."
+related_actions:
+  - netatmo.set_temperature_with_end_datetime
+  - netatmo.set_preset_mode_with_end_datetime
+  - netatmo.set_schedule
+  - netatmo.clear_temperature_setting
+---
+
+Use this action to set a target temperature for a Netatmo climate device that stays active for a length of time you choose, such as the next three hours. When that period ends, the device returns to its regular schedule.
+
+{% include actions/ui_header.md %}
+
+To set a temperature for a time period from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Netatmo climate device you want to control.
+6. From the actions shown for that target, select **Set temperature with time period**.
+7. Set the **Target temperature** and the **Time period**.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Target temperature:
+  description: The target temperature for the device, between 7 and 30 degrees.
+Time period:
+  description: The length of time the target temperature stays active. Defaults to three hours.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `netatmo.set_temperature_with_time_period`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: netatmo.set_temperature_with_time_period
+  target:
+    entity_id: climate.living_room
+  data:
+    target_temperature: 19.5
+    time_period:
+      hours: 2
+{% endexample %}
+
+This sets `climate.living_room` to 19.5 degrees for the next two hours.
+
+### Options in YAML
+
+{% options_yaml %}
+target_temperature:
+  description: The target temperature for the device, between 7 and 30 degrees.
+  required: true
+  type: float
+time_period:
+  description: The length of time the target temperature stays active. Defaults to three hours.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/targets.md %}
+
+## Good to know
+
+- When the time period ends, the climate device returns to its active schedule.
+
+{% include actions/try_it.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/netatmo.set_temperature_with_time_period.markdown
+++ b/source/_actions/netatmo.set_temperature_with_time_period.markdown
@@ -72,4 +72,6 @@ time_period:
 
 {% include actions/try_it.md %}
 
+{% include actions/stuck.md %}
+
 {% include actions/related.md %}

--- a/source/_actions/netatmo.unregister_webhook.markdown
+++ b/source/_actions/netatmo.unregister_webhook.markdown
@@ -1,0 +1,49 @@
+---
+title: "Unregister webhook"
+action: netatmo.unregister_webhook
+domain: netatmo
+description: "Manually unregisters the Netatmo webhook from the Netatmo backend."
+related_actions:
+  - netatmo.register_webhook
+---
+
+Use this action to manually unregister the Netatmo webhook from the Netatmo backend. This stops Netatmo from pushing instant events to Home Assistant until you register the webhook again.
+
+{% include actions/ui_header.md %}
+
+To unregister the webhook from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Netatmo: Unregister webhook**.
+6. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+This action has no additional options in the UI.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `netatmo.unregister_webhook`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: netatmo.unregister_webhook
+{% endexample %}
+
+This unregisters the webhook from the Netatmo backend.
+
+## Good to know
+
+- While the webhook is unregistered, devices that rely on instant events become less responsive, since their updates arrive through regular polling instead.
+- Use the **Register webhook** action again to restore instant events.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/netatmo.markdown
+++ b/source/_integrations/netatmo.markdown
@@ -106,74 +106,7 @@ The `netatmo` sensor platform is consuming the information provided by a [Netatm
 
 The `netatmo` switch platform provides support for Legrand/BTicino switches and power plugs.
 
-## Actions
-
-### Action: Set outdoor camera light mode
-
-The `netatmo.set_camera_light_mode` action sets the outdoor camera light mode.
-
-| Data attribute | Required | Description                |
-| ---------------------- | -------- | -------------------------- |
-| `camera_light_mode`    | Yes      | Outdoor camera light mode. |
-
-### Action: Set schedule
-
-The `netatmo.set_schedule` action sets the heating schedule.
-
-| Data attribute | Required | Description                           |
-| ---------------------- | -------- | ------------------------------------- |
-| `schedule_name`        | Yes      | The name of the schedule to activate. |
-
-### Action: Set preset mode with end date & time
-
-The `netatmo.set_preset_mode_with_end_datetime` action sets the preset mode for a Netatmo climate device. The preset mode must match a preset mode configured at Netatmo.
-
-| Data attribute | Required | Description                                                 |
-| ---------------------- | -------- | ----------------------------------------------------------- |
-| `preset_mode`          | Yes      | Climate preset mode such as Schedule, Away, or Frost Guard. |
-| `end_datetime`         | Yes      | Date & time until which the preset will be active.          |
-
-### Action: Set temperature with end date & time
-
-The `netatmo.set_temperature_with_end_datetime` action sets the target temperature for a Netatmo climate device with an end date & time.
-
-| Data attribute | Required | Description                                              |
-| ---------------------- | -------- | -------------------------------------------------------- |
-| `target_temperature`   | Yes      | The target temperature for the device.                   |
-| `end_datetime`         | Yes      | Date & time the target temperature will be active until. |
-
-### Action: Set temperature with time period
-
-The `netatmo.set_temperature_with_time_period` action sets the target temperature for a Netatmo climate device as well as the time period during which this target temperature applies.
-
-| Data attribute | Required | Description                                                 |
-| ---------------------- | -------- | ----------------------------------------------------------- |
-| `target_temperature`   | Yes      | The target temperature for the device.                      |
-| `time_period`          | Yes      | Time period during which the target temperature is applied. |
-
-### Action: Clear temperature setting
-
-The `netatmo.clear_temperature_setting` action clears any temperature setting for a Netatmo climate device reverting it to the current preset or schedule.
-
-### Action: Set persons as at home
-
-The `netatmo.set_persons_home` action sets a list of persons as at home. Person's name must match a name known by the Netatmo Smart Indoor Camera.
-
-| Data attribute | Required | Description    |
-| ---------------------- | -------- | -------------- |
-| `persons`              | Yes      | List of names. |
-
-### Action: Set person away
-
-The `netatmo.set_person_away` action sets a person away. If no person is set the home will be marked as empty. Person's name must match a name known by the Netatmo Smart Indoor Camera.
-
-| Data attribute | Required | Description    |
-| ---------------------- | -------- | -------------- |
-| `person`               | Yes      | Person's name. |
-
-### Action: Register webhook and unregister webhook
-
-The `netatmo.register_webhook` and `netatmo.unregister_webhook` actions manually register and unregister the webhook.
+{% include integrations/actions.md %}
 
 ## Webhook Events
 


### PR DESCRIPTION
## Proposed change

Migrates the Netatmo actions that were documented inline on the integration page into dedicated pages under `source/_actions/`, one file per action, and replaces the inline block with `{% include integrations/actions.md %}`.

While migrating, the camera light action was corrected from `set_camera_light_mode` to `set_camera_light`, which is the actual action name registered by the integration.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

