### PR TITLE
Apple TV: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/apple_tv.append_keyboard_text.markdown
+++ b/source/_actions/apple_tv.append_keyboard_text.markdown
@@ -1,0 +1,73 @@
+---
+title: "Append keyboard text"
+action: apple_tv.append_keyboard_text
+domain: apple_tv
+description: "Appends text to the currently focused text input field on an Apple TV."
+related_actions:
+  - apple_tv.set_keyboard_text
+  - apple_tv.clear_keyboard_text
+---
+
+Use this action to add text to the currently focused input field on an Apple TV, without clearing the text that is already there.
+
+The on-screen keyboard must be focused on the Apple TV for this action to work.
+
+{% include actions/ui_header.md %}
+
+To append keyboard text from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Apple TV: Append keyboard text**.
+6. Choose the **Apple TV** you want to send text to, and enter the **Text**.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Apple TV:
+  description: The Apple TV to send text to.
+Text:
+  description: The text to append.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `apple_tv.append_keyboard_text`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: apple_tv.append_keyboard_text
+  data:
+    config_entry_id: YOUR_CONFIG_ENTRY_ID
+    text: " (2022)"
+{% endexample %}
+
+This adds ` (2022)` to the end of the text in the focused input field on the selected Apple TV.
+
+### Options in YAML
+
+{% options_yaml %}
+config_entry_id:
+  description: The config entry ID of the Apple TV to send text to.
+  required: true
+  type: string
+text:
+  description: The text to append.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+## Good to know
+
+- You can find the `config_entry_id` under {% my integrations title="**Settings** > **Devices & services**" %} > **Apple TV** > your device. It is the last part of the URL when viewing the device page.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/apple_tv.clear_keyboard_text.markdown
+++ b/source/_actions/apple_tv.clear_keyboard_text.markdown
@@ -1,0 +1,66 @@
+---
+title: "Clear keyboard text"
+action: apple_tv.clear_keyboard_text
+domain: apple_tv
+description: "Clears the text in the currently focused text input field on an Apple TV."
+related_actions:
+  - apple_tv.set_keyboard_text
+  - apple_tv.append_keyboard_text
+---
+
+Use this action to clear the text in the currently focused input field on an Apple TV. This is helpful for starting a fresh search from an automation or a script.
+
+The on-screen keyboard must be focused on the Apple TV for this action to work.
+
+{% include actions/ui_header.md %}
+
+To clear keyboard text from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Apple TV: Clear keyboard text**.
+6. Choose the **Apple TV** you want to clear the text on.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Apple TV:
+  description: The Apple TV to clear the text on.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `apple_tv.clear_keyboard_text`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: apple_tv.clear_keyboard_text
+  data:
+    config_entry_id: YOUR_CONFIG_ENTRY_ID
+{% endexample %}
+
+This clears the text in the focused input field on the selected Apple TV.
+
+### Options in YAML
+
+{% options_yaml %}
+config_entry_id:
+  description: The config entry ID of the Apple TV to clear the text on.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+## Good to know
+
+- You can find the `config_entry_id` under {% my integrations title="**Settings** > **Devices & services**" %} > **Apple TV** > your device. It is the last part of the URL when viewing the device page.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/apple_tv.set_keyboard_text.markdown
+++ b/source/_actions/apple_tv.set_keyboard_text.markdown
@@ -1,0 +1,73 @@
+---
+title: "Set keyboard text"
+action: apple_tv.set_keyboard_text
+domain: apple_tv
+description: "Sets the text in the currently focused text input field on an Apple TV."
+related_actions:
+  - apple_tv.append_keyboard_text
+  - apple_tv.clear_keyboard_text
+---
+
+Use this action to set the text in the currently focused input field on an Apple TV, replacing any text that is already there. This is helpful for filling in a search box or a sign-in field from an automation or a script.
+
+The on-screen keyboard must be focused on the Apple TV for this action to work.
+
+{% include actions/ui_header.md %}
+
+To set keyboard text from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Apple TV: Set keyboard text**.
+6. Choose the **Apple TV** you want to send text to, and enter the **Text**.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Apple TV:
+  description: The Apple TV to send text to.
+Text:
+  description: The text to set.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `apple_tv.set_keyboard_text`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: apple_tv.set_keyboard_text
+  data:
+    config_entry_id: YOUR_CONFIG_ENTRY_ID
+    text: "Severance"
+{% endexample %}
+
+This sets the focused input field on the selected Apple TV to `Severance`.
+
+### Options in YAML
+
+{% options_yaml %}
+config_entry_id:
+  description: The config entry ID of the Apple TV to send text to.
+  required: true
+  type: string
+text:
+  description: The text to set.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+## Good to know
+
+- You can find the `config_entry_id` under {% my integrations title="**Settings** > **Devices & services**" %} > **Apple TV** > your device. It is the last part of the URL when viewing the device page.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/apple_tv.markdown
+++ b/source/_integrations/apple_tv.markdown
@@ -194,45 +194,14 @@ triggers:
     from: "off"
     to: "on"
 actions:
-  - action: apple_tv.clear_search_text
-    target:
-      entity_id: remote.my_apple_tv_remote
+  - action: apple_tv.clear_keyboard_text
+    data:
+      config_entry_id: YOUR_CONFIG_ENTRY_ID
 ```
 
-Three actions are available for sending text to the focused input field. These
-require that the keyboard is currently focused on the device.
+Three actions are available for sending text to the focused input field: [Set keyboard text](/actions/apple_tv.set_keyboard_text/), [Append keyboard text](/actions/apple_tv.append_keyboard_text/), and [Clear keyboard text](/actions/apple_tv.clear_keyboard_text/). They require that the keyboard is currently focused on the device.
 
-### Action `apple_tv.set_keyboard_text`
-
-Sets the text in the currently focused text input field, replacing any existing text.
-
-- **Data attribute**: `config_entry_id`
-  - **Description**: The config entry ID of the Apple TV.
-  - **Optional**: No
-- **Data attribute**: `text`
-  - **Description**: The text to set.
-  - **Optional**: No
-
-### Action `apple_tv.append_keyboard_text`
-
-Appends text to the currently focused text input field without clearing existing text.
-
-- **Data attribute**: `config_entry_id`
-  - **Description**: The config entry ID of the Apple TV.
-  - **Optional**: No
-- **Data attribute**: `text`
-  - **Description**: The text to append.
-  - **Optional**: No
-
-### Action `apple_tv.clear_keyboard_text`
-
-Clears the text in the currently focused text input field.
-
-- **Data attribute**: `config_entry_id`
-  - **Description**: The config entry ID of the Apple TV.
-  - **Optional**: No
-
-The `config_entry_id` can be found under {% my integrations title="**Settings** > **Devices & services**" %} > **Apple TV** > your device — it is the last part of the URL when viewing the device page.
+The `config_entry_id` can be found under {% my integrations title="**Settings** > **Devices & services**" %} > **Apple TV** > your device. It is the last part of the URL when viewing the device page.
 
 ### Examples
 
@@ -253,6 +222,8 @@ actions:
       config_entry_id: YOUR_CONFIG_ENTRY_ID
       text: "Severance"
 ```
+
+{% include integrations/actions.md %}
 
 ## FAQ
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change

Moves the inline keyboard text action documentation (`set_keyboard_text`, `append_keyboard_text`, and `clear_keyboard_text`) into dedicated pages under `source/_actions/`, and surfaces them on the integration page with the actions include. This also fixes an example automation that referenced the non-existent `apple_tv.clear_search_text` action; the correct action is `apple_tv.clear_keyboard_text`.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

