### PR TITLE
Group: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/group.reload.markdown
+++ b/source/_actions/group.reload.markdown
@@ -38,6 +38,10 @@ action: |
 
 This reloads the groups from your YAML configuration.
 
+### Options in YAML
+
+This action has no options.
+
 ## Good to know
 
 - Run this action after you change the groups in your YAML configuration so the changes take effect without a restart.

--- a/source/_actions/group.reload.markdown
+++ b/source/_actions/group.reload.markdown
@@ -1,0 +1,49 @@
+---
+title: "Reload groups"
+action: group.reload
+domain: group
+description: "Reloads the groups from the YAML configuration."
+related_actions:
+  - group.set
+  - group.remove
+---
+
+Use this action to reload the groups, entities, and notify services you configured in YAML, without restarting Home Assistant.
+
+{% include actions/ui_header.md %}
+
+To reload the groups from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Group: Reload groups**.
+6. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+This action has no additional options in the UI.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `group.reload`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: group.reload
+{% endexample %}
+
+This reloads the groups from your YAML configuration.
+
+## Good to know
+
+- Run this action after you change the groups in your YAML configuration so the changes take effect without a restart.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/group.remove.markdown
+++ b/source/_actions/group.remove.markdown
@@ -1,0 +1,66 @@
+---
+title: "Remove group"
+action: group.remove
+domain: group
+description: "Removes an old-style group."
+related_actions:
+  - group.set
+  - group.reload
+---
+
+Use this action to remove an old-style group you created with the [Set group](/actions/group.set/) action. You identify the group by its object ID.
+
+This action only works with old-style groups. It cannot be used with the new-style groups you create in the UI.
+
+{% include actions/ui_header.md %}
+
+To remove a group from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Group: Remove group**.
+6. Enter the **Object ID** of the group you want to remove.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Object ID:
+  description: The object ID of the group to remove. It is used as part of the entity ID, in the format `group.object_id`.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `group.remove`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: group.remove
+  data:
+    object_id: my_group
+{% endexample %}
+
+This removes the group `group.my_group`.
+
+### Options in YAML
+
+{% options_yaml %}
+object_id:
+  description: The object ID of the group to remove. It is used as part of the entity ID, in the format `group.object_id`.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+## Good to know
+
+- This action only removes groups created with the [Set group](/actions/group.set/) action. It does not remove groups defined in your YAML configuration.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/group.set.markdown
+++ b/source/_actions/group.set.markdown
@@ -1,0 +1,108 @@
+---
+title: "Set group"
+action: group.set
+domain: group
+description: "Creates or updates an old-style group."
+related_actions:
+  - group.remove
+  - group.reload
+---
+
+Use this action to create a new old-style group or update an existing one. You identify the group by its object ID and set its name, icon, members, and behavior.
+
+This action only works with old-style groups. It cannot be used with the new-style groups you create in the UI.
+
+{% include actions/ui_header.md %}
+
+To create or update a group from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Group: Set group**.
+6. Enter the **Object ID** and any other options you want to set.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Object ID:
+  description: The object ID of the group. It is used as part of the entity ID, in the format `group.object_id`.
+Name:
+  description: The name of the group.
+Icon:
+  description: The name of the icon for the group.
+Entities:
+  description: The full list of members in the group. Cannot be combined with **Add entities** or **Remove entities**.
+Add entities:
+  description: The members to add to the group. Cannot be combined with **Entities** or **Remove entities**.
+Remove entities:
+  description: The members to remove from the group. Cannot be combined with **Entities** or **Add entities**.
+All:
+  description: When enabled, the group is only on when all of its members are on.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `group.set`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: group.set
+  data:
+    object_id: my_group
+    name: "My group"
+    entities:
+      - light.living_room
+      - light.kitchen
+{% endexample %}
+
+This creates or updates the group `group.my_group` with two light members.
+
+### Options in YAML
+
+{% options_yaml %}
+object_id:
+  description: The object ID of the group. It is used as part of the entity ID, in the format `group.object_id`.
+  required: true
+  type: string
+name:
+  description: The name of the group.
+  required: false
+  type: string
+icon:
+  description: The name of the icon for the group.
+  required: false
+  type: string
+entities:
+  description: The full list of members in the group. Cannot be combined with `add_entities` or `remove_entities`.
+  required: false
+  type: list
+add_entities:
+  description: The members to add to the group. Cannot be combined with `entities` or `remove_entities`.
+  required: false
+  type: list
+remove_entities:
+  description: The members to remove from the group. Cannot be combined with `entities` or `add_entities`.
+  required: false
+  type: list
+all:
+  description: When enabled, the group is only on when all of its members are on.
+  required: false
+  type: boolean
+  default: false
+{% endoptions_yaml %}
+
+## Good to know
+
+- Use only one of `entities`, `add_entities`, or `remove_entities` in a single call. They cannot be combined.
+- A group created or updated with this action gets an `auto` attribute set to `true`.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/group.markdown
+++ b/source/_integrations/group.markdown
@@ -510,18 +510,4 @@ These are the attributes available for an old-style group.
 | `order`                              | Integer representing the order in which the entity was created, starting with `0`.                           |
 | `auto`                               | Boolean that will always be set to `true`. Only appears in groups that were created with the `set` action.   |
 
-### Actions
-
-The following actions to modify groups and a action to reload the configuration without restarting Home Assistant itself. These actions are only available for old-style groups. They cannot be used with the new-style groups described above.
-
-| Action   | Data              | Description                                                                   |
-| -------- | ----------------- | ----------------------------------------------------------------------------- |
-| `set`    | `Object ID`       | Group id and part of entity id.                                               |
-|          | `Name`            | Name of the group.                                                            |
-|          | `Icon`            | Name of the icon for the group.                                               |
-|          | `Entities`        | List of all members in the group. Not compatible with **delta**.              |
-|          | `Add Entities`    | List of members that will change on group listening.                          |
-|          | `Remove Entities` | List of members that will be removed from group listening.                    |
-|          | `All`             | Enable this option if the group should only turn on when all entities are on. |
-| `remove` | `Object ID`       | Group id and part of entity id.                                               |
-| `reload` | `Object ID`       | Group id and part of entity id.                                               |
+{% include integrations/actions.md %}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change

Moves the inline group action documentation (`set`, `remove`, and `reload`) into dedicated pages under `source/_actions/`, and replaces the inline table on the integration page with the actions include. This brings the integration in line with the standardized action documentation structure.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

