### PR TITLE
OctoPrint: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/octoprint.printer_connect.markdown
+++ b/source/_actions/octoprint.printer_connect.markdown
@@ -1,0 +1,114 @@
+---
+title: "Connect to a printer"
+action: octoprint.printer_connect
+domain: octoprint
+description: "Instructs the OctoPrint server to connect to a printer."
+---
+
+Use this action to tell your OctoPrint server to connect to a printer. You can let OctoPrint pick the connection settings automatically, or specify a printer profile, serial port, and baud rate.
+
+This is handy in automations, for example to reconnect to your printer automatically after the server reboots, so it is ready to start a print without manual steps.
+
+{% include actions/ui_header.md %}
+
+To connect to a printer from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **OctoPrint: Connect to a printer**.
+6. Select the **Server** that should connect. Optionally, set a profile name, serial port, and baud rate.
+7. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Server:
+  description: The OctoPrint server that should connect to the printer.
+  required: true
+Profile name:
+  description: The printer profile to connect with.
+  required: false
+Serial port:
+  description: The port name to connect on.
+  required: false
+Baudrate:
+  description: The baud rate to connect with.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `octoprint.printer_connect`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: octoprint.printer_connect
+  data:
+    device_id: a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4
+{% endexample %}
+
+This tells the selected OctoPrint server to connect to its printer using the automatic connection settings.
+
+### Options in YAML
+
+{% options_yaml %}
+device_id:
+  description: >
+    The OctoPrint server that should connect to the printer.
+  required: true
+  type: string
+profile_name:
+  description: >
+    The printer profile to connect with.
+  required: false
+  type: string
+port:
+  description: >
+    The serial port name to connect on.
+  required: false
+  type: string
+baudrate:
+  description: >
+    The baud rate to connect with. One of 9600, 19200, 38400, 57600,
+    115200, 230400, or 250000.
+  required: false
+  type: string
+{% endoptions_yaml %}
+
+## Good to know
+
+- When you leave the profile name, serial port, and baud rate empty, OctoPrint uses its automatic connection settings.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: reconnect to the printer after the server reboots
+
+When the OctoPrint server comes back online, tell it to connect to the printer so it is ready for the next print.
+
+- **Trigger**: The OctoPrint server becomes available
+- **Action**: OctoPrint: Connect to a printer
+
+{% details "YAML example for reconnecting after a reboot" %}
+
+{% example %}
+automation: |
+  alias: "Reconnect OctoPrint to the printer"
+  triggers:
+    - trigger: state
+      entity_id: binary_sensor.octoprint_printing
+      from: "unavailable"
+  actions:
+    - action: octoprint.printer_connect
+      data:
+        device_id: a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/octoprint.markdown
+++ b/source/_integrations/octoprint.markdown
@@ -96,11 +96,7 @@ The OctoPrint integration lets you set target bed and tool temperature. These wr
 - Set Target Bed Temperature
 - Set Target Tool (Nozzle) Temperature
 
-## Actions
-
-The OctoPrint integration provides the following actions, which may be invoked from automation, scripts, or as a button interaction.
-
-- Connect to printer
+{% include integrations/actions.md %}
 
 ## Troubleshooting
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change

Migrates the inline `octoprint.printer_connect` action documentation into a dedicated action page under `source/_actions/`, replacing the inline `## Actions` block on the OctoPrint integration page with the standard `{% include integrations/actions.md %}`.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

