### PR TITLE
ONVIF: migrate action to a dedicated action page

### DIFF
--- a/source/_actions/onvif.ptz.markdown
+++ b/source/_actions/onvif.ptz.markdown
@@ -95,7 +95,6 @@ preset:
   description: The PTZ preset profile token to move to. Used with the `GotoPreset` move mode.
   required: false
   type: string
-  default: "0"
 {% endoptions_yaml %}
 
 {% include actions/targets.md domain="camera" %}

--- a/source/_actions/onvif.ptz.markdown
+++ b/source/_actions/onvif.ptz.markdown
@@ -1,0 +1,111 @@
+---
+title: "PTZ"
+action: onvif.ptz
+domain: onvif
+description: "Pans, tilts, or zooms an ONVIF camera."
+---
+
+Use this action to pan, tilt, or zoom an ONVIF camera that supports <abbr title="pan, tilt, and zoom">PTZ</abbr>. You can also move the camera to a saved preset position.
+
+{% include actions/ui_header.md %}
+
+To move a camera from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the ONVIF camera you want to move.
+6. From the actions shown for that target, select **PTZ**.
+7. Fill in the options you want to use.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Pan:
+  description: "The pan direction. One of: `LEFT` or `RIGHT`."
+Tilt:
+  description: "The tilt direction. One of: `UP` or `DOWN`."
+Zoom:
+  description: "The zoom direction. One of: `ZOOM_IN` or `ZOOM_OUT`."
+Distance:
+  description: The distance coefficient. Sets how much the camera moves in one request, from 0 to 1.
+Speed:
+  description: The speed coefficient. Sets how fast the camera moves, from 0 to 1.
+Move Mode:
+  description: "The move mode. One of: `ContinuousMove`, `RelativeMove`, `AbsoluteMove`, `GotoPreset`, or `Stop`."
+Continuous duration:
+  description: For `ContinuousMove`, the delay in seconds before the move stops.
+Preset:
+  description: The PTZ preset profile token to move to. Used with the `GotoPreset` move mode.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `onvif.ptz`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: onvif.ptz
+  target:
+    entity_id: camera.front_door
+  data:
+    pan: RIGHT
+    tilt: UP
+{% endexample %}
+
+This pans the camera right and tilts it up.
+
+### Options in YAML
+
+{% options_yaml %}
+pan:
+  description: "The pan direction. One of: `LEFT` or `RIGHT`."
+  required: false
+  type: string
+tilt:
+  description: "The tilt direction. One of: `UP` or `DOWN`."
+  required: false
+  type: string
+zoom:
+  description: "The zoom direction. One of: `ZOOM_IN` or `ZOOM_OUT`."
+  required: false
+  type: string
+distance:
+  description: The distance coefficient. Sets how much the camera moves in one request, from 0 to 1.
+  required: false
+  type: float
+  default: 0.1
+speed:
+  description: The speed coefficient. Sets how fast the camera moves, from 0 to 1.
+  required: false
+  type: float
+move_mode:
+  description: "The move mode. One of: `ContinuousMove`, `RelativeMove`, `AbsoluteMove`, `GotoPreset`, or `Stop`."
+  required: false
+  type: string
+  default: RelativeMove
+continuous_duration:
+  description: For the `ContinuousMove` mode, the delay in seconds before the move stops.
+  required: false
+  type: float
+  default: 0.5
+preset:
+  description: The PTZ preset profile token to move to. Used with the `GotoPreset` move mode.
+  required: false
+  type: string
+  default: "0"
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="camera" %}
+
+## Good to know
+
+- Your camera must support PTZ for this action to have any effect.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/onvif.markdown
+++ b/source/_integrations/onvif.markdown
@@ -81,22 +81,6 @@ To help with development of this integration, enable `info` level logging for `h
 
 If you are running into trouble with this sensor, please refer to the [Troubleshooting section](/integrations/ffmpeg/#troubleshooting).
 
-### Action `onvif.ptz`
-
-If your ONVIF camera supports <abbr title="pan, tilt, and zoom">PTZ</abbr>, you will be able to pan, tilt or zoom your camera.
-
-| Data attribute | Description |
-| -----------------------| ----------- |
-| `entity_id` | String or list of strings that point at `entity_id`s of cameras. Use `entity_id: all` to target all. |
-| `tilt` | Tilt direction. Allowed values: `UP`, `DOWN`, `NONE` |
-| `pan` | Pan direction. Allowed values: `RIGHT`, `LEFT`, `NONE` |
-| `zoom` | Zoom. Allowed values: `ZOOM_IN`, `ZOOM_OUT`, `NONE` |
-| `distance` | Distance coefficient. Sets how much <abbr title="pan, tilt, and zoom">PTZ</abbr> should be executed in one request. Allowed values: floating point numbers, 0 to 1. Default : 0.1 |
-| `speed` | Speed coefficient. Sets how fast PTZ will be executed. Allowed values: floating point numbers, 0 to 1. Default : 0.5 |
-| `preset` | PTZ preset profile token. Sets the preset profile token which is executed with GotoPreset. |
-| `move_mode` | PTZ moving mode. Allowed values: `ContinuousMove`, `RelativeMove`, `AbsoluteMove`, `GotoPreset`, `Stop`. Default :`RelativeMove` |
-| `continuous_duration` | Set ContinuousMove delay in seconds before stopping the move. Allowed values: floating point numbers or integer. Default : 0.5 |
-
 ### Supported switches
 
 This integration uses the ONVIF auxiliary command and imaging service to send certain settings and information to the camera via switch entities. Below is a list of currently supported switches.
@@ -106,6 +90,8 @@ This integration uses the ONVIF auxiliary command and imaging service to send ce
 | IR lamp  | `ir_lamp` |  Turn infrared lamp on and off via `IrCutFilter` ONVIF imaging setting. |
 | Autofocus  | `autofocus` |  Turn autofocus on and off via `AutoFocusMode` ONVIF imaging setting. |
 | Wiper  | `wiper` |  Turn on the lens wiper on and off via the `Wiper` ONVIF auxiliary command. |
+
+{% include integrations/actions.md %}
 
 ## Troubleshooting
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change

Moves the inline ONVIF action documentation (`ptz`) into a dedicated page under `source/_actions/`, and replaces the inline table on the integration page with the actions include. This brings the integration in line with the standardized action documentation structure.

While verifying the fields against the core `camera.py` schema, `services.yaml`, and `strings.json`, I corrected a couple of inaccuracies: `pan`, `tilt`, and `zoom` do not accept a `NONE` value, and `speed` has no default. I also dropped the `entity_id` row, since it is the action target rather than a data field.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase:
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

