### PR TITLE
Reolink: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/reolink.play_chime.markdown
+++ b/source/_actions/reolink.play_chime.markdown
@@ -1,0 +1,71 @@
+---
+title: "Play chime"
+action: reolink.play_chime
+domain: reolink
+description: "Plays a ringtone on a Reolink Chime."
+related_actions:
+  - reolink.ptz_move
+---
+
+Use this action to play a ringtone on one or more Reolink Chime devices, for example from an automation when motion is detected.
+
+{% include actions/ui_header.md %}
+
+To play a ringtone from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Reolink: Play chime**.
+6. Choose the **Target chime** and the **Ringtone** you want to play.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label. You select the chime through the **Target chime** option instead.
+
+### Options in the UI
+
+{% options_ui %}
+Target chime:
+  description: The Reolink Chime to play the ringtone on.
+Ringtone:
+  description: The ringtone to play.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `reolink.play_chime`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: reolink.play_chime
+  data:
+    device_id:
+      - 12a34b56c7d8ef9ghijklm0n1op2345q
+    ringtone: operetta
+{% endexample %}
+
+This plays the `operetta` ringtone on the selected Reolink Chime.
+
+### Options in YAML
+
+{% options_yaml %}
+device_id:
+  description: The list of device IDs of the Reolink Chimes to play the ringtone on.
+  required: true
+  type: list
+ringtone:
+  description: "The ringtone to play. One of: `citybird`, `originaltune`, `pianokey`, `loop`, `attraction`, `hophop`, `goodday`, `operetta`, `moonlight`, or `waybackhome`."
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+## Good to know
+
+- This action only works with Reolink Chime devices. Other Reolink devices are not shown as a target.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/reolink.ptz_move.markdown
+++ b/source/_actions/reolink.ptz_move.markdown
@@ -1,0 +1,66 @@
+---
+title: "PTZ move"
+action: reolink.ptz_move
+domain: reolink
+description: "Moves a Reolink camera at a specific speed."
+related_actions:
+  - reolink.play_chime
+---
+
+Use this action to move a Reolink <abbr title="pan, tilt, and zoom">PTZ</abbr> camera at a speed you choose. Some Reolink PTZ cameras can move at different speeds. For those cameras, this action works together with the **PTZ left**, **right**, **up**, **down**, **zoom in**, and **zoom out** button entities.
+
+{% include actions/ui_header.md %}
+
+To move a camera from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Reolink PTZ button entity you want to move, for example **PTZ left**.
+6. From the actions shown for that target, select **PTZ move**.
+7. Enter the **Speed** you want to move at.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Speed:
+  description: The speed to move at, from 1 to 64.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `reolink.ptz_move`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: reolink.ptz_move
+  target:
+    entity_id: button.trackmix_ptz_left
+  data:
+    speed: 10
+{% endexample %}
+
+This moves the camera left at speed `10` using the `button.trackmix_ptz_left` entity.
+
+### Options in YAML
+
+{% options_yaml %}
+speed:
+  description: The speed to move at, from 1 to 64.
+  required: true
+  type: integer
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="button" %}
+
+## Good to know
+
+- If the PTZ button entities for a camera do not appear when you choose a target, that camera does not support custom PTZ speeds.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/reolink.markdown
+++ b/source/_integrations/reolink.markdown
@@ -234,14 +234,7 @@ Depending on the supported features of the camera ([see specifications of the ca
 
 **Guard set current position** will set the current position as the new guard position.
 
-#### Action reolink.ptz_move
-
-Some Reolink <abbr title="pan, tilt, and zoom">PTZ</abbr> cameras can move at different speeds. For those cameras, the `reolink.ptz_move` action can be used in combination with the **PTZ left**, **right**, **up**, **down**, **zoom in**, or **zoom out** entity which allows specifying the speed attribute. If the <abbr title="pan, tilt, and zoom">PTZ</abbr> button entities for a specific camera are not shown under **Choose entity** under **targets** of the `reolink.ptz_move` action, it means that this camera does not support custom <abbr title="pan, tilt, and zoom">PTZ</abbr> speeds.
-
-| Data attribute | Optional | Description                                                                                                                         |
-| ---------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| `entity_id`            | no       | Name of the Reolink <abbr title="pan, tilt, and zoom">PTZ</abbr> button entity to control. For example, `button.trackmix_ptz_left`. |
-| `speed`                | no       | <abbr title="pan, tilt, and zoom">PTZ</abbr> move speed. For example `10`.                                                          |
+Some Reolink <abbr title="pan, tilt, and zoom">PTZ</abbr> cameras can move at different speeds. For those cameras, the [PTZ move](/actions/reolink.ptz_move/) action works in combination with the **PTZ left**, **right**, **up**, **down**, **zoom in**, or **zoom out** button entities, which let you specify the speed. If those button entities are not shown when you choose a target for the action, that camera does not support custom <abbr title="pan, tilt, and zoom">PTZ</abbr> speeds.
 
 ### Select entities
 
@@ -282,14 +275,7 @@ Depending on the supported features of the camera ([see specifications of the ca
 
 **Hub scene modes** can be set in the Reolink app/client. The scene names are loaded into Home Assistant at the start of the integration. After adding new custom scenes, restart the Reolink integration.
 
-#### Action reolink.play_chime
-
-To play a ringtone on a Reolink chime, the `reolink.play_chime` action can be used.
-
-| Data attribute | Optional | Description                                                                                                                                 |
-| ---------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| `device_id`            | no       | List of device ids of the Reolink Chimes to control. For example, `- 12a34b56c7d8ef9ghijklm0n1op2345q`.                             |
-| `ringtone`             | no       | The ringtone to play. For example `operetta`.                                                                                       |
+To play a ringtone on a Reolink Chime, use the [Play chime](/actions/reolink.play_chime/) action.
 
 ### Siren entities
 
@@ -383,6 +369,8 @@ Therefore the update entity in Home Assistant can find and install a firmware up
 If the camera supports recording to an SD card or NVR/Hub ([see specifications of the camera model on Reolink.com](#tested-models)), the Reolink integration will provide a media browser through which recorded videos of the camera can be accessed.
 In the sidebar, select "Media" > "Reolink" and select the **camera** of which you want to see recordings. Optionally, select if you want a high or low **resolution** stream and select the recording **date**. Here, all available video files of that day will be shown.
 Recordings up to 1 month old can be viewed in Home Assistant.
+
+{% include integrations/actions.md %}
 
 ## Tested models
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change

Moves the inline ptz_move and play_chime action documentation into dedicated pages under `source/_actions/`, and replaces the inline table on the integration page with the actions include. This brings the integration in line with the standardized action documentation structure.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

