### PR TITLE
Input select: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/input_select.reload.markdown
+++ b/source/_actions/input_select.reload.markdown
@@ -1,0 +1,49 @@
+---
+title: "Reload input selects"
+action: input_select.reload
+domain: input_select
+description: "Reloads the input select helpers from the YAML configuration."
+related_actions:
+  - input_select.select_option
+  - input_select.set_options
+---
+
+Use this action to reload the input select helpers you configured in YAML, without restarting Home Assistant. Helpers you created through the UI are not affected.
+
+{% include actions/ui_header.md %}
+
+To reload the input select helpers from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Input select: Reload input selects**.
+6. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label. Only users with administrator rights can run this action.
+
+### Options in the UI
+
+This action has no additional options in the UI.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `input_select.reload`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: input_select.reload
+{% endexample %}
+
+This reloads the input select helpers from your YAML configuration.
+
+## Good to know
+
+- Run this action after you change the input select helpers in your YAML configuration so the changes take effect without a restart.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/input_select.select_first.markdown
+++ b/source/_actions/input_select.select_first.markdown
@@ -1,0 +1,52 @@
+---
+title: "Select first input select option"
+action: input_select.select_first
+domain: input_select
+description: "Selects the first option of an input select."
+related_actions:
+  - input_select.select_last
+  - input_select.select_option
+---
+
+Use this action to select the first option of one or more input selects. An input select is a helper you can use in automations and scripts to pick from a list of predefined options.
+
+{% include actions/ui_header.md %}
+
+To select the first option from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the input select you want to change.
+6. From the actions shown for that target, select **Select first input select option**.
+7. Select **Save**.
+
+### Options in the UI
+
+This action has no additional options in the UI.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `input_select.select_first`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: input_select.select_first
+  target:
+    entity_id: input_select.who_cooks
+{% endexample %}
+
+This selects the first option on the `input_select.who_cooks` helper.
+
+{% include actions/targets.md %}
+
+## Good to know
+
+- The first option is the one at the top of the list configured for the input select.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/input_select.select_last.markdown
+++ b/source/_actions/input_select.select_last.markdown
@@ -1,0 +1,52 @@
+---
+title: "Select last input select option"
+action: input_select.select_last
+domain: input_select
+description: "Selects the last option of an input select."
+related_actions:
+  - input_select.select_first
+  - input_select.select_option
+---
+
+Use this action to select the last option of one or more input selects. An input select is a helper you can use in automations and scripts to pick from a list of predefined options.
+
+{% include actions/ui_header.md %}
+
+To select the last option from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the input select you want to change.
+6. From the actions shown for that target, select **Select last input select option**.
+7. Select **Save**.
+
+### Options in the UI
+
+This action has no additional options in the UI.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `input_select.select_last`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: input_select.select_last
+  target:
+    entity_id: input_select.who_cooks
+{% endexample %}
+
+This selects the last option on the `input_select.who_cooks` helper.
+
+{% include actions/targets.md %}
+
+## Good to know
+
+- The last option is the one at the bottom of the list configured for the input select.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/input_select.select_next.markdown
+++ b/source/_actions/input_select.select_next.markdown
@@ -1,0 +1,65 @@
+---
+title: "Select next input select option"
+action: input_select.select_next
+domain: input_select
+description: "Selects the next option of an input select."
+related_actions:
+  - input_select.select_previous
+  - input_select.select_option
+---
+
+Use this action to move one or more input selects to the next option in their list. An input select is a helper you can use in automations and scripts to pick from a list of predefined options.
+
+{% include actions/ui_header.md %}
+
+To select the next option from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the input select you want to change.
+6. From the actions shown for that target, select **Select next input select option**.
+7. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Cycle:
+  description: When enabled, selecting the next option after the last one cycles back to the first option.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `input_select.select_next`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: input_select.select_next
+  target:
+    entity_id: input_select.who_cooks
+{% endexample %}
+
+This selects the next option on the `input_select.who_cooks` helper.
+
+### Options in YAML
+
+{% options_yaml %}
+cycle:
+  description: When enabled, selecting the next option after the last one cycles back to the first option.
+  required: false
+  type: boolean
+  default: true
+{% endoptions_yaml %}
+
+{% include actions/targets.md %}
+
+## Good to know
+
+- By default, the selection cycles from the last option back to the first. Set `cycle` to `false` to stop at the last option instead.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/input_select.select_option.markdown
+++ b/source/_actions/input_select.select_option.markdown
@@ -1,0 +1,67 @@
+---
+title: "Select input select option"
+action: input_select.select_option
+domain: input_select
+description: "Selects an option of an input select."
+related_actions:
+  - input_select.set_options
+  - input_select.select_next
+---
+
+Use this action to select a specific option of one or more input selects. An input select is a helper you can use in automations and scripts to pick from a list of predefined options.
+
+{% include actions/ui_header.md %}
+
+To select an option from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the input select you want to change.
+6. From the actions shown for that target, select **Select input select option**.
+7. Enter the **Option** you want to select.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Option:
+  description: The option to select.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `input_select.select_option`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: input_select.select_option
+  target:
+    entity_id: input_select.who_cooks
+  data:
+    option: "Paulus"
+{% endexample %}
+
+This selects the `Paulus` option on the `input_select.who_cooks` helper.
+
+### Options in YAML
+
+{% options_yaml %}
+option:
+  description: The option to select.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/targets.md %}
+
+## Good to know
+
+- The option you select must be one of the options configured for the input select.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/input_select.select_previous.markdown
+++ b/source/_actions/input_select.select_previous.markdown
@@ -1,0 +1,65 @@
+---
+title: "Select previous input select option"
+action: input_select.select_previous
+domain: input_select
+description: "Selects the previous option of an input select."
+related_actions:
+  - input_select.select_next
+  - input_select.select_option
+---
+
+Use this action to move one or more input selects to the previous option in their list. An input select is a helper you can use in automations and scripts to pick from a list of predefined options.
+
+{% include actions/ui_header.md %}
+
+To select the previous option from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the input select you want to change.
+6. From the actions shown for that target, select **Select previous input select option**.
+7. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Cycle:
+  description: When enabled, selecting the previous option before the first one cycles to the last option.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `input_select.select_previous`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: input_select.select_previous
+  target:
+    entity_id: input_select.who_cooks
+{% endexample %}
+
+This selects the previous option on the `input_select.who_cooks` helper.
+
+### Options in YAML
+
+{% options_yaml %}
+cycle:
+  description: When enabled, selecting the previous option before the first one cycles to the last option.
+  required: false
+  type: boolean
+  default: true
+{% endoptions_yaml %}
+
+{% include actions/targets.md %}
+
+## Good to know
+
+- By default, the selection cycles from the first option to the last. Set `cycle` to `false` to stop at the first option instead.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/input_select.set_options.markdown
+++ b/source/_actions/input_select.set_options.markdown
@@ -1,0 +1,70 @@
+---
+title: "Set input select options"
+action: input_select.set_options
+domain: input_select
+description: "Sets the options of an input select."
+related_actions:
+  - input_select.select_option
+  - input_select.reload
+---
+
+Use this action to replace the full list of options for one or more input selects. An input select is a helper you can use in automations and scripts to pick from a list of predefined options.
+
+{% include actions/ui_header.md %}
+
+To set the options from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the input select you want to change.
+6. From the actions shown for that target, select **Set input select options**.
+7. Enter the **Options** you want to set.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Options:
+  description: The full list of options to set. At least one option is required.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `input_select.set_options`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: input_select.set_options
+  target:
+    entity_id: input_select.who_cooks
+  data:
+    options:
+      - "Alice"
+      - "Bob"
+      - "Paulus"
+{% endexample %}
+
+This replaces the options of the `input_select.who_cooks` helper with the three listed values.
+
+### Options in YAML
+
+{% options_yaml %}
+options:
+  description: The full list of options to set. At least one option is required.
+  required: true
+  type: list
+{% endoptions_yaml %}
+
+{% include actions/targets.md %}
+
+## Good to know
+
+- This action replaces the entire list of options. The currently selected option is kept only if it is still part of the new list.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/input_select.markdown
+++ b/source/_integrations/input_select.markdown
@@ -67,39 +67,13 @@ input_select:
 Because YAML defines [booleans](https://yaml.org/type/bool.html) as equivalent, any variations of 'On', 'Yes', 'Y', 'Off', 'No', or 'N'  (regardless of case) used as option names will be replaced by True and False unless they are defined in quotation marks.
 {% endnote %}
 
-### Restore state
+## Restore state
 
 If you set a valid value for `initial` this integration will start with the state set to that value. Otherwise, it will restore the state it had before Home Assistant stopping.
 
-### Actions
+{% include integrations/actions.md %}
 
-This integration provides three actions to modify the state of the `input_select`.
-
-| Action          | Data                        | Description                                           |
-| --------------- | --------------------------- | ----------------------------------------------------- |
-| `select_option` | `option`                    | This can be used to select a specific option.         |
-| `set_options`   | `options`<br>`entity_id(s)` | Set the options for specific `input_select` entities. |
-| `select_first`  |                             | Select the first option.                              |
-| `select_last`   |                             | Select the last option.                               |
-| `reload`        |                             | Reload `input_select` configuration                   |
-
-#### Action `input_select.select_next`
-
-Select the next option.
-
-| Data attribute | Optional | Description                                                         |
-| ---------------------- | -------- | ------------------------------------------------------------------- |
-| `cycle`                | yes      | Whether to cycle to the first value after the last. Default: `true` |
-
-#### Action `input_select.select_previous`
-
-Select the previous option.
-
-| Data attribute | Optional | Description                                                          |
-| ---------------------- | -------- | -------------------------------------------------------------------- |
-| `cycle`                | yes      | Whether to cycle to the last value before the first. Default: `true` |
-
-### Scenes
+## Scenes
 
 Specifying a target option in a [Scene](/integrations/scene/) is simple:
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change

Moves the inline input select action documentation (`select_option`, `set_options`, `select_first`, `select_last`, `select_next`, `select_previous`, and `reload`) into dedicated pages under `source/_actions/`, and replaces the inline table on the integration page with the actions include. This brings the integration in line with the standardized action documentation structure.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

