### PR TITLE
Plex: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/plex.refresh_library.markdown
+++ b/source/_actions/plex.refresh_library.markdown
@@ -1,0 +1,94 @@
+---
+title: "Refresh library"
+action: plex.refresh_library
+domain: plex
+description: "Refreshes a Plex library to scan for new and updated media."
+---
+
+Use this action to tell Plex to scan one of its libraries for new and updated media. This is handy when you add files outside of Plex's regular scan schedule and want them to show up right away.
+
+{% include actions/ui_header.md %}
+
+To refresh a Plex library from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Plex: Refresh library**.
+6. Enter the **Library name** you want to refresh.
+7. _Optional_: If you have more than one Plex server, enter the **Server name** to choose which one to use.
+8. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Library name:
+  description: The name of the Plex library to refresh.
+Server name:
+  description: The name of the Plex server to use. Only needed if you have more than one server configured.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `plex.refresh_library`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: plex.refresh_library
+  data:
+    library_name: TV Shows
+{% endexample %}
+
+This scans the `TV Shows` library for new and updated media.
+
+### Options in YAML
+
+{% options_yaml %}
+library_name:
+  description: The name of the Plex library to refresh.
+  required: true
+  type: string
+server_name:
+  description: The name of the Plex server to use. Only needed if you have more than one server configured.
+  required: false
+  type: string
+{% endoptions_yaml %}
+
+## Good to know
+
+- Plex scans your libraries on its own schedule. Use this action when you want a scan to happen right away, for example after a new download lands on your media drive.
+- The library name must match the name of a library on your Plex server exactly.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: refresh the library every night
+
+Keep your Plex library up to date by scanning it once a day, while everyone is asleep.
+
+- **Trigger**: Time, 03:00
+- **Action**: Plex: Refresh library
+  - **Library name**: TV Shows
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  alias: "Refresh the Plex TV library nightly"
+  triggers:
+    - trigger: time
+      at: "03:00:00"
+  actions:
+    - action: plex.refresh_library
+      data:
+        library_name: TV Shows
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}

--- a/source/_actions/plex.refresh_library.markdown
+++ b/source/_actions/plex.refresh_library.markdown
@@ -40,7 +40,7 @@ In YAML, refer to this action as `plex.refresh_library`. A basic example looks l
 action: |
   action: plex.refresh_library
   data:
-    library_name: TV Shows
+    library_name: "TV Shows"
 {% endexample %}
 
 This scans the `TV Shows` library for new and updated media.
@@ -86,9 +86,11 @@ automation: |
   actions:
     - action: plex.refresh_library
       data:
-        library_name: TV Shows
+        library_name: "TV Shows"
 {% endexample %}
 
 {% enddetails %}
 
 {% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/plex.markdown
+++ b/source/_integrations/plex.markdown
@@ -374,17 +374,7 @@ media_content_type: playlist
 media_content_id: 'plex://{ "playlist_name": "Party Mix" }'
 ```
 
-## Additional actions
-
-### Action: Refresh library
-
-The `plex.refresh_library` action refreshes a Plex library to scan for new and updated media.
-
-| Data attribute | Required | Description                                                | Example          |
-| ---------------------- | -------- | ---------------------------------------------------------- | ---------------- |
-| `server_name`          | No       | Name of Plex server to use if multiple servers configured. | "My Plex Server" |
-| `library_name`         | Yes      | Name of Plex library to update.                            | "TV Shows"       |
-
+{% include integrations/actions.md %}
 
 ## Notes
 


### PR DESCRIPTION
## Proposed change

Migrates the `plex.refresh_library` action that was documented inline on the integration page into a dedicated page under `source/_actions/`, and replaces the inline block with `{% include integrations/actions.md %}`.

The `media_player.play_media` documentation stays on the integration page, since it documents the generic media player action with Plex-specific `media_content_id` payloads rather than a Plex action.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

