### PR TITLE
Input number: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/input_number.decrement.markdown
+++ b/source/_actions/input_number.decrement.markdown
@@ -1,0 +1,52 @@
+---
+title: "Decrement input number"
+action: input_number.decrement
+domain: input_number
+description: "Decrements the value of an input number by 1 step."
+related_actions:
+  - input_number.increment
+  - input_number.set_value
+---
+
+Use this action to decrease one or more input numbers by their configured step. An input number is a helper you can use in automations and scripts to store and control a numeric value.
+
+{% include actions/ui_header.md %}
+
+To decrement an input number from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the input number you want to decrement.
+6. From the actions shown for that target, select **Decrement input number**.
+7. Select **Save**.
+
+### Options in the UI
+
+This action has no additional options in the UI.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `input_number.decrement`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: input_number.decrement
+  target:
+    entity_id: input_number.target_temperature
+{% endexample %}
+
+This decreases the `input_number.target_temperature` helper by its configured step.
+
+{% include actions/targets.md %}
+
+## Good to know
+
+- The value decreases by the `step` you configured for the input number and never goes below the configured `min`.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/input_number.decrement.markdown
+++ b/source/_actions/input_number.decrement.markdown
@@ -39,6 +39,10 @@ action: |
 
 This decreases the `input_number.target_temperature` helper by its configured step.
 
+### Options in YAML
+
+This action has no additional YAML options beyond the target.
+
 {% include actions/targets.md %}
 
 ## Good to know

--- a/source/_actions/input_number.increment.markdown
+++ b/source/_actions/input_number.increment.markdown
@@ -1,0 +1,52 @@
+---
+title: "Increment input number"
+action: input_number.increment
+domain: input_number
+description: "Increments the value of an input number by 1 step."
+related_actions:
+  - input_number.decrement
+  - input_number.set_value
+---
+
+Use this action to increase one or more input numbers by their configured step. An input number is a helper you can use in automations and scripts to store and control a numeric value.
+
+{% include actions/ui_header.md %}
+
+To increment an input number from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the input number you want to increment.
+6. From the actions shown for that target, select **Increment input number**.
+7. Select **Save**.
+
+### Options in the UI
+
+This action has no additional options in the UI.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `input_number.increment`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: input_number.increment
+  target:
+    entity_id: input_number.target_temperature
+{% endexample %}
+
+This increases the `input_number.target_temperature` helper by its configured step.
+
+{% include actions/targets.md %}
+
+## Good to know
+
+- The value increases by the `step` you configured for the input number and never goes above the configured `max`.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/input_number.increment.markdown
+++ b/source/_actions/input_number.increment.markdown
@@ -39,6 +39,10 @@ action: |
 
 This increases the `input_number.target_temperature` helper by its configured step.
 
+### Options in YAML
+
+This action has no additional YAML options beyond the target.
+
 {% include actions/targets.md %}
 
 ## Good to know

--- a/source/_actions/input_number.reload.markdown
+++ b/source/_actions/input_number.reload.markdown
@@ -38,6 +38,10 @@ action: |
 
 This reloads the input number helpers from your YAML configuration.
 
+### Options in YAML
+
+This action has no additional options in YAML.
+
 ## Good to know
 
 - Run this action after you change the input number helpers in your YAML configuration so the changes take effect without a restart.

--- a/source/_actions/input_number.reload.markdown
+++ b/source/_actions/input_number.reload.markdown
@@ -1,0 +1,49 @@
+---
+title: "Reload input numbers"
+action: input_number.reload
+domain: input_number
+description: "Reloads the input number helpers from the YAML configuration."
+related_actions:
+  - input_number.set_value
+  - input_number.increment
+---
+
+Use this action to reload the input number helpers you configured in YAML, without restarting Home Assistant. Helpers you created through the UI are not affected.
+
+{% include actions/ui_header.md %}
+
+To reload the input number helpers from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Input number: Reload input numbers**.
+6. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label. Only users with administrator rights can run this action.
+
+### Options in the UI
+
+This action has no additional options in the UI.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `input_number.reload`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: input_number.reload
+{% endexample %}
+
+This reloads the input number helpers from your YAML configuration.
+
+## Good to know
+
+- Run this action after you change the input number helpers in your YAML configuration so the changes take effect without a restart.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/input_number.set_value.markdown
+++ b/source/_actions/input_number.set_value.markdown
@@ -1,0 +1,67 @@
+---
+title: "Set input number value"
+action: input_number.set_value
+domain: input_number
+description: "Sets the value of an input number."
+related_actions:
+  - input_number.increment
+  - input_number.decrement
+---
+
+Use this action to set one or more input numbers to a specific value. An input number is a helper you can use in automations and scripts to store and control a numeric value, shown as a slider or a numeric input box.
+
+{% include actions/ui_header.md %}
+
+To set an input number value from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the input number you want to set.
+6. From the actions shown for that target, select **Set input number value**.
+7. Enter the **Value** you want to set.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Value:
+  description: The target value to set.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `input_number.set_value`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: input_number.set_value
+  target:
+    entity_id: input_number.target_temperature
+  data:
+    value: 21
+{% endexample %}
+
+This sets the `input_number.target_temperature` helper to `21`.
+
+### Options in YAML
+
+{% options_yaml %}
+value:
+  description: The target value to set.
+  required: true
+  type: float
+{% endoptions_yaml %}
+
+{% include actions/targets.md %}
+
+## Good to know
+
+- The value must be within the `min` and `max` range you configured for the input number, and it follows the configured `step`.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/input_number.markdown
+++ b/source/_integrations/input_number.markdown
@@ -82,23 +82,13 @@ input_number:
         type: icon
 {% endconfiguration %}
 
-### Actions
+{% include integrations/actions.md %}
 
-This integration provides the following actions to modify the state of the `input_number` and an action to reload the
-configuration without restarting Home Assistant itself.
-
-| Service     | Data                                      | Description                                                       |
-| ----------- | ----------------------------------------- | ----------------------------------------------------------------- |
-| `decrement` | `entity_id(s)`<br>`area_id(s)`            | Decrement the value of specific `input_number` entities by `step` |
-| `increment` | `entity_id(s)`<br>`area_id(s)`            | Increment the value of specific `input_number` entities by `step` |
-| `reload`    |                                           | Reload `input_number` configuration                               |
-| `set_value` | `value`<br>`entity_id(s)`<br>`area_id(s)` | Set the value of specific `input_number` entities                 |
-
-### Restore state
+## Restore state
 
 If you set a valid value for `initial` this integration will start with the state set to that value. Otherwise, it will restore the state it had before Home Assistant stopping. `initial` is only available in a YAML configuration and not via the Home Assistant user interface.
 
-### Scenes
+## Scenes
 
 To set the value of an input_number in a [Scene](/integrations/scene/):
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change

Moves the inline input number action documentation (`set_value`, `increment`, `decrement`, and `reload`) into dedicated pages under `source/_actions/`, and replaces the inline table on the integration page with the actions include. This brings the integration in line with the standardized action documentation structure.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

