### PR TITLE
Todoist: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/todoist.new_task.markdown
+++ b/source/_actions/todoist.new_task.markdown
@@ -44,7 +44,7 @@ Labels:
   description: Any labels that you want to apply to this task, separated by a comma.
   required: false
 Assignee:
-  description: The username of a shared project's member to assign this task to.
+  description: The username of a member of a shared project to assign this task to.
   required: false
 Priority:
   description: The priority of this task, from 1 (normal) to 4 (urgent).
@@ -56,7 +56,7 @@ Due date language:
   description: The language of the due date string.
   required: false
 Due date:
-  description: The time this task is due, in format YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS, in UTC timezone.
+  description: The time this task is due, in the format YYYY-MM-DD or YYYY-MM-DD HH:MM, in the UTC time zone.
   required: false
 Reminder date string:
   description: When you should be reminded of this task, in natural language.
@@ -65,7 +65,7 @@ Reminder date language:
   description: The language of the reminder date string.
   required: false
 Reminder date:
-  description: When you should be reminded of this task, in format YYYY-MM-DDTHH:MM:SS, in UTC timezone.
+  description: When you should be reminded of this task, in the format YYYY-MM-DD HH:MM, in the UTC time zone.
   required: false
 {% endoptions_ui %}
 
@@ -117,7 +117,7 @@ labels:
   type: string
 assignee:
   description: >
-    The username of a shared project's member to assign this task to.
+    The username of a member of a shared project to assign this task to.
   required: false
   type: string
 priority:
@@ -138,8 +138,8 @@ due_date_lang:
   type: string
 due_date:
   description: >
-    The time this task is due, in format YYYY-MM-DD or
-    YYYY-MM-DDTHH:MM:SS, in UTC timezone. Mutually exclusive with the
+    The time this task is due, in the format YYYY-MM-DD or
+    YYYY-MM-DD HH:MM, in the UTC time zone. Mutually exclusive with the
     due date string.
   required: false
   type: string
@@ -156,8 +156,8 @@ reminder_date_lang:
   type: string
 reminder_date:
   description: >
-    When you should be reminded of this task, in format
-    YYYY-MM-DDTHH:MM:SS, in UTC timezone. Mutually exclusive with the
+    When you should be reminded of this task, in the format
+    YYYY-MM-DD HH:MM, in the UTC time zone. Mutually exclusive with the
     reminder date string.
   required: false
   type: string

--- a/source/_actions/todoist.new_task.markdown
+++ b/source/_actions/todoist.new_task.markdown
@@ -1,0 +1,208 @@
+---
+title: "New task"
+action: todoist.new_task
+domain: todoist
+description: "Creates a new Todoist task and adds it to a project."
+---
+
+Use this action to create a new Todoist task. Beyond the basic to-do actions, this action gives you more control over the task, letting you set a project, section, labels, an assignee, a priority, a due date, and a reminder.
+
+This is handy in automations, for example to add a "Take out the bins" task with a due date the evening before collection day, so it shows up in Todoist automatically.
+
+When you leave the project and labels empty, the task goes to your **Inbox** project.
+
+{% include actions/ui_header.md %}
+
+To create a new task from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Todoist: New task**.
+6. Enter the **Content** for the task, and optionally set any of the other fields.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Content:
+  description: The name of the task.
+  required: true
+Description:
+  description: A description for the task.
+  required: false
+Project:
+  description: The name of the project this task should belong to.
+  required: false
+Section:
+  description: The name of a section within the project to add the task to.
+  required: false
+Labels:
+  description: Any labels that you want to apply to this task, separated by a comma.
+  required: false
+Assignee:
+  description: The username of a shared project's member to assign this task to.
+  required: false
+Priority:
+  description: The priority of this task, from 1 (normal) to 4 (urgent).
+  required: false
+Due date string:
+  description: The time this task is due, in natural language.
+  required: false
+Due date language:
+  description: The language of the due date string.
+  required: false
+Due date:
+  description: The time this task is due, in format YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS, in UTC timezone.
+  required: false
+Reminder date string:
+  description: When you should be reminded of this task, in natural language.
+  required: false
+Reminder date language:
+  description: The language of the reminder date string.
+  required: false
+Reminder date:
+  description: When you should be reminded of this task, in format YYYY-MM-DDTHH:MM:SS, in UTC timezone.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `todoist.new_task`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: todoist.new_task
+  data:
+    content: "Pick up the mail"
+    project: "Errands"
+    labels: "Homework,School"
+    priority: 3
+    due_date: "2017-09-12 14:00"
+{% endexample %}
+
+This creates the task "Pick up the mail" in the Errands project.
+
+### Options in YAML
+
+{% options_yaml %}
+content:
+  description: >
+    The name of the task.
+  required: true
+  type: string
+description:
+  description: >
+    A description for the task.
+  required: false
+  type: string
+project:
+  description: >
+    The name of the project this task should belong to. Defaults to your
+    Inbox project.
+  required: false
+  type: string
+section:
+  description: >
+    The name of a section within the project to add the task to.
+  required: false
+  type: string
+labels:
+  description: >
+    Any labels that you want to apply to this task, separated by a comma.
+  required: false
+  type: string
+assignee:
+  description: >
+    The username of a shared project's member to assign this task to.
+  required: false
+  type: string
+priority:
+  description: >
+    The priority of this task, from 1 (normal) to 4 (urgent).
+  required: false
+  type: integer
+due_date_string:
+  description: >
+    The time this task is due, in natural language. Mutually exclusive
+    with the due date.
+  required: false
+  type: string
+due_date_lang:
+  description: >
+    The language of the due date string.
+  required: false
+  type: string
+due_date:
+  description: >
+    The time this task is due, in format YYYY-MM-DD or
+    YYYY-MM-DDTHH:MM:SS, in UTC timezone. Mutually exclusive with the
+    due date string.
+  required: false
+  type: string
+reminder_date_string:
+  description: >
+    When you should be reminded of this task, in natural language.
+    Mutually exclusive with the reminder date.
+  required: false
+  type: string
+reminder_date_lang:
+  description: >
+    The language of the reminder date string.
+  required: false
+  type: string
+reminder_date:
+  description: >
+    When you should be reminded of this task, in format
+    YYYY-MM-DDTHH:MM:SS, in UTC timezone. Mutually exclusive with the
+    reminder date string.
+  required: false
+  type: string
+{% endoptions_yaml %}
+
+## Good to know
+
+- For everyday tasks, you can also use the actions from the [to-do](/integrations/todo/) integration to create, update, and delete to-do items.
+- The due date string and the due date are mutually exclusive. Use one or the other.
+- The reminder date string and the reminder date are mutually exclusive. Use one or the other.
+- When you leave the project empty, the task goes to your **Inbox** project.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: add a bin collection reminder
+
+The evening before bin collection, add a Todoist task with a due date so it shows up in your list.
+
+- **Trigger**: Every Tuesday at 18:00
+- **Action**: Todoist: New task
+
+{% details "YAML example for a bin collection reminder" %}
+
+{% example %}
+automation: |
+  alias: "Add bin collection task"
+  triggers:
+    - trigger: time
+      at: "18:00:00"
+  conditions:
+    - condition: time
+      weekday:
+        - tue
+  actions:
+    - action: todoist.new_task
+      data:
+        content: "Take out the bins"
+        due_date_string: "tomorrow at 7am"
+        due_date_lang: "en"
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/todoist.markdown
+++ b/source/_integrations/todoist.markdown
@@ -153,61 +153,8 @@ the Todoist UI.
 
 ## Actions
 
