### PR TITLE
Input button: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/input_button.press.markdown
+++ b/source/_actions/input_button.press.markdown
@@ -7,7 +7,7 @@ related_actions:
   - input_button.reload
 ---
 
-Use this action to press one or more input buttons. An input button is a stateless helper you can use in automations and scripts, for example to trigger a routine on demand. Pressing it does not store a value; it simply fires an event you can respond to.
+Use this action to press one or more input buttons. An input button is a stateless helper you can use in automations and scripts, for example to trigger a routine on demand. Pressing it updates its timestamp, which triggers a state change you can respond to in automations.
 
 {% include actions/ui_header.md %}
 
@@ -23,7 +23,7 @@ To press an input button from an automation or a script:
 
 ### Options in the UI
 
-This action has no additional options in the UI.
+This action has no additional options beyond the target.
 
 {% include actions/yaml_header.md %}
 
@@ -37,6 +37,10 @@ action: |
 {% endexample %}
 
 This presses the `input_button.my_button` helper.
+
+### Options in YAML
+
+This action has no additional YAML options beyond the target.
 
 {% include actions/targets.md %}
 

--- a/source/_actions/input_button.press.markdown
+++ b/source/_actions/input_button.press.markdown
@@ -1,0 +1,51 @@
+---
+title: "Press input button"
+action: input_button.press
+domain: input_button
+description: "Presses an input button."
+related_actions:
+  - input_button.reload
+---
+
+Use this action to press one or more input buttons. An input button is a stateless helper you can use in automations and scripts, for example to trigger a routine on demand. Pressing it does not store a value; it simply fires an event you can respond to.
+
+{% include actions/ui_header.md %}
+
+To press an input button from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the input button you want to press.
+6. From the actions shown for that target, select **Press input button**.
+7. Select **Save**.
+
+### Options in the UI
+
+This action has no additional options in the UI.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `input_button.press`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: input_button.press
+  target:
+    entity_id: input_button.my_button
+{% endexample %}
+
+This presses the `input_button.my_button` helper.
+
+{% include actions/targets.md %}
+
+## Good to know
+
+- Pressing an input button updates its timestamp and fires a state change. Automations that trigger on that helper run in response.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/input_button.reload.markdown
+++ b/source/_actions/input_button.reload.markdown
@@ -1,0 +1,48 @@
+---
+title: "Reload input buttons"
+action: input_button.reload
+domain: input_button
+description: "Reloads the input button helpers from the YAML configuration."
+related_actions:
+  - input_button.press
+---
+
+Use this action to reload the input button helpers you configured in YAML, without restarting Home Assistant. Helpers you created through the UI are not affected.
+
+{% include actions/ui_header.md %}
+
+To reload the input button helpers from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Input button: Reload input buttons**.
+6. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label. Only users with administrator rights can run this action.
+
+### Options in the UI
+
+This action has no additional options in the UI.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `input_button.reload`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: input_button.reload
+{% endexample %}
+
+This reloads the input button helpers from your YAML configuration.
+
+## Good to know
+
+- Run this action after you change the input button helpers in your YAML configuration so the changes take effect without a restart.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/input_button.reload.markdown
+++ b/source/_actions/input_button.reload.markdown
@@ -20,7 +20,7 @@ To reload the input button helpers from an automation or a script:
 5. From the search box, search for and select **Input button: Reload input buttons**.
 6. Select **Save**.
 
-This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label. Only users with administrator rights can run this action.
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
 
 ### Options in the UI
 
@@ -37,9 +37,14 @@ action: |
 
 This reloads the input button helpers from your YAML configuration.
 
+### Options in YAML
+
+This action has no additional options in YAML.
+
 ## Good to know
 
 - Run this action after you change the input button helpers in your YAML configuration so the changes take effect without a restart.
+- Only administrators can run this action.
 
 {% include actions/try_it.md %}
 

--- a/source/_integrations/input_button.markdown
+++ b/source/_integrations/input_button.markdown
@@ -76,15 +76,4 @@ actions:
       message: "My button has been pressed!"
 ```
 
-## Actions
-
-The input button entities exposes a single action:
-{% my developer_call_service service="input_button.press" %}
-
-This action can be used to trigger a button press for that entity.
-
-```yaml
-- action: input_button.press
-  target:
-    entity_id: input_button.my_button
-```
+{% include integrations/actions.md %}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change

Moves the inline `press` action documentation into a dedicated page under `source/_actions/`, adds a dedicated page for the previously undocumented `reload` action, and replaces the inline section on the integration page with the actions include. This brings the integration in line with the standardized action documentation structure.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

