### PR TITLE
Picnic: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/picnic.add_product.markdown
+++ b/source/_actions/picnic.add_product.markdown
@@ -33,7 +33,7 @@ Product ID:
   description: The product ID of a Picnic product.
   required: false
 Product name:
-  description: Search for a product and add the first result.
+  description: The product name to search for. The first search result is added to the cart.
   required: false
 Amount:
   description: The amount to add of the selected product.
@@ -59,7 +59,7 @@ This searches for "Picnic cola zero" and adds the first result to your cart.
 {% options_yaml %}
 config_entry_id:
   description: >
-    The ID of the Picnic service config entry to add the product to.
+    The configuration entry ID of the Picnic service to add the product to.
   required: true
   type: string
 product_id:

--- a/source/_actions/picnic.add_product.markdown
+++ b/source/_actions/picnic.add_product.markdown
@@ -7,7 +7,7 @@ description: "Adds a product to your Picnic shopping cart by product ID or by se
 
 Use this action to add a product to your Picnic shopping cart. You can add a product either by its product ID or by a product name. When you add a product by name, Picnic searches for it and adds the first result to your cart.
 
-This is handy for automations, for example to top up your cart with a staple like milk or coffee on a schedule, so it is ready the next time you place an order.
+This is handy for automations, for example, to top up your cart with a staple like milk or coffee on a schedule, so it is ready the next time you place an order.
 
 {% include actions/ui_header.md %}
 

--- a/source/_actions/picnic.add_product.markdown
+++ b/source/_actions/picnic.add_product.markdown
@@ -1,0 +1,124 @@
+---
+title: "Add a product to the cart"
+action: picnic.add_product
+domain: picnic
+description: "Adds a product to your Picnic shopping cart by product ID or by searching for a product name."
+---
+
+Use this action to add a product to your Picnic shopping cart. You can add a product either by its product ID or by a product name. When you add a product by name, Picnic searches for it and adds the first result to your cart.
+
+This is handy for automations, for example to top up your cart with a staple like milk or coffee on a schedule, so it is ready the next time you place an order.
+
+{% include actions/ui_header.md %}
+
+To add a product to your cart from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Picnic: Add a product to the cart**.
+6. Select the **Picnic service** to add the product to, then provide a product ID or a product name.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Picnic service:
+  description: The Picnic service to add the product to.
+  required: true
+Product ID:
+  description: The product ID of a Picnic product.
+  required: false
+Product name:
+  description: Search for a product and add the first result.
+  required: false
+Amount:
+  description: The amount to add of the selected product.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `picnic.add_product`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: picnic.add_product
+  data:
+    config_entry_id: 6b4be47a1fa7c3764f14cf756dc9899d
+    product_name: "Picnic cola zero"
+{% endexample %}
+
+This searches for "Picnic cola zero" and adds the first result to your cart.
+
+### Options in YAML
+
+{% options_yaml %}
+config_entry_id:
+  description: >
+    The ID of the Picnic service config entry to add the product to.
+  required: true
+  type: string
+product_id:
+  description: >
+    The product ID of a Picnic product.
+  required: false
+  type: string
+product_name:
+  description: >
+    A product name to search for. The first search result is added to
+    the cart.
+  required: false
+  type: string
+amount:
+  description: >
+    The amount to add of the selected product.
+  required: false
+  type: integer
+  default: 1
+{% endoptions_yaml %}
+
+## Good to know
+
+- Provide either a product ID or a product name, not both. The two are mutually exclusive.
+- When you add a product by name, the first search result is added to your cart.
+- The action fails when no matching product can be found, or when neither a product ID nor a product name is provided.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: add coffee to the cart every Monday
+
+Add a bag of coffee to your Picnic cart at the start of each week, so it is ready for your next order.
+
+- **Trigger**: Every Monday at 09:00
+- **Action**: Picnic: Add a product to the cart
+
+{% details "YAML example for adding coffee every Monday" %}
+
+{% example %}
+automation: |
+  alias: "Add coffee to the Picnic cart"
+  triggers:
+    - trigger: time
+      at: "09:00:00"
+  conditions:
+    - condition: time
+      weekday:
+        - mon
+  actions:
+    - action: picnic.add_product
+      data:
+        config_entry_id: 6b4be47a1fa7c3764f14cf756dc9899d
+        product_name: "Coffee beans"
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/picnic.markdown
+++ b/source/_integrations/picnic.markdown
@@ -48,6 +48,6 @@ This integration provides the following sensors. Some sensors are disabled by de
 
 This integration provides a list containing the content of your shopping cart. This list is provided as a [to-do list](/integrations/todo/) and can also be found in the to-do list dashboard in the main sidebar of your Home Assistant instance.
 
-You can add products to your shopping cart by entering a name in the **Add item** field. Just like with the [Add a product to the cart](/actions/picnic.add_product/) action, a search will be done and the first item found will be added.
+You can add products to your shopping cart by entering a name in the **Add item** field. Just like with the [Add a product to the cart](/actions/picnic.add_product/) action, Picnic searches for the product and adds the first result to your cart.
 
 {% include integrations/actions.md %}

--- a/source/_integrations/picnic.markdown
+++ b/source/_integrations/picnic.markdown
@@ -48,27 +48,6 @@ This integration provides the following sensors. Some sensors are disabled by de
 
 This integration provides a list containing the content of your shopping cart. This list is provided as a [to-do list](/integrations/todo/) and can also be found in the to-do list dashboard in the main sidebar of your Home Assistant instance.
 
-You can add products to your shopping cart by entering a name in the **Add item** field. Just like with the [`picnic.add_product`](#action-picnicadd_product) action, a search will be done and the first item found will be added.
+You can add products to your shopping cart by entering a name in the **Add item** field. Just like with the [Add a product to the cart](/actions/picnic.add_product/) action, a search will be done and the first item found will be added.
 
-## Actions
-
-### Action `picnic.add_product`
-
-Add a product to your cart using the `picnic.add_product` action, either using a product ID or a product name.
-A search will be done and the first result will be added to the cart when one adds a product using a product name.
-The action will fail when no product can be found, or when no `product_id` or `product_name` is specified.
-
-| Data attribute | Optional | Description                                                                      |
-|------------------------|----------|----------------------------------------------------------------------------------|
-| `config_entry_id`      | No       | The Id of the Picnic service config entry.                                       |
-| `product_id`           | yes      | The Picnic product ID.                                                           |
-| `product_name`         | yes      | A product name to search for, the first search result will be added to the cart. |
-| `amount`               | yes      | The amount to add, defaults to 1.                                                |
-
-```yaml
-# Example automation action to add a product to the cart by name.
-- action: picnic.add_product
-  data:
-    config_entry_id: 6b4be47a1fa7c3764f14cf756dc9899d
-    product_name: "Picnic cola zero"
-```
+{% include integrations/actions.md %}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change

Migrates the inline `picnic.add_product` action documentation into a dedicated action page under `source/_actions/`, replacing the inline `## Actions` block on the Picnic integration page with the standard `{% include integrations/actions.md %}`.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

