### PR TITLE
Workday: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/workday.check_date.markdown
+++ b/source/_actions/workday.check_date.markdown
@@ -1,0 +1,75 @@
+---
+title: "Check date"
+action: workday.check_date
+domain: workday
+description: "Checks whether a given date is a workday."
+---
+
+Use this action to check whether a specific date is a workday, based on the workdays and holidays you configured for your Workday sensor.
+
+This action returns its result in a response variable, which you can use in later steps of the same automation or script.
+
+{% include actions/ui_header.md %}
+
+To check a date from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select your Workday sensor.
+6. From the actions shown for that target, select **Check date**.
+7. Set the **Date** you want to check.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Date:
+  description: The date to check, such as 2023-12-25.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `workday.check_date`. Store the result in a response variable so you can use it in later steps:
+
+{% example %}
+action: |
+  action: workday.check_date
+  target:
+    entity_id: binary_sensor.workday
+  data:
+    check_date: "2023-12-25"
+  response_variable: check_date
+{% endexample %}
+
+This checks whether 2023-12-25 is a workday for `binary_sensor.workday`.
+
+### Options in YAML
+
+{% options_yaml %}
+check_date:
+  description: The date to check, such as 2023-12-25.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="binary_sensor" %}
+
+## Response data
+
+The action returns a `workday` field that is `true` when the date is a workday and `false` when it is not.
+
+A shortened example of the response looks like this:
+
+```yaml
+binary_sensor.workday:
+  workday: true
+```
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/workday.markdown
+++ b/source/_integrations/workday.markdown
@@ -54,30 +54,7 @@ The offset can be used to see if future days are workdays. For example, put `1` 
 
 Additional categories can be added through the configuration to include optional holidays according to the lists provided in the [python-holidays library](https://github.com/vacanza/python-holidays?tab=readme-ov-file#available-countries)
 
-## Action `workday.check_date`
-
-
-This action populates [Response Data](/docs/scripts/perform-actions#use-templates-to-handle-response-data)
-providing feedback if the date is a workday or not.
-
-| Data attribute | Required | Description | Example |
-| ---------------------- | -------- | ----------- | --------|
-| `check_date` | yes | Date to test if workday or not. | 2022-03-10
-
-```yaml
-action: workday.check_date
-target:
-  entity_id: binary_sensor.workday
-data:
-  check_date: "2023-12-25"
-response_variable: check_date
-```
-
-The response data field `check_date` is providing:
-
-| Response data | Description | Example |
-| ---------------------- | ----------- | -------- |
-| `workday` | Is date a workday. | True
+{% include integrations/actions.md %}
 
 ## Automation example
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change

Moves the inline workday.check_date action documentation into a dedicated action page under source/_actions/, and replaces the inline section on the integration page with the actions include. Part of the ongoing initiative to standardize action documentation across integrations.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

