### PR TITLE
HEOS: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/heos.get_queue.markdown
+++ b/source/_actions/heos.get_queue.markdown
@@ -28,16 +28,17 @@ This action has no additional options in the UI.
 
 {% include actions/yaml_header.md %}
 
-In YAML, refer to this action as `heos.get_queue`. A basic example looks like this:
+In YAML, refer to this action as `heos.get_queue`. Store the result in a response variable so you can use it in later steps:
 
 {% example %}
 action: |
   action: heos.get_queue
   target:
     entity_id: media_player.office
+  response_variable: queue
 {% endexample %}
 
-This returns the play queue of `media_player.office`.
+This stores the play queue of `media_player.office` in `queue`.
 
 {% include actions/targets.md domain="media_player" %}
 

--- a/source/_actions/heos.get_queue.markdown
+++ b/source/_actions/heos.get_queue.markdown
@@ -1,0 +1,85 @@
+---
+title: "Get queue"
+action: heos.get_queue
+domain: heos
+description: "Retrieves the play queue of a HEOS media player."
+related_actions:
+  - heos.move_queue_item
+  - heos.remove_from_queue
+---
+
+Use this action to read the play queue of a HEOS media player. It returns the items currently queued, which you can use to inspect what's lined up or to find the queue IDs needed by the [Move queue item](/actions/heos.move_queue_item/) and [Remove from queue](/actions/heos.remove_from_queue/) actions.
+
+{% include actions/ui_header.md %}
+
+To get the queue from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the HEOS media player you want to read.
+6. From the actions shown for that target, select **Get queue**.
+7. Select **Save**.
+
+### Options in the UI
+
+This action has no additional options in the UI.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `heos.get_queue`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: heos.get_queue
+  target:
+    entity_id: media_player.office
+{% endexample %}
+
+This returns the play queue of `media_player.office`.
+
+{% include actions/targets.md domain="media_player" %}
+
+## Response data
+
+The response is keyed by the entity ID of each targeted player. For every player, a `queue` list holds the queued items, each with the following fields:
+
+- `queue_id`: The position of the item in the queue, starting at 1.
+- `song`: The title of the track.
+- `album`: The album the track belongs to.
+- `artist`: The artist of the track.
+- `image_url`: A link to the cover art.
+- `media_id`: The HEOS identifier of the track.
+- `album_id`: The HEOS identifier of the album.
+
+```yaml
+media_player.office:
+  queue:
+    - queue_id: 1
+      song: Alone Again
+      album: After Hours
+      artist: The Weeknd
+      image_url: >-
+        http://resources.example.com/images/640x640.jpg
+      media_id: "134788274"
+      album_id: "134788273"
+    - queue_id: 2
+      song: Too Late
+      album: After Hours
+      artist: The Weeknd
+      image_url: >-
+        http://resources.example.com/images/640x640.jpg
+      media_id: "134788275"
+      album_id: "134788273"
+```
+
+## Good to know
+
+- Use this action first to find the `queue_id` values, then pass them to [Move queue item](/actions/heos.move_queue_item/) or [Remove from queue](/actions/heos.remove_from_queue/).
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/heos.group_volume_down.markdown
+++ b/source/_actions/heos.group_volume_down.markdown
@@ -1,0 +1,53 @@
+---
+title: "Turn down group volume"
+action: heos.group_volume_down
+domain: heos
+description: "Turns down the volume of a HEOS group a step."
+related_actions:
+  - heos.group_volume_up
+  - heos.group_volume_set
+---
+
+Use this action to turn down the volume of a HEOS group by a step, while keeping the relative balance between the group members. You can call it on any player that is joined to the group.
+
+{% include actions/ui_header.md %}
+
+To turn down the group volume from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select a HEOS media player that is joined to the group.
+6. From the actions shown for that target, select **Turn down group volume**.
+7. Select **Save**.
+
+### Options in the UI
+
+This action has no additional options in the UI.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `heos.group_volume_down`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: heos.group_volume_down
+  target:
+    entity_id: media_player.kitchen
+{% endexample %}
+
+This turns down the volume of the group that `media_player.kitchen` belongs to.
+
+{% include actions/targets.md domain="media_player" %}
+
+## Good to know
+
+- The step keeps the relative volume of each member, so the group stays in balance.
+- To set an exact level instead of stepping, use [Set group volume](/actions/heos.group_volume_set/).
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/heos.group_volume_set.markdown
+++ b/source/_actions/heos.group_volume_set.markdown
@@ -1,0 +1,68 @@
+---
+title: "Set group volume"
+action: heos.group_volume_set
+domain: heos
+description: "Sets the volume of a HEOS group while preserving member volume ratios."
+related_actions:
+  - heos.group_volume_up
+  - heos.group_volume_down
+---
+
+Use this action to set the volume of a HEOS group. It keeps the relative balance between the group members, so a player that was quieter than the others stays quieter. You can call it on any player that is joined to the group.
+
+{% include actions/ui_header.md %}
+
+To set the group volume from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select a HEOS media player that is joined to the group.
+6. From the actions shown for that target, select **Set group volume**.
+7. Set the **Level** you want.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Level:
+  description: The volume to set, where 0 is inaudible and 1 is the maximum volume.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `heos.group_volume_set`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: heos.group_volume_set
+  target:
+    entity_id: media_player.kitchen
+  data:
+    volume_level: 0.4
+{% endexample %}
+
+This sets the group that `media_player.kitchen` belongs to, to 40% volume.
+
+### Options in YAML
+
+{% options_yaml %}
+volume_level:
+  description: The volume to set, where 0 is inaudible and 1 is the maximum volume.
+  required: true
+  type: float
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="media_player" %}
+
+## Good to know
+
+- The action keeps the relative volume of each member. If one player was set lower than the rest, it stays proportionally lower after the change.
+- You can target any player in the group. The whole group's volume is adjusted, not just the one you target.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/heos.group_volume_up.markdown
+++ b/source/_actions/heos.group_volume_up.markdown
@@ -1,0 +1,53 @@
+---
+title: "Turn up group volume"
+action: heos.group_volume_up
+domain: heos
+description: "Turns up the volume of a HEOS group a step."
+related_actions:
+  - heos.group_volume_down
+  - heos.group_volume_set
+---
+
+Use this action to turn up the volume of a HEOS group by a step, while keeping the relative balance between the group members. You can call it on any player that is joined to the group.
+
+{% include actions/ui_header.md %}
+
+To turn up the group volume from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select a HEOS media player that is joined to the group.
+6. From the actions shown for that target, select **Turn up group volume**.
+7. Select **Save**.
+
+### Options in the UI
+
+This action has no additional options in the UI.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `heos.group_volume_up`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: heos.group_volume_up
+  target:
+    entity_id: media_player.kitchen
+{% endexample %}
+
+This turns up the volume of the group that `media_player.kitchen` belongs to.
+
+{% include actions/targets.md domain="media_player" %}
+
+## Good to know
+
+- The step keeps the relative volume of each member, so the group stays in balance.
+- To set an exact level instead of stepping, use [Set group volume](/actions/heos.group_volume_set/).
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/heos.move_queue_item.markdown
+++ b/source/_actions/heos.move_queue_item.markdown
@@ -1,0 +1,75 @@
+---
+title: "Move queue item"
+action: heos.move_queue_item
+domain: heos
+description: "Reorders one or more items within a HEOS media player's play queue."
+related_actions:
+  - heos.get_queue
+  - heos.remove_from_queue
+---
+
+Use this action to reorder a HEOS media player's play queue. You provide the queue IDs of the items to move and the position to move them to. Look up the queue IDs with the [Get queue](/actions/heos.get_queue/) action.
+
+{% include actions/ui_header.md %}
+
+To move items within the queue from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the HEOS media player you want to control.
+6. From the actions shown for that target, select **Move queue item**.
+7. Enter the **Queue IDs** to move and the **Destination position**.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Queue IDs:
+  description: The IDs (positions) of the items in the queue to move. You can find these with the Get queue action.
+Destination position:
+  description: The position in the queue to move the items to, starting at 1.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `heos.move_queue_item`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: heos.move_queue_item
+  target:
+    entity_id: media_player.family_room
+  data:
+    queue_ids:
+      - 2
+    destination_position: 1
+{% endexample %}
+
+This moves the second item in the queue to the top for `media_player.family_room`.
+
+### Options in YAML
+
+{% options_yaml %}
+queue_ids:
+  description: The IDs (positions) of the items in the queue to move. You can find these with the Get queue action.
+  required: true
+  type: list
+destination_position:
+  description: The position in the queue to move the items to, starting at 1.
+  required: true
+  type: integer
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="media_player" %}
+
+## Good to know
+
+- Queue IDs start at 1. Use [Get queue](/actions/heos.get_queue/) first to look up the current positions, since they shift as items are moved.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/heos.remove_from_queue.markdown
+++ b/source/_actions/heos.remove_from_queue.markdown
@@ -1,0 +1,69 @@
+---
+title: "Remove from queue"
+action: heos.remove_from_queue
+domain: heos
+description: "Removes one or more items from a HEOS media player's play queue."
+related_actions:
+  - heos.get_queue
+  - heos.move_queue_item
+---
+
+Use this action to remove one or more items from a HEOS media player's play queue. You identify the items by their queue IDs, which you can look up with the [Get queue](/actions/heos.get_queue/) action.
+
+{% include actions/ui_header.md %}
+
+To remove items from the queue from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the HEOS media player you want to control.
+6. From the actions shown for that target, select **Remove from queue**.
+7. Enter the **Queue IDs** of the items you want to remove.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Queue IDs:
+  description: The IDs (positions) of the items in the queue to remove. You can find these with the Get queue action.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `heos.remove_from_queue`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: heos.remove_from_queue
+  target:
+    entity_id: media_player.family_room
+  data:
+    queue_ids:
+      - 1
+      - 3
+{% endexample %}
+
+This removes the first and third items from the queue of `media_player.family_room`.
+
+### Options in YAML
+
+{% options_yaml %}
+queue_ids:
+  description: The IDs (positions) of the items in the queue to remove. You can find these with the Get queue action.
+  required: true
+  type: list
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="media_player" %}
+
+## Good to know
+
+- Queue IDs start at 1. Use [Get queue](/actions/heos.get_queue/) first to look up the current positions, since they shift as items are added or removed.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/heos.markdown
+++ b/source/_integrations/heos.markdown
@@ -82,92 +82,9 @@ This integration follows standard integration removal. No extra steps are requir
 1. Go to **{% my integrations icon title="Settings > Devices & services" %}**.
 2. Select **Denon HEOS**. Click the three dots {% icon "mdi:dots-vertical" %} menu and then select **Delete**.
 
