### PR TITLE
SwitchBot: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/switchbot.add_password.markdown
+++ b/source/_actions/switchbot.add_password.markdown
@@ -1,0 +1,75 @@
+---
+title: Add password
+action: switchbot.add_password
+domain: switchbot
+description: "Adds a password to a SwitchBot Keypad Vision device."
+---
+
+The **Add password** action adds a password to a SwitchBot Keypad Vision device. After you add it, the password can be used to unlock the linked device on the keypad.
+
+The password must be 6 to 12 digits long.
+
+{% include actions/ui_header.md %}
+
+To add a password from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create** to start a new one.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **SwitchBot: Add password**.
+6. Select the **Device** and enter the **Password**.
+7. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Device:
+  description: The Keypad Vision device to add the password to.
+  required: true
+Password:
+  description: A 6 to 12 digit password.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `switchbot.add_password`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: switchbot.add_password
+  data:
+    device_id: c2d01328efd261f586e56d914e3af07e
+    password: "123456"
+{% endexample %}
+
+This adds the password `123456` to the selected Keypad Vision device.
+
+### Options in YAML
+
+{% options_yaml %}
+device_id:
+  description: >
+    The device ID of the Keypad Vision device to add the password to.
+  required: true
+  type: string
+password:
+  description: >
+    A 6 to 12 digit password.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+## Good to know
+
+- This action is available on SwitchBot Keypad Vision devices.
+- The password must be 6 to 12 digits long.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/switchbot.markdown
+++ b/source/_integrations/switchbot.markdown
@@ -569,16 +569,7 @@ Features:
 - get tamper alarm
 - get doorbell event
 
-Actions:
-- add_password
-
-Examples:
-```yaml
-action: switchbot.add_password
-data:
-  device_id: c2d01328efd261f586e56d914e3af07e
-  password: 123456
-```
+This device supports the [Add password](/actions/switchbot.add_password/) action.
 
 ### Lights
 
@@ -901,6 +892,7 @@ Features:
 - next image
 - previous image
 
+{% include integrations/actions.md %}
 
 ## Data updates
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change

Migrates the SwitchBot integration's `switchbot.add_password` action to a dedicated page under `source/_actions/` and replaces the inline documentation in the Keypad Vision section with the standard `{% include integrations/actions.md %}` block.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

