### PR TITLE
Google Cast: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/cast.show_lovelace_view.markdown
+++ b/source/_actions/cast.show_lovelace_view.markdown
@@ -1,0 +1,80 @@
+---
+title: "Show dashboard view via Google Cast"
+action: cast.show_lovelace_view
+domain: cast
+description: "Shows a dashboard view on a Google Cast device."
+---
+
+Use this action to show a specific dashboard view on a Google Cast device, such as putting your downstairs overview on the kitchen display. This is the Home Assistant Cast feature you trigger from an automation or script.
+
+You pick the Cast device, the view to show, and optionally which dashboard the view belongs to.
+
+{% include actions/ui_header.md %}
+
+To show a dashboard view from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Google Cast: Show dashboard view via Google Cast**.
+6. Select the Cast device in the **Entity** field, and enter the **View path** to show. Optionally, set a **Dashboard path** if the view is not on your default dashboard.
+7. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Entity:
+  description: The Cast media player to show the dashboard view on.
+  required: true
+View path:
+  description: The URL path of the dashboard view to show.
+  required: true
+Dashboard path:
+  description: The URL path of the dashboard to show. Defaults to `lovelace` when not set.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `cast.show_lovelace_view`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: cast.show_lovelace_view
+  data:
+    entity_id: media_player.kitchen
+    dashboard_path: lovelace-cast
+    view_path: downstairs
+{% endexample %}
+
+This shows the `downstairs` view of the `lovelace-cast` dashboard on the kitchen Cast device.
+
+### Options in YAML
+
+{% options_yaml %}
+entity_id:
+  description: The Cast media player to show the dashboard view on.
+  required: true
+  type: string
+view_path:
+  description: The URL path of the dashboard view to show.
+  required: true
+  type: string
+dashboard_path:
+  description: The URL path of the dashboard to show. Defaults to `lovelace` when not set.
+  required: false
+  type: string
+{% endoptions_yaml %}
+
+## Good to know
+
+- Only administrators can run this action.
+- Home Assistant Cast requires your Home Assistant installation to be reachable over `https://`. If you use Home Assistant Cloud, this is already taken care of. Otherwise, set your [`external_url`](/integrations/homeassistant/#editing-the-general-settings-in-yaml).
+- Each dashboard view needs a `path` defined for the **View path** to work. See the [views documentation](/dashboards/views/#path).
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/cast.markdown
+++ b/source/_integrations/cast.markdown
@@ -33,22 +33,13 @@ Ignore CEC:
 
 ## Home Assistant Cast
 
-Home Assistant has its own Cast application to show the Home Assistant UI on any Chromecast device. You can use it by adding the [Cast entity row](/dashboards/entities/#cast) to your dashboards, or by calling the `cast.show_lovelace_view` action. The action takes the path of a dashboard view and an entity ID of a Cast device to show the view on. A `path` has to be defined in your dashboard's YAML for each view, as outlined in the [views documentation](/dashboards/views/#path). The `dashboard_path` is the part of the dashboard URL that follows the defined `base_url`, typically "`lovelace`". The following is a full configuration for a script that starts casting the `downstairs` tab of the `lovelace-cast` path (note that `entity_id` is specified under `data` and not for the action):
-
-```yaml
-cast_downstairs_on_kitchen:
-  alias: "Show Downstairs on kitchen"
-  sequence:
-    - action: cast.show_lovelace_view
-      data:
-        dashboard_path: lovelace-cast
-        entity_id: media_player.kitchen
-        view_path: downstairs
-```
+Home Assistant has its own Cast application to show the Home Assistant UI on any Chromecast device. You can use it by adding the [Cast entity row](/dashboards/entities/#cast) to your dashboards, or by calling the `cast.show_lovelace_view` action to show a specific dashboard view on a Cast device from an automation or script.
 
 {% important %}
 Home Assistant Cast requires your Home Assistant installation to be accessible via `https://`. If you're using Home Assistant Cloud, you don't need to do anything. Otherwise you must make sure that you have configured the `external_url` in your [configuration](/integrations/homeassistant/#homeassistant-configuration-variables).
 {% endimportant %}
+
+{% include integrations/actions.md %}
 
 ## Playing media
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change

Moves the inline cast.show_lovelace_view action documentation into a dedicated action page under source/_actions/, and replaces the inline mechanics and example in the Home Assistant Cast section with the actions include. Part of the ongoing initiative to standardize action documentation across integrations.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

