### PR TITLE
Wake on LAN: migrate action to a dedicated action page

### DIFF
--- a/source/_actions/wake_on_lan.send_magic_packet.markdown
+++ b/source/_actions/wake_on_lan.send_magic_packet.markdown
@@ -27,7 +27,7 @@ This action does not support targets. In the UI, you are not prompted to choose 
 MAC address:
   description: The MAC address of the device to wake up.
 SecureOn password:
-  description: The SecureOn password, in 6-byte hexadecimal format, to append to the magic packet.
+  description: The SecureOn password, in 6-byte hexadecimal format, to append to the magic packet. For example, `00:aa:22:bb:33:cc`.
 Broadcast address:
   description: The IP address to send the magic packet to. Defaults to `255.255.255.255` and is normally not changed.
 Broadcast port:
@@ -53,7 +53,7 @@ mac:
   required: true
   type: string
 secureon_password:
-  description: The SecureOn password, in 6-byte hexadecimal format, to append to the magic packet.
+  description: The SecureOn password, in 6-byte hexadecimal format, to append to the magic packet. For example, `00:aa:22:bb:33:cc`.
   required: false
   type: string
 broadcast_address:

--- a/source/_actions/wake_on_lan.send_magic_packet.markdown
+++ b/source/_actions/wake_on_lan.send_magic_packet.markdown
@@ -1,0 +1,79 @@
+---
+title: "Send magic packet"
+action: wake_on_lan.send_magic_packet
+domain: wake_on_lan
+description: "Sends a magic packet to wake up a device with Wake-on-LAN capabilities."
+---
+
+Use this action to send a _magic packet_ to wake up a device with [Wake-on-LAN](https://en.wikipedia.org/wiki/Wake-on-LAN) capabilities, for example to turn on a computer from an automation.
+
+{% include actions/ui_header.md %}
+
+To send a magic packet from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Wake on LAN: Send magic packet**.
+6. Enter the **MAC address** of the device you want to wake up, and fill in any other options you want to use.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label. You enter the device's MAC address through the **MAC address** option instead.
+
+### Options in the UI
+
+{% options_ui %}
+MAC address:
+  description: The MAC address of the device to wake up.
+SecureOn password:
+  description: The SecureOn password, in 6-byte hexadecimal format, to append to the magic packet.
+Broadcast address:
+  description: The IP address to send the magic packet to. Defaults to `255.255.255.255` and is normally not changed.
+Broadcast port:
+  description: The port to send the magic packet to. Defaults to `9` and is normally not changed.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `wake_on_lan.send_magic_packet`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: wake_on_lan.send_magic_packet
+  data:
+    mac: "00:40:13:ed:f1:32"
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+mac:
+  description: The MAC address of the device to wake up.
+  required: true
+  type: string
+secureon_password:
+  description: The SecureOn password, in 6-byte hexadecimal format, to append to the magic packet.
+  required: false
+  type: string
+broadcast_address:
+  description: The IP address to send the magic packet to. Normally not changed.
+  required: false
+  type: string
+  default: "255.255.255.255"
+broadcast_port:
+  description: The port to send the magic packet to. Normally not changed.
+  required: false
+  type: integer
+  default: 9
+{% endoptions_yaml %}
+
+## Good to know
+
+- This usually only works if the target device is connected to the same network. Routing the magic packet to a different subnet requires special configuration on your router, or may not be possible. The router feature that does this is often named "IP Helper", but not all routers support it.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/wake_on_lan.send_magic_packet.markdown
+++ b/source/_actions/wake_on_lan.send_magic_packet.markdown
@@ -5,7 +5,7 @@ domain: wake_on_lan
 description: "Sends a magic packet to wake up a device with Wake-on-LAN capabilities."
 ---
 
-Use this action to send a _magic packet_ to wake up a device with [Wake-on-LAN](https://en.wikipedia.org/wiki/Wake-on-LAN) capabilities, for example to turn on a computer from an automation.
+Use this action to send a _magic packet_ to wake up a device by using [Wake-on-LAN](https://en.wikipedia.org/wiki/Wake-on-LAN), for example to turn on a computer from an automation.
 
 {% include actions/ui_header.md %}
 

--- a/source/_integrations/wake_on_lan.markdown
+++ b/source/_integrations/wake_on_lan.markdown
@@ -44,44 +44,16 @@ Broadcast port:
   description: The port to send the magic packet to.
 {% endconfiguration_basic %}
 
-### Integration services
+## Integration services
 
-Available services: `send_magic_packet`.
-
-To only use this service, add the following to your {% term "`configuration.yaml`" %} file
+To use only the [Send magic packet](/actions/wake_on_lan.send_magic_packet/) action, without the button or switch, add the following to your {% term "`configuration.yaml`" %} file:
 
 ```yaml
 # Example configuration.yaml entry
 wake_on_lan:
 ```
 
-### Actions
-
-Available actions: `send_magic_packet`.
-
-#### Action: Send magic packet
-
-The `wake_on_lan.send_magic_packet` action sends a _magic packet_ to wake up a device with 'Wake on LAN' capabilities.
-
-| Data attribute | Optional | Description                                           |
-| ---------------------- | -------- | ----------------------------------------------------- |
-| `mac`                  | no       | MAC address of the device to wake up.                 |
-| `secureon_password`    | yes      | The SecureOn password to append to the magic packet.  |
-| `broadcast_address`    | yes      | Optional broadcast IP where to send the magic packet. |
-| `broadcast_port`       | yes      | Optional port where to send the magic packet.         |
-
-Sample action data:
-
-```json
-{
-   "mac":"00:40:13:ed:f1:32"
-}
-```
-
-{% note %}
-This usually only works if the target device is connected to the same network. Routing the magic packet to a different subnet requires a special configuration on your router or may not be possible.
-The action to route the packet is most likely named "IP Helper". It may support Wake on LAN, but not all routers support this.
-{% endnote %}
+{% include integrations/actions.md %}
 
 ## Button
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change

Moves the inline Wake on LAN action documentation (`send_magic_packet`) into a dedicated page under `source/_actions/`, and replaces the inline table on the integration page with the actions include. This brings the integration in line with the standardized action documentation structure.

I verified the fields against the core `services.yaml` and `strings.json`, converted the data-attribute table to the standard options list, and promoted the orphaned `Integration services` heading to a top-level section so the heading structure stays valid.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