-## Actions
+In addition to the standard [media player actions](/integrations/media_player/#actions), the HEOS integration provides actions to control group volume and to manage a player's queue.
 
-In addition to the standard [Media Player actions](/integrations/media_player#actions), the HEOS integration provides the following {% term actions %}:
-
-Group volume actions: `heos.group_volume_set`, `heos.group_volume_down`, and `heos.group_volume_up` for entities joined to a group.
-
-Queue actions: `heos.get_queue`, `heos.move_queue_item`, and `heos.remove_from_queue` to manage a player's queue items.
-
-### Action: Set group volume
-
-The `heos.group_volume_set` action sets the group's volume while preserving member volume ratios. This action can be called on any entity in a group.
-
-| Data attribute | Optional | Description                                      |
-|------------------------|----------|------------------------------------------------------------------|
-| `entity_id`            |      yes | A media player entity that is joined to a group.                  |
-| `volume_level`         |       no | The volume level, where 0 is inaudible, 1 is the maximum volume. |
-
-### Action: Get queue
-
-The `heos.get_queue` action returns the items in the player's queue. This action can be used to inspect the current play queue of target players.
-
-| Data attribute | Optional | Description                                      |
-|------------------------|----------|------------------------------------------------------------------|
-| `entity_id`            | no      | `entity_id` of the player(s)                                     |
-
-Example response:
-
-```yaml
-media_player.office:
-  queue:
-    - queue_id: 1
-      song: Alone Again
-      album: After Hours
-      artist: The Weeknd
-      image_url: >-
-        http://resources.wimpmusic.com/images/22f72311/8e9e/461e/a100/d9cfd4ddc2fa/640x640.jpg
-      media_id: "134788274"
-      album_id: "134788273"
-    - queue_id: 2
-      song: Too Late
-      album: After Hours
-      artist: The Weeknd
-      image_url: >-
-        http://resources.wimpmusic.com/images/22f72311/8e9e/461e/a100/d9cfd4ddc2fa/640x640.jpg
-      media_id: "134788275"
-      album_id: "134788273"
-```
-
-### Action: Move queue item
-
-The `heos.move_queue_item` action moves one or more items in the target player's queue, effectively reordering the play queue. The play queue can be enumerated by using the `heos.get_queue` action.
-
-Example action data payload that moves the second item to the top of the play queue:
-
-```yaml
-action: heos.move_queue_item
-target:
-  entity_id: media_player.family_room_receiver
-data:
-  queue_ids:
-    - 2
-  destination_position: 1
-```
-
-| Data attribute | Optional | Description                                                     |
-| ---------------------- | -------- | ------------------------------------------------------- |
-| `queue_ids`            | no       | The IDs (indexes) of the items in the queue to move.    |
-| `destination_position` | no       | The destination position in the queue (starting at 1).  |
-
-### Action: Remove from queue
-
-The `heos.remove_from_queue` action removes one or more items from the target player(s) queue. The play queue can be enumerated by using the `heos.get_queue` action. Example action data payload:
-
-```yaml
-action: heos.remove_from_queue
-target:
-  entity_id: media_player.family_room_receiver
-data:
-  queue_ids:
-    - 1
-    - 3
-```
-
-| Data attribute | Optional | Description                                                     |
-| ---------------------- | -------- | ------------------------------------------------------- |
-| `queue_ids`            | no       | The IDs (indexes) of the items in the queue to remove.   |
+{% include integrations/actions.md %}
 
 ## Examples
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change

Moves the inline HEOS action documentation for the group volume and queue actions into dedicated pages under `source/_actions/`, and replaces the inline block on the integration page with the actions include. This brings HEOS in line with the standardized action documentation structure.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

