### PR TITLE
Roon: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/roon.transfer.markdown
+++ b/source/_actions/roon.transfer.markdown
@@ -1,0 +1,98 @@
+---
+title: "Transfer"
+action: roon.transfer
+domain: roon
+description: "Transfers playback from one Roon player to another."
+---
+
+Use this action to move playback from one Roon player to another. The player you target is the source, and the transfer ID you provide is the destination.
+
+This is handy in automations, for example to follow you around the house by moving the music to the player in whichever room you walk into.
+
+{% include actions/ui_header.md %}
+
+To transfer playback from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the source player you want to transfer playback from.
+6. From the actions shown for that target, select **Transfer**.
+7. Set the **Transfer ID** to the destination player.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Transfer ID:
+  description: The destination player to transfer playback to.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `roon.transfer`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: roon.transfer
+  target:
+    entity_id: media_player.living_room
+  data:
+    transfer_id: media_player.kitchen
+{% endexample %}
+
+This transfers playback from `media_player.living_room` to `media_player.kitchen`.
+
+### Options in YAML
+
+{% options_yaml %}
+transfer_id:
+  description: >
+    The destination player to transfer playback to.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="media_player" %}
+
+## Good to know
+
+- The target is the source player, and the transfer ID is the destination player.
+- Both players must be Roon media players.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: move music to the kitchen in the evening
+
+In the evening, move whatever is playing in the living room to the kitchen player.
+
+- **Trigger**: Every day at 18:00
+- **Action**: Transfer
+  - **Target**: Living room player
+  - **Transfer ID**: Kitchen player
+
+{% details "YAML example for moving music in the evening" %}
+
+{% example %}
+automation: |
+  alias: "Move Roon music to the kitchen"
+  triggers:
+    - trigger: time
+      at: "18:00:00"
+  actions:
+    - action: roon.transfer
+      target:
+        entity_id: media_player.living_room
+      data:
+        transfer_id: media_player.kitchen
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/roon.markdown
+++ b/source/_integrations/roon.markdown
@@ -28,28 +28,19 @@ This integration uses Roon Core, a Roon application that runs on a machine on yo
 5. Roon core will then provide Home Assistant with the details of your media players.
 6. In Home Assistant you can then pick an area for each of your music players, and add them to Home Assistant.
 
-## Actions
+## Playing media
 
-### Action: Play media
+The [`media_player.play_media`](/integrations/media_player/) action plays media on a Roon player. Roon uses a path based on the Roon browser hierarchy to specify which media to play. You can find this by using the media browser, or by following the examples below. If Roon can't follow the path, you will find an error in the log that shows which part of the path Roon could not follow, and the possibilities at that point.
 
-The `media_player.play_media` action plays media on a Roon player. Roon uses a path based on the Roon browser hierarchy to specify which media to play. You can find this by using the media browser, or by following the examples below. If roon can't follow the path you will find an error in the log that will show which part of the path roon could not follow, and the possibilities at that point.
+This action accepts the following data:
 
-| Data attribute | Optional | Description                                                             |
-| ---------------------- | -------- | ----------------------------------------------------------------------- |
-| `entity_id`            | yes      | Target a specific media player. To target all media players, use `all`. |
-| `media_content_id`     | no       | A path to specify the media you want to play, see examples below.       |
-| `media_content_type`   | no       | Only `music` is supported                                               |
+- `entity_id` (optional): Target a specific media player. To target all media players, use `all`.
+- `media_content_id` (required): A path to specify the media you want to play. See the examples below.
+- `media_content_type` (required): Only `music` is supported.
 
- For example to play the album Harvest by Neil Young you should set `media_content_id` to `Library/Artists/Neil Young/Harvest` and to play BBC Radio 4 you would set `media_content_id` to `My Live Radio/BBC Radio 4`
+For example, to play the album Harvest by Neil Young, set `media_content_id` to `Library/Artists/Neil Young/Harvest`. To play BBC Radio 4, set `media_content_id` to `My Live Radio/BBC Radio 4`.
 
-### Action: Transfer
-
-The `roon.transfer` action transfers playback from one player to another.
-
-| Data attribute | Optional | Description                   |
-| ---------------------- | -------- | ----------------------------- |
-| `entity_id`            | yes      | id of the source player.      |
-| `transfer_id`          | no       | id of the destination player. |
+{% include integrations/actions.md %}
 
 ## Roon endpoint volume control via Home Assistant
 

--- a/source/_integrations/roon.markdown
+++ b/source/_integrations/roon.markdown
@@ -30,11 +30,10 @@ This integration uses Roon Core, a Roon application that runs on a machine on yo
 
 ## Playing media
 
-The [`media_player.play_media`](/integrations/media_player/) action plays media on a Roon player. Roon uses a path based on the Roon browser hierarchy to specify which media to play. You can find this by using the media browser, or by following the examples below. If Roon can't follow the path, you will find an error in the log that shows which part of the path Roon could not follow, and the possibilities at that point.
+The [`media_player.play_media`](/actions/media_player.play_media/) action plays media on a Roon player. Roon uses a path based on the Roon browser hierarchy to specify which media to play. You can find this by using the media browser, or by following the examples below. If Roon can't follow the path, you will find an error in the log that shows which part of the path Roon could not follow, and the possibilities at that point.
 
-This action accepts the following data:
+Target the media player you want to control, then provide the following data:
 
-- `entity_id` (optional): Target a specific media player. To target all media players, use `all`.
 - `media_content_id` (required): A path to specify the media you want to play. See the examples below.
 - `media_content_type` (required): Only `music` is supported.
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change

Migrates the Roon-specific `roon.transfer` action into a dedicated action page under `source/_actions/`, and replaces the inline `## Actions` block with the standard `{% include integrations/actions.md %}`. The Roon-specific guidance for the generic `media_player.play_media` action is kept on the integration page (table converted to a list).

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

