### PR TITLE
Google Assistant SDK: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/google_assistant_sdk.send_text_command.markdown
+++ b/source/_actions/google_assistant_sdk.send_text_command.markdown
@@ -1,0 +1,109 @@
+---
+title: "Send text command"
+action: google_assistant_sdk.send_text_command
+domain: google_assistant_sdk
+description: "Sends a command as a text query to Google Assistant."
+---
+
+The **Send text command** action sends one or more commands as text queries to Google Assistant, just as if you had spoken them out loud. This lets you reach Google Assistant features that aren't otherwise available in Home Assistant, like controlling devices that are only linked to your Google account.
+
+You can optionally have Google Assistant's spoken response played back on a media player, which is useful for commands that answer a question, such as asking for a joke or the weather.
+
+{% include actions/ui_header.md %}
+
+To send a text command from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Google Assistant SDK: Send text command**.
+6. Enter the **Command** to send, and optionally select a **Media player entity** to play the audio response on.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Command:
+  description: One or more commands to send to Google Assistant.
+  required: true
+Media player entity:
+  description: One or more media player entities to play Google Assistant's audio response on. This does not target the device for the command itself.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `google_assistant_sdk.send_text_command`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: google_assistant_sdk.send_text_command
+  data:
+    command: "turn off kitchen TV"
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+command:
+  description: >
+    One or more commands to send to Google Assistant.
+  required: true
+  type: string
+media_player:
+  description: >
+    One or more media player entities to play Google Assistant's audio
+    response on. This does not target the device for the command itself.
+  required: false
+  type: string
+{% endoptions_yaml %}
+
+## Good to know
+
+- To control a specific device, like streaming a camera to a TV, include the device's name (as known by Google Assistant) in the text command itself. The **Media player entity** option only plays back the audio response and does not direct the command.
+- You can send multiple commands in the same conversation context, which is useful for commands that need a follow-up, such as unlocking a door or opening a cover that requires a PIN.
+- This action can optionally return Google Assistant's responses. Store them in a [response variable](/docs/scripts/perform-actions/#use-templates-to-handle-response-data) to use them later in your automation or script.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Play a joke on a speaker
+
+Ask Google Assistant to tell a joke and play the spoken response on a living room speaker.
+
+{% details "YAML example for playing a joke on a speaker" %}
+
+{% example %}
+action: |
+  action: google_assistant_sdk.send_text_command
+  data:
+    command: "tell me a joke"
+    media_player: media_player.living_room_speaker
+{% endexample %}
+
+{% enddetails %}
+
+### Send multiple commands in one conversation
+
+Send a sequence of commands in the same conversation context, for example to open a garage door that needs a PIN.
+
+{% details "YAML example for sending multiple commands" %}
+
+{% example %}
+action: |
+  action: google_assistant_sdk.send_text_command
+  data:
+    command:
+      - "open the garage door"
+      - "1234"
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/google_assistant_sdk.markdown
+++ b/source/_integrations/google_assistant_sdk.markdown
@@ -153,54 +153,9 @@ The easiest way to check if the integration is working is to check [My Google Ac
 
 On the configure page, you can set the language code of the interactions with Google Assistant. If not configured, the integration picks one based on Home Assistant's configured language and country. Supported languages are listed [here](https://developers.google.com/assistant/sdk/reference/rpc/languages).
 
-## Actions
+{% include integrations/actions.md %}
 
-### Send text command
-
-You can use the `google_assistant_sdk.send_text_command` action to send commands to Google Assistant.
-
-| Data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `command`              | no       | Command(s) to send to Google Assistant. |
-| `media_player`         | yes      | Name(s) of media player entities to play the Google Assistant's audio response on. This does **not** target the device for the command itself. |
-
-Examples:
-
-```yaml
-action: google_assistant_sdk.send_text_command
-data:
-  command: "turn off kitchen TV"
-```
-
-```yaml
-# Say a joke on the living room speaker. The `media_player` entity receives the audio response.
-action: google_assistant_sdk.send_text_command
-data:
-  command: "tell me a joke"
-  media_player: media_player.living_room_speaker
-```
-
-```yaml
-# Stream a camera to a Chromecast-enabled TV or display.
-# The target device ("living room tv") must be part of the command itself.
-action: google_assistant_sdk.send_text_command
-data:
-  command: "show the front door camera on the living room tv"
-```
-
-Note: To control a specific device, like streaming a camera to a TV, you must include the device's name (as known by Google Assistant) in the text `command`. The `media_player` parameter is only used for playing back Google Assistant's audio response and will not direct the video stream.
-
-You can send multiple commands in the same conversation context which is useful to unlock doors or open covers that need a PIN. Example:
-
-```yaml
-action: google_assistant_sdk.send_text_command
-data:
-  command:
-    - "open the garage door"
-    - "1234"
-```
-
-### Action: Broadcast message
+## Broadcast message
 
 The `notify.google_assistant_sdk` action allows you to broadcast messages to Google Assistant speakers and displays without interrupting music/video playback.
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change

Migrates the Google Assistant SDK `send_text_command` action to a dedicated action page under `source/_actions/`, replacing the inline table-based documentation with the standard actions include. The `notify.google_assistant_sdk` broadcast action is left in place because it belongs to the notify domain.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

