### PR TITLE
Denon AVR: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/denonavr.get_command.markdown
+++ b/source/_actions/denonavr.get_command.markdown
@@ -1,0 +1,70 @@
+---
+title: Get command
+action: denonavr.get_command
+domain: denonavr
+description: "Send a generic HTTP command to a Denon AVR receiver over the network."
+related_actions:
+  - denonavr.set_dynamic_eq
+  - denonavr.update_audyssey
+---
+
+Use this action to send a generic HTTP command to your Denon AVR receiver. Denon AVR receivers support a simple text-based network interface, so you can reach features that do not have their own control in Home Assistant. You can also send IR remote codes through this same interface.
+
+A list of network commands supported by the various Denon AVR receivers can be [found here](https://www.heimkinoraum.de/upload/files/product/IP_Protocol_AVR-Xx100.pdf). A list of IR codes can be [found here](https://assets.denon.com/DocumentMaster/UK/AVR3313_IR_CODE_V01.pdf).
+
+{% include actions/ui_header.md %}
+
+To send a command from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Denon AVR media players you want to send the command to.
+6. From the actions shown for that target, select **Get command**.
+7. Fill in the options you want to use.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Command:
+  description: The endpoint of the command to send, including any associated parameters. For example, `/goform/formiPhoneAppDirect.xml?VSMONI2`.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `denonavr.get_command`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: denonavr.get_command
+  target:
+    entity_id: media_player.marantz
+  data:
+    command: "/goform/formiPhoneAppDirect.xml?VSMONI2"
+{% endexample %}
+
+This switches the HDMI output to output 2 (if your receiver supports it). To send an IR code instead, use a command such as `/goform/formiPhoneAppDirect.xml?RCKSK0410370`, which toggles muting.
+
+### Options in YAML
+
+{% options_yaml %}
+command:
+  description: The endpoint of the command to send, including any associated parameters.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+## Good to know
+
+- Append the specific command to the path `/goform/formiPhoneAppDirect.xml?`. For example, `/goform/formiPhoneAppDirect.xml?VSMONI2`.
+- The Denon AVR receiver also supports the standard media player controls, such as `turn_on` and `volume_up`. Calling the [`media_player.turn_on`](/integrations/media_player/) action is equivalent to calling **Get command** with the command `/goform/formiPhoneAppDirect.xml?PWON`.
+
+{% include actions/targets.md domain="media_player" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/denonavr.set_dynamic_eq.markdown
+++ b/source/_actions/denonavr.set_dynamic_eq.markdown
@@ -1,0 +1,64 @@
+---
+title: Set dynamic equalizer
+action: denonavr.set_dynamic_eq
+domain: denonavr
+description: "Enable or disable the DynamicEQ setting on a Denon AVR receiver."
+related_actions:
+  - denonavr.get_command
+  - denonavr.update_audyssey
+---
+
+Use this action to enable or disable the DynamicEQ setting on your Denon AVR receiver.
+
+{% include actions/ui_header.md %}
+
+To set DynamicEQ from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Denon AVR media players you want to control.
+6. From the actions shown for that target, select **Set dynamic equalizer**.
+7. Fill in the options you want to use.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Dynamic equalizer:
+  description: Turn on to enable DynamicEQ, turn off to disable it.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `denonavr.set_dynamic_eq`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: denonavr.set_dynamic_eq
+  target:
+    entity_id: media_player.marantz
+  data:
+    dynamic_eq: true
+{% endexample %}
+
+This enables DynamicEQ on the targeted receiver.
+
+### Options in YAML
+
+{% options_yaml %}
+dynamic_eq:
+  description: Whether DynamicEQ should be enabled or disabled.
+  required: true
+  type: boolean
+  default: true
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="media_player" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/denonavr.update_audyssey.markdown
+++ b/source/_actions/denonavr.update_audyssey.markdown
@@ -1,0 +1,56 @@
+---
+title: Update Audyssey
+action: denonavr.update_audyssey
+domain: denonavr
+description: "Update the Audyssey settings on a Denon AVR receiver."
+related_actions:
+  - denonavr.get_command
+  - denonavr.set_dynamic_eq
+---
+
+Use this action to update the Audyssey settings on your Denon AVR receiver.
+
+{% include actions/ui_header.md %}
+
+To update Audyssey settings from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Denon AVR media players you want to update.
+6. From the actions shown for that target, select **Update Audyssey**.
+7. Select **Save**.
+
+### Options in the UI
+
+This action has no additional options in the UI.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `denonavr.update_audyssey`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: denonavr.update_audyssey
+  target:
+    entity_id: media_player.marantz
+{% endexample %}
+
+This updates the Audyssey settings on the targeted receiver.
+
+### Options in YAML
+
+This action has no additional options in YAML.
+
+## Good to know
+
+- Updating Audyssey settings can take up to 10 seconds on some receivers.
+
+{% include actions/targets.md domain="media_player" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/denonavr.markdown
+++ b/source/_integrations/denonavr.markdown
@@ -155,42 +155,6 @@ A few notes:
 - To remotely power on Marantz receivers with Home Assistant, the Auto-Standby feature must be enabled in the receiver's settings.
 - Sound mode: The command to set a specific sound mode is different from the value of the current sound mode reported by the receiver (sound_mode_raw). There is a key-value structure (sound_mode_dict) that matches the raw sound mode to one of the possible commands to set a sound mode (for instance {'MUSIC':['PLII MUSIC']}. If you get a "Not able to match sound mode" warning, please open an issue on the [denonavr library](https://github.com/ol-iver/denonavr), stating which raw sound mode could not be matched so it can be added to the matching dictionary. You can find the current raw sound mode under {% my developer_states title="**Settings** > **Developer tools** > **States**" %}.
 
-#### Action `denonavr.get_command`
-
-Denon AVR receivers support a simple text-based network interface for sending commands to the receiver over the network. You can access this interface via the `denonavr.get_command` action. In addition, IR remote codes can also be sent to this interface.
-
-A list of network commands supported by the various Denon AVR receivers can be [found here](https://www.heimkinoraum.de/upload/files/product/IP_Protocol_AVR-Xx100.pdf). A list of IR codes can be [found here](https://assets.denon.com/DocumentMaster/UK/AVR3313_IR_CODE_V01.pdf).
-
-To use these commands, call the `denonavr.get_command` action and append the specific command to the path `/goform/formiPhoneAppDirect.xml?`:
-
-| Data attribute | Optional | Description                                          |
-| ---------------------- | -------- | ---------------------------------------------------- |
-| `entity_id`            |       no | Name of entity to send command to. For example `media_player.marantz`|
-| `command`              |       no | Command to send to device, for example, `/goform/formiPhoneAppDirect.xml?VSMONI2`|
-
-So for example, the above command `/goform/formiPhoneAppDirect.xml?VSMONI2` will switch the HDMI to output 2 (if your receiver supports it). Sending an IR code works the same, so the command `/goform/formiPhoneAppDirect.xml?RCKSK0410370` will toggle muting.
-
-{% tip %}
-
-The denonavr platform supports the standard media player controls such as `turn_on` and `volume_up`. Thus calling the `media_player.turn_on` action is equivalent to calling `denonavr.get_command` with the command `/goform/formiPhoneAppDirect.xml?PWON`. See [media_player](/integrations/media_player/) for more details.
-
-{% endtip %}
-
-#### Action `denonavr.set_dynamic_eq`
-
-Enable or disable DynamicEQ setting.
-
-| Data attribute | Optional | Description                                          |
-| ---------------------- | -------- | ---------------------------------------------------- |
-| `entity_id`            |      yes | Name of entity to send command to. For example `media_player.marantz`|
-| `dynamic_eq`           |       no | True/false for enable/disable.|
-
-#### Action `denonavr.update_audyssey`
-
-Update Audyssey settings. This can take up to 10 Seconds for some receivers.
-
-| Data attribute | Optional | Description                                          |
-| ---------------------- | -------- | ---------------------------------------------------- |
-| `entity_id`            |      yes | Name of entity to send command to. For example `media_player.marantz`|
+{% include integrations/actions.md %}
 
 [Denon]: /integrations/denon


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change

Migrates the Denon AVR `get_command`, `set_dynamic_eq`, and `update_audyssey` actions from the inline documentation on the integration page into dedicated pages under `source/_actions/`, and replaces the inline block with the shared actions include.

Also corrects the documented fields against the current core service schema (the entity target is no longer listed as a data attribute, and the `set_dynamic_eq` default is captured).

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