-You may use the actions from the [todo](/integrations/todo/) integration for
-creating, updating, or deleting to-do items on the to-do list.
+You may use the actions from the [to-do](/integrations/todo/) integration for creating, updating, or deleting to-do items on the to-do list.
 
-Todoist also comes with an additional action, `todoist.new_task` that offers
-more advanced attributes when creating a Todoist task. You can specify labels
-and a project, or you can leave them blank, and the task will go to your
-**Inbox** project.
+Todoist also comes with an additional action that offers more advanced attributes when creating a Todoist task.
 
-Here are two example JSON payloads resulting in the same task:
-
-```json
-{
-    "content": "Pick up the mail",
-    "project": "Errands",
-    "labels":"Homework,School",
-    "priority":3,
-    "due_date":"2017-09-12 14:00"
-}
-```
-
-```json
-{
-    "content": "Pick up the mail",
-    "project": "Errands",
-    "labels":"Homework,School",
-    "priority":3,
-    "due_date_string":"tomorrow at 14:00",
-    "due_date_lang":"en"
-}
-```
-
-- **content** (*Required*): The name of the task you want to create.
-
-- **description** (*Optional*): A description of the task.
-
-- **project** (*Optional*): The project to put the task in.
-
-- **section** (*Optional*): The section within the project to add the task to.
-
-- **labels** (*Optional*): Any labels you want to add to the task, separated by commas.
-
-- **assignee** (*Optional*): A member's username of a shared project to assign this task to. You find the username formatted as bold text in the collaborator menu of a shared project. 
-
-- **priority** (*Optional*): The priority of the task, from 1-4. Again, 1 means least important, and 4 means most important.
-
-- **due_date_string** (*Optional*): When the task should be due, in [natural language](https://get.todoist.help/hc/articles/205325931-Dates-and-Times). Mutually exclusive with `due_date`
-
-- **due_date_lang** (*Optional*): When `due_date_string` is set, it is possible to set the language.
-  Valid languages are: `en`, `da`, `pl`, `zh`, `ko`, `de`, `pt`, `ja`, `it`, `fr`, `sv`, `ru`, `es`, `nl`
-
-- **due_date** (*Optional*): When the task should be due, in either YYYY-MM-DD format or YYYY-MM-DD HH:MM format  (in UTC timezone). Mutually exclusive with `due_date_string`.
-
-- **reminder_date_string** (*Optional*):  When should user be reminded of this task, in [natural language](https://get.todoist.help/hc/articles/205325931-Dates-and-Times). Mutually exclusive with `reminder_date`
-
-- **reminder_date_lang** (*Optional*): When `reminder_date_string` is set, it is possible to set the language.
-  Valid languages are: `en`, `da`, `pl`, `zh`, `ko`, `de`, `pt`, `ja`, `it`, `fr`, `sv`, `ru`, `es`, `nl`
-
-- **reminder_date** (*Optional*): When should the user be reminded of this task, in either YYYY-MM-DD format or YYYY-MM-DD HH:MM format (in UTC timezone). Mutually exclusive with `reminder_date_string`.
+{% include integrations/actions.md %}

--- a/source/_integrations/todoist.markdown
+++ b/source/_integrations/todoist.markdown
@@ -151,10 +151,4 @@ the Todoist UI.
 
 - **due_today**: Whether the reported task is due today.
 
-## Actions
-
-You may use the actions from the [to-do](/integrations/todo/) integration for creating, updating, or deleting to-do items on the to-do list.
-
-Todoist also comes with an additional action that offers more advanced attributes when creating a Todoist task.
-
 {% include integrations/actions.md %}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change

Migrates the inline `todoist.new_task` action documentation into a dedicated action page under `source/_actions/`, replacing the inline `## Actions` block on the Todoist integration page with the standard `{% include integrations/actions.md %}`. The pointer to the to-do integration actions is kept.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

