### PR TITLE
Input datetime: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/input_datetime.reload.markdown
+++ b/source/_actions/input_datetime.reload.markdown
@@ -1,0 +1,48 @@
+---
+title: "Reload input datetimes"
+action: input_datetime.reload
+domain: input_datetime
+description: "Reloads the input datetime helpers from the YAML configuration."
+related_actions:
+  - input_datetime.set_datetime
+---
+
+Use this action to reload the input datetime helpers you configured in YAML, without restarting Home Assistant. Helpers you created through the UI are not affected.
+
+{% include actions/ui_header.md %}
+
+To reload the input datetime helpers from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Input datetime: Reload input datetimes**.
+6. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label. Only users with administrator rights can run this action.
+
+### Options in the UI
+
+This action has no additional options in the UI.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `input_datetime.reload`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: input_datetime.reload
+{% endexample %}
+
+This reloads the input datetime helpers from your YAML configuration.
+
+## Good to know
+
+- Run this action after you change the input datetime helpers in your YAML configuration so the changes take effect without a restart.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/input_datetime.reload.markdown
+++ b/source/_actions/input_datetime.reload.markdown
@@ -37,6 +37,10 @@ action: |
 
 This reloads the input datetime helpers from your YAML configuration.
 
+### Options in YAML
+
+This action has no additional options in YAML.
+
 ## Good to know
 
 - Run this action after you change the input datetime helpers in your YAML configuration so the changes take effect without a restart.

--- a/source/_actions/input_datetime.set_datetime.markdown
+++ b/source/_actions/input_datetime.set_datetime.markdown
@@ -1,0 +1,87 @@
+---
+title: "Set input datetime value"
+action: input_datetime.set_datetime
+domain: input_datetime
+description: "Sets the date and/or time of an input datetime."
+related_actions:
+  - input_datetime.reload
+---
+
+Use this action to set the date, the time, or both for one or more input datetimes. An input datetime is a helper you can use in automations and scripts to store a date, a time, or a combination of the two.
+
+{% include actions/ui_header.md %}
+
+To set an input datetime from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the input datetime you want to set.
+6. From the actions shown for that target, select **Set input datetime value**.
+7. Enter a **Date**, a **Time**, or both, depending on what the helper stores.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Date:
+  description: The target date, in the format `YYYY-MM-DD`.
+Time:
+  description: The target time, in the format `HH:MM:SS`.
+Date & time:
+  description: The target date and time, in the format `YYYY-MM-DD HH:MM:SS`.
+Timestamp:
+  description: The target date and time, expressed as a UNIX timestamp.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `input_datetime.set_datetime`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: input_datetime.set_datetime
+  target:
+    entity_id: input_datetime.alarm_clock
+  data:
+    time: "05:30:00"
+{% endexample %}
+
+This sets the time of the `input_datetime.alarm_clock` helper to `05:30:00`.
+
+### Options in YAML
+
+You must provide at least one of `date`, `time`, `datetime`, or `timestamp`.
+
+{% options_yaml %}
+date:
+  description: The target date, in the format `YYYY-MM-DD`.
+  required: false
+  type: string
+time:
+  description: The target time, in the format `HH:MM:SS`.
+  required: false
+  type: string
+datetime:
+  description: The target date and time, in the format `YYYY-MM-DD HH:MM:SS`.
+  required: false
+  type: string
+timestamp:
+  description: The target date and time, expressed as a UNIX timestamp.
+  required: false
+  type: float
+{% endoptions_yaml %}
+
+{% include actions/targets.md %}
+
+## Good to know
+
+- Use `date` and `time` together, or use `datetime` or `timestamp` on their own, to set both the date and the time in a single call.
+- The value you set must match what the helper stores. A date-only helper accepts a date, a time-only helper accepts a time, and a helper that stores both accepts either both fields or a single `datetime` or `timestamp` value.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/input_datetime.markdown
+++ b/source/_integrations/input_datetime.markdown
@@ -73,7 +73,7 @@ input_datetime:
         default: <today> 00:00 | 00:00 | <today>
 {% endconfiguration %}
 
-### Attributes
+## Attributes
 
 A datetime input entity's state exports several attributes that can be useful in
 automations and templates.
@@ -85,28 +85,11 @@ automations and templates.
 | `year`<br>`month`<br>`day` | The year, month and day of the date.<br>(only available if `has_date: true`)                 |
 | `timestamp`                | A timestamp representing the time held in the input.<br>(only available if `has_time: true`) |
 
-### Restore state
+## Restore state
 
 If you set a valid value for `initial`, this integration will start with the state set to that value. Otherwise, it will restore the state it had before Home Assistant stopping.
 
-### Actions
-
-Available actions: `input_datetime.set_datetime` and `input_datetime.reload`.
-
-#### input_datetime.set_datetime
-
-| Data attribute | Format String       | Description                                                                      |
-| -------------- | ------------------- | -------------------------------------------------------------------------------- |
-| `date`         | `%Y-%m-%d`          | This can be used to dynamically set the date.                                    |
-| `time`         | `%H:%M:%S`          | This can be used to dynamically set the time.                                    |
-| `datetime`     | `%Y-%m-%d %H:%M:%S` | This can be used to dynamically set both the date & time.                        |
-| `timestamp`    | N/A                 | This can be used to dynamically set both the date & time using a UNIX timestamp. |
-
-To set both the date and time in the same call, use `date` and `time` together, or use `datetime` or `timestamp` by itself. Using `datetime` or `timestamp` has the advantage that both can be set using one template.
-
-#### input_datetime.reload
-
-`input_datetime.reload` action allows one to reload `input_datetime`'s configuration without restarting Home Assistant itself.
+{% include integrations/actions.md %}
 
 ## Examples
 
@@ -127,7 +110,7 @@ automation:
 ```
 
 To dynamically set the `input_datetime` you can call
-`input_datetime.set_datetime`. The values for `date`, `time` and/or `datetime` must be in a certain format for the call to be successful. (See action description above.)
+`input_datetime.set_datetime`. The values for `date`, `time` and/or `datetime` must be in a certain format for the call to be successful. See the [Set input datetime value](/actions/input_datetime.set_datetime/) action for the expected formats.
 If you have a `datetime` object, you can use its `timestamp` method. Or, if you have a timestamp, you can just use it directly.
 
 ```yaml


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change

Moves the inline input datetime action documentation (`set_datetime` and `reload`) into dedicated pages under `source/_actions/`, and replaces the inline table on the integration page with the actions include. This brings the integration in line with the standardized action documentation structure.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

