### PR TITLE
Input boolean: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/input_boolean.reload.markdown
+++ b/source/_actions/input_boolean.reload.markdown
@@ -1,0 +1,49 @@
+---
+title: "Reload input booleans"
+action: input_boolean.reload
+domain: input_boolean
+description: "Reloads the input boolean helpers from the YAML configuration."
+related_actions:
+  - input_boolean.turn_on
+  - input_boolean.toggle
+---
+
+Use this action to reload the input boolean helpers you configured in YAML, without restarting Home Assistant. Helpers you created through the UI are not affected.
+
+{% include actions/ui_header.md %}
+
+To reload the input boolean helpers from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Input boolean: Reload input booleans**.
+6. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label. Only users with administrator rights can run this action.
+
+### Options in the UI
+
+This action has no additional options in the UI.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `input_boolean.reload`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: input_boolean.reload
+{% endexample %}
+
+This reloads the input boolean helpers from your YAML configuration.
+
+## Good to know
+
+- Run this action after you change the input boolean helpers in your YAML configuration so the changes take effect without a restart.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/input_boolean.toggle.markdown
+++ b/source/_actions/input_boolean.toggle.markdown
@@ -1,0 +1,52 @@
+---
+title: "Toggle input boolean"
+action: input_boolean.toggle
+domain: input_boolean
+description: "Toggles an input boolean between on and off."
+related_actions:
+  - input_boolean.turn_on
+  - input_boolean.turn_off
+---
+
+Use this action to toggle one or more input booleans. If the input boolean is on, it turns off, and if it is off, it turns on. An input boolean is a toggle helper you can use in automations and scripts.
+
+{% include actions/ui_header.md %}
+
+To toggle an input boolean from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the input boolean you want to toggle.
+6. From the actions shown for that target, select **Toggle input boolean**.
+7. Select **Save**.
+
+### Options in the UI
+
+This action has no additional options in the UI.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `input_boolean.toggle`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: input_boolean.toggle
+  target:
+    entity_id: input_boolean.guest_mode
+{% endexample %}
+
+This toggles the `input_boolean.guest_mode` helper.
+
+{% include actions/targets.md %}
+
+## Good to know
+
+- Toggling is handy for a single button or remote key that should switch a behavior on and off with each press.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/input_boolean.turn_off.markdown
+++ b/source/_actions/input_boolean.turn_off.markdown
@@ -1,0 +1,52 @@
+---
+title: "Turn off input boolean"
+action: input_boolean.turn_off
+domain: input_boolean
+description: "Turns an input boolean off."
+related_actions:
+  - input_boolean.turn_on
+  - input_boolean.toggle
+---
+
+Use this action to set one or more input booleans to off. An input boolean is a toggle helper you can use in automations and scripts, for example to enable or disable a behavior.
+
+{% include actions/ui_header.md %}
+
+To turn off an input boolean from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the input boolean you want to turn off.
+6. From the actions shown for that target, select **Turn off input boolean**.
+7. Select **Save**.
+
+### Options in the UI
+
+This action has no additional options in the UI.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `input_boolean.turn_off`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: input_boolean.turn_off
+  target:
+    entity_id: input_boolean.guest_mode
+{% endexample %}
+
+This turns off the `input_boolean.guest_mode` helper.
+
+{% include actions/targets.md %}
+
+## Good to know
+
+- Turn an input boolean off to pause a behavior that other automations check, such as a notification routine.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/input_boolean.turn_on.markdown
+++ b/source/_actions/input_boolean.turn_on.markdown
@@ -1,0 +1,79 @@
+---
+title: "Turn on input boolean"
+action: input_boolean.turn_on
+domain: input_boolean
+description: "Turns an input boolean on."
+related_actions:
+  - input_boolean.turn_off
+  - input_boolean.toggle
+---
+
+Use this action to set one or more input booleans to on. An input boolean is a toggle helper you can use in automations and scripts, for example to enable or disable a behavior.
+
+{% include actions/ui_header.md %}
+
+To turn on an input boolean from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the input boolean you want to turn on.
+6. From the actions shown for that target, select **Turn on input boolean**.
+7. Select **Save**.
+
+### Options in the UI
+
+This action has no additional options in the UI.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `input_boolean.turn_on`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: input_boolean.turn_on
+  target:
+    entity_id: input_boolean.guest_mode
+{% endexample %}
+
+This turns on the `input_boolean.guest_mode` helper.
+
+{% include actions/targets.md %}
+
+## Good to know
+
+- Use an input boolean as a switch in your automations. For example, turn it on to enable a notification routine and turn it off to pause it.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: enable guest mode when a guest arrives
+
+Turn on a guest mode helper that other automations check.
+
+- **Trigger**: A guest's phone connects to the Wi-Fi
+- **Action**: Turn on input boolean
+  - **Target**: Guest mode
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  - alias: "Enable guest mode when a guest arrives"
+    triggers:
+      - trigger: state
+        entity_id: device_tracker.guest_phone
+        to: "home"
+    actions:
+      - action: input_boolean.turn_on
+        target:
+          entity_id: input_boolean.guest_mode
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/input_boolean.markdown
+++ b/source/_integrations/input_boolean.markdown
@@ -61,20 +61,9 @@ input_boolean:
     icon: mdi:car
 ```
 
-## Actions
+{% include integrations/actions.md %}
 
-This integration provides the following {% term actions %} to modify the state of the
-`input_boolean` and an action to reload the configuration without restarting
-Home Assistant itself.
-
-| Action     | Data                           | Description                                                 |
-| ---------- | ------------------------------ | ----------------------------------------------------------- |
-| `turn_on`  | `entity_id(s)`<br>`area_id(s)` | Set the value of specific `input_boolean` entities to `on`  |
-| `turn_off` | `entity_id(s)`<br>`area_id(s)` | Set the value of specific `input_boolean` entities to `off` |
-| `toggle`   | `entity_id(s)`<br>`area_id(s)` | Toggle the value of specific `input_boolean` entities       |
-| `reload`   |                                | Reload `input_boolean` configuration                        |
-
-### Restore state
+## Restore state
 
 If you set a valid value for `initial` this integration will start with the state
 set to that value. Otherwise, it will restore the state it had before


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change

Moves the inline input boolean action documentation (`turn_on`, `turn_off`, `toggle`, and `reload`) into dedicated pages under `source/_actions/`, and replaces the inline table on the integration page with the actions include. This brings the integration in line with the standardized action documentation structure.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

