### PR TITLE
Jellyfin: migrate action to a dedicated action page

### DIFF
--- a/source/_actions/jellyfin.play_media_shuffle.markdown
+++ b/source/_actions/jellyfin.play_media_shuffle.markdown
@@ -1,0 +1,68 @@
+---
+title: Play media shuffled
+action: jellyfin.play_media_shuffle
+domain: jellyfin
+description: "Start playing a Jellyfin directory shuffled, replacing the current play queue."
+---
+
+Use this action to start playing a directory from your Jellyfin library shuffled, such as a full series, TV show, or season. The Jellyfin API supports shuffling a directory when playback begins. This immediately replaces the current play queue of the client with the shuffled media.
+
+To play media without shuffling, use the [`media_player.play_media`](/integrations/media_player/) action instead.
+
+{% include actions/ui_header.md %}
+
+To shuffle play media from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Jellyfin players you want to play on.
+6. From the actions shown for that target, select **Play media shuffled**.
+7. Fill in the options you want to use.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Media:
+  description: The media to play. Browse to the directory you want to shuffle, such as a series or a season.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `jellyfin.play_media_shuffle`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: jellyfin.play_media_shuffle
+  target:
+    entity_id: media_player.chrome
+  data:
+    media:
+      media_content_id: 34361f3855c9c0ac39b0f7503fe86be0
+{% endexample %}
+
+This shuffle plays a full season of a TV show on the targeted Jellyfin client.
+
+### Options in YAML
+
+{% options_yaml %}
+media:
+  description: The media to play, given as a mapping that contains the `media_content_id` of the directory you want to shuffle.
+  required: true
+  type: map
+{% endoptions_yaml %}
+
+## Good to know
+
+- To find the `media_content_id` of the content you want to play, browse or search your library with the [`media_player.browse_media`](/integrations/media_player/) and [`media_player.search_media`](/integrations/media_player/) actions.
+- Shuffling works on directories, such as a series, TV show, or season.
+
+{% include actions/targets.md domain="media_player" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/jellyfin.play_media_shuffle.markdown
+++ b/source/_actions/jellyfin.play_media_shuffle.markdown
@@ -7,11 +7,11 @@ description: "Start playing a Jellyfin directory shuffled, replacing the current
 
 Use this action to start playing a directory from your Jellyfin library shuffled, such as a full series, TV show, or season. The Jellyfin API supports shuffling a directory when playback begins. This immediately replaces the current play queue of the client with the shuffled media.
 
-To play media without shuffling, use the [`media_player.play_media`](/integrations/media_player/) action instead.
+To play media without shuffling, use [Play media](/actions/media_player.play_media/) instead.
 
 {% include actions/ui_header.md %}
 
-To shuffle play media from an automation or a script:
+To play media shuffled from an automation or a script:
 
 1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
 2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
@@ -56,7 +56,7 @@ media:
 
 ## Good to know
 
-- To find the `media_content_id` of the content you want to play, browse or search your library with the [`media_player.browse_media`](/integrations/media_player/) and [`media_player.search_media`](/integrations/media_player/) actions.
+- To find the `media_content_id` of the content you want to play, browse or search your library with the [`media_player.browse_media`](/actions/media_player.browse_media/) and [`media_player.search_media`](/actions/media_player.search_media/) actions.
 - Shuffling works on directories, such as a series, TV show, or season.
 
 {% include actions/targets.md domain="media_player" %}

--- a/source/_integrations/jellyfin.markdown
+++ b/source/_integrations/jellyfin.markdown
@@ -207,27 +207,7 @@ data:
   enqueue: next
 ```
 
-### Action jellyfin.play_media_shuffle
-
-The Jellyfin API supports shuffling of a directory (series/tvshow or season) when beginning playback. This is enabled through a separate {% term service %} to [play_media](#action-play_media). This will immediately replace the current play queue of the client with the shuffled media. An `entity_id` target is required.
-
-- Data attribute: `media_content_id`
-  - Optional: No.
-  - Description: Unique identifier of the content you want to play.
-  - Example: `895dc4e1066da92847d48f9be28eb77c`
-
-#### Examples:
-
-Shuffle play a full season of a TV show on a Jellyfin client.
-
-```yaml
-action: jellyfin.play_media_shuffled
-target:
-  entity_id:
-    - media_player.chrome
-data:
-  media_content_id: 34361f3855c9c0ac39b0f7503fe86be0
-```
+{% include integrations/actions.md %}
 
 ## Notes
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change

Migrates the Jellyfin `play_media_shuffle` action from the inline documentation on the integration page into a dedicated page under `source/_actions/`, and replaces it with the shared actions include.

The other actions documented on the page (`media_player.browse_media`, `media_player.search_media`, and `media_player.play_media`) are generic media player actions, so they are left in place.

Also corrects the action page against the current core service schema: the field is now the `media` selector (not a bare `media_content_id`), and the example used the wrong action name (`play_media_shuffled`).

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

