### PR TITLE
VeSync: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/vesync.update_devices.markdown
+++ b/source/_actions/vesync.update_devices.markdown
@@ -1,0 +1,52 @@
+---
+title: Update devices
+action: vesync.update_devices
+domain: vesync
+description: "Polls the VeSync server to find and add any new devices."
+---
+
+The **Update devices** action polls the VeSync server for your account and adds any new devices to Home Assistant. Use it after you set up a new VeSync device in the VeSync app, so it shows up in Home Assistant without waiting or restarting.
+
+{% include actions/ui_header.md %}
+
+To update devices from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create** to start a new one.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **VeSync: Update devices**.
+6. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+This action has no additional options in the UI.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `vesync.update_devices`:
+
+{% example %}
+action: |
+  action: vesync.update_devices
+{% endexample %}
+
+This polls the VeSync server and adds any new devices it finds.
+
+### Options in YAML
+
+This action has no additional options in YAML.
+
+## Good to know
+
+- Run this action after adding a device in the VeSync app to bring it into Home Assistant right away.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/vesync.markdown
+++ b/source/_integrations/vesync.markdown
@@ -108,11 +108,7 @@ This integration follows standard integration removal. No extra steps are requir
 
 {% include integrations/remove_device_service.md %}
 
-## Actions
-
-| Action | Description |
-|---------|-------------|
-| `update_devices` | Poll Vesync server to find and add any new devices |
+{% include integrations/actions.md %}
 
 ## Power & energy sensors
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change

Migrates the VeSync integration's `vesync.update_devices` action to a dedicated page under `source/_actions/` and replaces the inline actions table with the standard `{% include integrations/actions.md %}` block.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

