### PR TITLE
Input text: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/input_text.reload.markdown
+++ b/source/_actions/input_text.reload.markdown
@@ -1,0 +1,48 @@
+---
+title: "Reload input texts"
+action: input_text.reload
+domain: input_text
+description: "Reloads the input text helpers from the YAML configuration."
+related_actions:
+  - input_text.set_value
+---
+
+Use this action to reload the input text helpers you configured in YAML, without restarting Home Assistant. Helpers you created through the UI are not affected.
+
+{% include actions/ui_header.md %}
+
+To reload the input text helpers from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Input text: Reload input texts**.
+6. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label. Only users with administrator rights can run this action.
+
+### Options in the UI
+
+This action has no additional options in the UI.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `input_text.reload`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: input_text.reload
+{% endexample %}
+
+This reloads the input text helpers from your YAML configuration.
+
+## Good to know
+
+- Run this action after you change the input text helpers in your YAML configuration so the changes take effect without a restart.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/input_text.reload.markdown
+++ b/source/_actions/input_text.reload.markdown
@@ -37,6 +37,10 @@ action: |
 
 This reloads the input text helpers from your YAML configuration.
 
+### Options in YAML
+
+This action has no additional options in YAML.
+
 ## Good to know
 
 - Run this action after you change the input text helpers in your YAML configuration so the changes take effect without a restart.

--- a/source/_actions/input_text.set_value.markdown
+++ b/source/_actions/input_text.set_value.markdown
@@ -1,0 +1,66 @@
+---
+title: "Set input text value"
+action: input_text.set_value
+domain: input_text
+description: "Sets the value of an input text."
+related_actions:
+  - input_text.reload
+---
+
+Use this action to set the text value of one or more input texts. An input text is a helper you can use in automations and scripts to store a line of text, such as a message or a name.
+
+{% include actions/ui_header.md %}
+
+To set an input text value from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the input text you want to set.
+6. From the actions shown for that target, select **Set input text value**.
+7. Enter the **Value** you want to set.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Value:
+  description: The target value to set.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `input_text.set_value`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: input_text.set_value
+  target:
+    entity_id: input_text.welcome_message
+  data:
+    value: "Hello!"
+{% endexample %}
+
+This sets the `input_text.welcome_message` helper to `Hello!`.
+
+### Options in YAML
+
+{% options_yaml %}
+value:
+  description: The target value to set.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/targets.md %}
+
+## Good to know
+
+- The value must fit within the `min` and `max` length you configured for the input text, and it must match the configured pattern if one is set.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/input_text.markdown
+++ b/source/_integrations/input_text.markdown
@@ -79,20 +79,13 @@ input_text:
         default: text
 {% endconfiguration %}
 
-### Actions
+{% include integrations/actions.md %}
 
-This integration provides an action to modify the state of the `input_text` and an action to reload the `input_text` configuration without restarting Home Assistant itself.
-
-| Action      | Data                      | Description                                       |
-| ----------- | ------------------------- | ------------------------------------------------- |
-| `set_value` | `value`<br>`entity_id(s)` | Set the value for specific `input_text` entities. |
-| `reload`    |                           | Reload `input_text` configuration                 |
-
-### Restore state
+## Restore state
 
 If you set a valid value for `initial` this integration will start with state set to that value. Otherwise, it will restore the state it had before Home Assistant stopping.
 
-### Scenes
+## Scenes
 
 To set the state of the input_text in a [Scene](/integrations/scene/):
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change

Moves the inline input text action documentation (`set_value` and `reload`) into dedicated pages under `source/_actions/`, and replaces the inline table on the integration page with the actions include. This brings the integration in line with the standardized action documentation structure.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

