### PR TITLE
Roborock: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/roborock.get_maps.markdown
+++ b/source/_actions/roborock.get_maps.markdown
@@ -1,0 +1,51 @@
+---
+title: "Get maps"
+action: roborock.get_maps
+domain: roborock
+description: "Retrieves the map and room information of a Roborock vacuum."
+related_actions:
+  - roborock.set_vacuum_goto_position
+  - roborock.get_vacuum_current_position
+---
+
+Use this action to retrieve the maps available on a Roborock vacuum, along with details about any named rooms on each map. This returns the name of each map and the name and ID number of each room.
+
+This action returns its result in a response variable, which you can use in later steps of the same automation or script. It does not move the vacuum.
+
+{% include actions/ui_header.md %}
+
+To get a vacuum's maps from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Roborock vacuum whose maps you want to retrieve.
+6. From the actions shown for that target, select **Get maps**.
+7. Select **Save**.
+
+This action has no additional options in the UI.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `roborock.get_maps`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: roborock.get_maps
+  target:
+    entity_id: vacuum.roborock_s7
+  response_variable: vacuum_maps
+{% endexample %}
+
+This action has no additional options in YAML.
+
+{% include actions/targets.md domain="vacuum" %}
+
+## Response data
+
+The action returns the name of each map and the name and ID number of each room on it. You can use the room IDs to clean a specific room.
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/roborock.get_vacuum_current_position.markdown
+++ b/source/_actions/roborock.get_vacuum_current_position.markdown
@@ -1,0 +1,61 @@
+---
+title: "Get current position"
+action: roborock.get_vacuum_current_position
+domain: roborock
+description: "Retrieves the current position of a Roborock vacuum."
+related_actions:
+  - roborock.set_vacuum_goto_position
+  - roborock.get_maps
+---
+
+Use this action to retrieve the current position of a Roborock vacuum as X and Y coordinates.
+
+This action returns its result in a response variable, which you can use in later steps of the same automation or script. It does not move the vacuum.
+
+{% include actions/ui_header.md %}
+
+To get a vacuum's current position from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Roborock vacuum whose position you want to retrieve.
+6. From the actions shown for that target, select **Get current position**.
+7. Select **Save**.
+
+This action has no additional options in the UI.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `roborock.get_vacuum_current_position`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: roborock.get_vacuum_current_position
+  target:
+    entity_id: vacuum.roborock_s7
+  response_variable: vacuum_position
+{% endexample %}
+
+This action has no additional options in YAML.
+
+{% include actions/targets.md domain="vacuum" %}
+
+## Response data
+
+The action returns the X and Y coordinates of the vacuum, keyed by entity ID:
+
+```yaml
+vacuum.roborock_s7:
+  x: 28081
+  y: 25168
+```
+
+## Good to know
+
+- This is a cloud call meant for diagnostics, not for automations. Frequent requests can lead to rate limiting.
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/roborock.set_vacuum_goto_position.markdown
+++ b/source/_actions/roborock.set_vacuum_goto_position.markdown
@@ -1,0 +1,68 @@
+---
+title: "Go to position"
+action: roborock.set_vacuum_goto_position
+domain: roborock
+description: "Sends a Roborock vacuum to a specific position."
+related_actions:
+  - roborock.get_vacuum_current_position
+  - roborock.get_maps
+---
+
+Use this action to send a Roborock vacuum to a specific position on its map. You give the position as X and Y coordinates, which are relative to the dock.
+
+{% include actions/ui_header.md %}
+
+To send a vacuum to a position from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Roborock vacuum you want to send.
+6. From the actions shown for that target, select **Go to position**.
+7. Enter the **X-coordinate** and **Y-coordinate** you want the vacuum to go to.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+X-coordinate:
+  description: "The X-coordinate to send the vacuum to. Coordinates are relative to the dock: x=25500, y=25500 is the dock position."
+Y-coordinate:
+  description: "The Y-coordinate to send the vacuum to. Coordinates are relative to the dock: x=25500, y=25500 is the dock position."
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `roborock.set_vacuum_goto_position`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: roborock.set_vacuum_goto_position
+  target:
+    entity_id: vacuum.roborock_s7
+  data:
+    x: 27500
+    y: 32000
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+x:
+  description: "The X-coordinate to send the vacuum to. Coordinates are relative to the dock: x=25500, y=25500 is the dock position."
+  required: true
+  type: integer
+y:
+  description: "The Y-coordinate to send the vacuum to. Coordinates are relative to the dock: x=25500, y=25500 is the dock position."
+  required: true
+  type: integer
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="vacuum" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/roborock.markdown
+++ b/source/_integrations/roborock.markdown
@@ -293,61 +293,6 @@ There are currently four buttons that allow you to reset the various maintenance
 
 In addition, some vacuums allow routines to be set up in the app. For each of those routines, a button entity will be created, allowing you to trigger it.
 
-#### Actions
-
-##### Action Set Vacuum Goto Position
-
-The `roborock.set_vacuum_goto_position` action will set the vacuum to go to
-the specified coordinates.
-
-- **Data attribute**: `entity_id`
-  - **Description**: Only act on a specific robot.
-  - **Optional**: No.
-- **Data attribute**: `x`
-  - **Description**: X-coordinate, integer value. The dock is located at x-coordinate 25500.
-  - **Optional**: No.
-- **Data attribute**: `y`
-  - **Description**: Y-coordinate, integer value. The dock is located at y-coordinate 25500.
-  - **Optional**: No.
-
-##### Action Get Vacuum Current Position
-
-The `roborock.get_vacuum_current_position` action will get the current position of the vacuum. This
-is a cloud call and should only be used for diagnostics. This is not meant to be used for
-automations. Frequent requests can lead to rate limiting. 
-
-- **Data attribute**: `entity_id`
-  - **Description**: Only act on a specific robot.
-  - **Optional**: No.
-
-Example:
-
-```yaml
-action: roborock.get_vacuum_current_position
-target:
-  entity_id: vacuum.roborock_s7
-data: {}
-```
-
-- **Result**: You will get a response like this:
-
-  ```yaml
-  vacuum.roborock_s7:
-    x: 28081
-    y: 25168
-  ```
-
-##### Action Get Maps
-
-The `roborock.get_maps` action will return the maps available on the device and
-details about any named rooms on each map.
-
-- **Data attribute**: `entity_id`
-  - **Description**: Get maps for a specific device
-  - **Optional**: No.
-
-This returns the name of the map, and the room names and ID numbers.
-
 ### Dyad devices
 
 Roborock wet/dry vacuums currently expose some entities through an MQTT connection - it is currently cloud dependent.
@@ -390,6 +335,8 @@ Roborock Zeo One currently exposes some entities through an MQTT connection - it
 
 - **Error**
   - **Description**: The current error of the Zeo, if one exists.
+
+{% include integrations/actions.md %}
 
 ## Removing the integration
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change

Moves the inline Roborock action documentation (`set_vacuum_goto_position`, `get_vacuum_current_position`, and `get_maps`) into dedicated pages under `source/_actions/`, and replaces the inline blocks on the integration page with the actions include. This brings the integration in line with the standardized action documentation structure.

While verifying every field against the core `services.yaml` and `strings.json`, I dropped the `entity_id` data attribute from the field lists, since it is the action target rather than a data field.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

