### PR TITLE
Litter-Robot: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/litterrobot.set_sleep_mode.markdown
+++ b/source/_actions/litterrobot.set_sleep_mode.markdown
@@ -63,8 +63,8 @@ start_time:
   description: >
     The time at which the Litter-Robot enters sleep mode and prevents an
     automatic clean cycle for 8 hours. Use the 24-hour format
-    %H:%M:%S, with seconds being optional, based on your Home Assistant
-    time zone. For example, 22:30:00 is 10:30 PM.
+    `%H:%M:%S`, with seconds being optional, based on your Home Assistant
+    time zone. For example, `22:30:00` is 10:30 PM.
   required: false
   type: string
 {% endoptions_yaml %}

--- a/source/_actions/litterrobot.set_sleep_mode.markdown
+++ b/source/_actions/litterrobot.set_sleep_mode.markdown
@@ -1,0 +1,82 @@
+---
+title: "Set sleep mode"
+action: litterrobot.set_sleep_mode
+domain: litterrobot
+description: "Sets the sleep mode and start time on a Litter-Robot."
+---
+
+The **Set sleep mode** action turns sleep mode on or off for a Litter-Robot. When sleep mode is enabled, the Litter-Robot does not run an automatic clean cycle for 8 hours starting from the time you choose.
+
+This is handy for keeping the unit quiet overnight or while you are nearby, without changing settings in the Whisker app.
+
+{% include actions/ui_header.md %}
+
+To set sleep mode from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Litter-Robot: Set sleep mode**.
+6. Under **Targets**, choose the Litter-Robot entities to control.
+7. Turn **Enabled** on or off, and optionally set a **Start time**.
+8. Select **Save**.
+
+{% include actions/targets.md domain="vacuum" %}
+
+### Options in the UI
+
+{% options_ui %}
+Enabled:
+  description: Whether sleep mode should be enabled.
+  required: true
+Start time:
+  description: The time at which the Litter-Robot enters sleep mode and prevents an automatic clean cycle for 8 hours.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `litterrobot.set_sleep_mode`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: litterrobot.set_sleep_mode
+  target:
+    entity_id: vacuum.litter_robot_litter_box
+  data:
+    enabled: true
+    start_time: "22:30:00"
+{% endexample %}
+
+This enables sleep mode starting at 10:30 PM.
+
+### Options in YAML
+
+{% options_yaml %}
+enabled:
+  description: >
+    Whether sleep mode should be enabled.
+  required: true
+  type: boolean
+start_time:
+  description: >
+    The time at which the Litter-Robot enters sleep mode and prevents an
+    automatic clean cycle for 8 hours. Use the 24-hour format
+    %H:%M:%S, with seconds being optional, based on your Home Assistant
+    time zone. For example, 22:30:00 is 10:30 PM.
+  required: false
+  type: string
+{% endoptions_yaml %}
+
+## Good to know
+
+- Sleep mode scheduling through this action is currently limited to the Litter-Robot 3. To change the sleep schedule on a Litter-Robot 4, use the Whisker app.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/litterrobot.set_sleep_mode.markdown
+++ b/source/_actions/litterrobot.set_sleep_mode.markdown
@@ -58,6 +58,7 @@ enabled:
   description: >
     Whether sleep mode should be enabled.
   required: true
+  default: true
   type: boolean
 start_time:
   description: >

--- a/source/_integrations/litterrobot.markdown
+++ b/source/_integrations/litterrobot.markdown
@@ -98,30 +98,7 @@ Password:
 | Visits today | `sensor` | Pet's daily visits to the Litter-Robot. |
 | Weight       | `sensor` | Pet's weight.                                     |
 
-## Actions
-
-Actions are utilized for additional functionality that is available in the Whisker (previously Litter-Robot) companion app. The following are currently available:
-
-### set_sleep_mode
-
-Enables (with `start_time` parameter) or disables sleep mode on the Litter-Robot. Currently, this is limited to only the Litter-Robot 3. To make changes to the sleep schedule on your Litter-Robot 4, please continue to use the Whisker app.
-
-| Parameter  | Type   | Required | Description                                                                                                                                                                                                                                                                                                                                              |
-| ---------- | ------ | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| enabled    | bool   | yes      | Set to true to enable and false to disable.                                                                                                                                                                                                                                                                                                              |
-| start_time | string | no       | Time at which the unit will enter sleep mode and prevent an automatic clean cycle for 8 hours. This param uses the 24-hour format string `%H:%M:%S`, with seconds being optional, and is based on the timezone configured for your Home Assistant installation. As such, `10:30:00` would indicate 10:30 AM, whereas `22:30:00` would indicate 10:30 PM. |
-
-Example of setting the sleep mode to begin at 10:30 PM.
-
-```yaml
-action: litterrobot.set_sleep_mode
-target:
-  entity_id: vacuum.litter_robot_litter_box
-data:
-  enabled: true
-  start_time: "22:30:00"
-
-```
+{% include integrations/actions.md %}
 
 ## Data updates
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change

Migrates the Litter-Robot `set_sleep_mode` action to a dedicated action page under `source/_actions/`, replacing the inline table-based documentation with the standard actions include.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

