### PR TITLE
HomeKit Bridge: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/homekit.reload.markdown
+++ b/source/_actions/homekit.reload.markdown
@@ -1,0 +1,80 @@
+---
+title: Reload HomeKit
+action: homekit.reload
+domain: homekit
+description: "Reloads HomeKit and reprocesses the YAML configuration."
+related_actions:
+  - homekit.reset_accessory
+  - homekit.unpair
+---
+
+The **Reload HomeKit** action reloads the HomeKit Bridge integration and reprocesses its YAML configuration. Use it after you change YAML-defined HomeKit settings and want Home Assistant to apply those changes without a restart.
+
+This action only reloads HomeKit instances that are defined in YAML. It does not change instances you manage from the UI.
+
+{% include actions/ui_header.md %}
+
+To use this action in an automation or script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create** to start a new one.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **HomeKit Bridge: Reload HomeKit**.
+6. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+This action has no additional options in the UI.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `homekit.reload`:
+
+{% example %}
+action: |
+  action: homekit.reload
+{% endexample %}
+
+This reloads HomeKit and reprocesses your YAML configuration.
+
+### Options in YAML
+
+This action has no additional options in YAML.
+
+## Good to know
+
+- Only an administrator account can run this action.
+- This action reloads YAML-defined HomeKit instances only. Instances you create in the UI are not changed.
+- If you have not changed your YAML, running this action does not make any visible changes.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: reload HomeKit after a scheduled YAML sync
+
+If another process updates your HomeKit YAML before a set time, you can schedule this action so Home Assistant picks up those changes automatically.
+
+- **Trigger**: A scheduled time
+- **Action**: HomeKit Bridge: Reload HomeKit
+
+{% details "YAML example for reloading HomeKit after a scheduled sync" %}
+
+{% example %}
+automation: |
+  alias: "Reload HomeKit after nightly YAML sync"
+  triggers:
+    - trigger: time
+      at: "03:05:00"
+  actions:
+    - action: homekit.reload
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/homekit.reset_accessory.markdown
+++ b/source/_actions/homekit.reset_accessory.markdown
@@ -1,0 +1,69 @@
+---
+title: Reset accessory
+action: homekit.reset_accessory
+domain: homekit
+description: "Resets a HomeKit accessory."
+related_actions:
+  - homekit.reload
+  - homekit.unpair
+---
+
+The **Reset accessory** action resets one or more HomeKit accessories whose configuration may have changed. The accessory behaves as if it's being set up for the first time, so you need to restore its name, group, room, scene, and automation settings afterward.
+
+This is useful after changing a media player's device class to `tv`, linking a battery sensor, or whenever Home Assistant adds support for new HomeKit features to existing entities.
+
+{% include actions/ui_header.md %}
+
+To reset an accessory from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create** to start a new one.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **HomeKit Bridge: Reset accessory**.
+6. Select the **Entity** to reset.
+7. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Entity:
+  description: The entity, or entities, to reset.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `homekit.reset_accessory`:
+
+{% example %}
+action: |
+  action: homekit.reset_accessory
+  data:
+    entity_id: media_player.living_room_tv
+{% endexample %}
+
+This resets the HomeKit accessory for the given entity.
+
+### Options in YAML
+
+{% options_yaml %}
+entity_id:
+  description: >
+    The entity ID, or list of entity IDs, of the accessories to reset.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+## Good to know
+
+- After a reset, the accessory behaves as if it's set up for the first time. You need to restore its name, group, room, scene, and automation settings.
+- On earlier versions of Home Assistant, you can reset accessories by removing the entity from HomeKit through the filter and then adding it back.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/homekit.unpair.markdown
+++ b/source/_actions/homekit.unpair.markdown
@@ -1,0 +1,69 @@
+---
+title: Unpair an accessory or bridge
+action: homekit.unpair
+domain: homekit
+description: "Forcefully removes all pairings from an accessory to allow re-pairing."
+related_actions:
+  - homekit.reload
+  - homekit.reset_accessory
+---
+
+The **Unpair an accessory or bridge** action forcefully removes all pairings from an accessory so you can pair it again. Use it when an accessory is no longer responsive and you want to avoid deleting and re-adding the integration entry.
+
+Occasionally, the public key for a paired device goes missing because of pairing failures, which can make one or more devices show the accessory as unavailable. Unpairing and re-pairing ensures the integration has the public key for each paired client.
+
+{% include actions/ui_header.md %}
+
+To unpair an accessory from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create** to start a new one.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **HomeKit Bridge: Unpair an accessory or bridge**.
+6. Select the **Device** to unpair.
+7. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Device:
+  description: The device to unpair.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `homekit.unpair`:
+
+{% example %}
+action: |
+  action: homekit.unpair
+  data:
+    device_id: a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4
+{% endexample %}
+
+This removes all pairings from the selected device so you can pair it again.
+
+### Options in YAML
+
+{% options_yaml %}
+device_id:
+  description: >
+    The device ID of the accessory or bridge to unpair.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+## Good to know
+
+- After unpairing, the accessory behaves as if it's set up for the first time. You need to restore its name, group, room, scene, and automation settings.
+- When you set up HomeKit from the UI, this action avoids the sometimes time-consuming process of deleting and recreating the integration entry.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/homekit.markdown
+++ b/source/_integrations/homekit.markdown
@@ -513,6 +513,8 @@ automation:
         message: "The garage door got opened via HomeKit"
 ```
 
+{% include integrations/actions.md %}
+
 ## Troubleshooting
 
 ### All or some devices are intermittently unresponsive
@@ -691,7 +693,7 @@ HomeKit camera snapshots tie up the HomeKit connection during snapshots. To avoi
 
 #### Resetting accessories
 
-You may use the `homekit.reset_accessory` action with one or more entity IDs to reset accessories whose configuration may have changed. This can be useful when changing a media player's device class to `tv`, linking a battery, or whenever Home Assistant adds support for new HomeKit features to existing entities.
+You may use the [Reset accessory](/actions/homekit.reset_accessory/) action with one or more entity IDs to reset accessories whose configuration may have changed. This can be useful when changing a media player's device class to `tv`, linking a battery, or whenever Home Assistant adds support for new HomeKit features to existing entities.
 
 On earlier versions of Home Assistant, you can reset accessories by removing the entity from HomeKit (via [filter](#configure-filter)) and then re-adding the accessory.
 
@@ -699,7 +701,7 @@ With either strategy, the accessory will behave as if it's the first time the ac
 
 #### Unpairing and Re-pairing
 
-The HomeKit integration remembers a public key for each paired device. Occasionally, the public key for a device pairing will be missing because of pairing failures. Suppose one or more devices show the accessory as unavailable. In that case, it may be necessary to unpair and re-pair the device to ensure the integration has the public key for each paired client. The `homekit.unpair` action will forcefully remove all pairings and allow re-pairing with the accessory. When setting up HomeKit from the UI, this avoids the sometimes time-consuming process of deleting and create a new instance.
+The HomeKit integration remembers a public key for each paired device. Occasionally, the public key for a device pairing will be missing because of pairing failures. Suppose one or more devices show the accessory as unavailable. In that case, it may be necessary to unpair and re-pair the device to ensure the integration has the public key for each paired client. The [Unpair an accessory or bridge](/actions/homekit.unpair/) action will forcefully remove all pairings and allow re-pairing with the accessory. When setting up HomeKit from the UI, this avoids the sometimes time-consuming process of deleting and create a new instance.
 
 The accessory will behave as if it's the first time the accessory has been set up, so you will need to restore the name, group, room, scene, and/or automation settings.
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change

Migrates the HomeKit Bridge integration's actions (`homekit.reload`, `homekit.reset_accessory`, and `homekit.unpair`) to dedicated pages under `source/_actions/` and replaces the inline references with the standard `{% include integrations/actions.md %}` block.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

