### PR TITLE
Sony Songpal: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/songpal.set_sound_setting.markdown
+++ b/source/_actions/songpal.set_sound_setting.markdown
@@ -7,7 +7,7 @@ description: "Changes a sound setting on a Sony Songpal device."
 
 Use this action to change a sound setting on a Sony Songpal device, such as turning night mode on or off. You provide the name of the setting and the value you want to set.
 
-This is handy in automations, for example to switch on night mode on your soundbar in the evening so late-night viewing stays quiet.
+This is handy in an automation to switch on night mode on your soundbar in the evening so late-night viewing stays quiet, for example.
 
 {% include actions/ui_header.md %}
 

--- a/source/_actions/songpal.set_sound_setting.markdown
+++ b/source/_actions/songpal.set_sound_setting.markdown
@@ -1,0 +1,108 @@
+---
+title: "Set sound setting"
+action: songpal.set_sound_setting
+domain: songpal
+description: "Changes a sound setting on a Sony Songpal device."
+---
+
+Use this action to change a sound setting on a Sony Songpal device, such as turning night mode on or off. You provide the name of the setting and the value you want to set.
+
+This is handy in automations, for example to switch on night mode on your soundbar in the evening so late-night viewing stays quiet.
+
+{% include actions/ui_header.md %}
+
+To change a sound setting from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Songpal device you want to change.
+6. From the actions shown for that target, select **Set sound setting**.
+7. Enter the **Name** of the setting and the **Value** to set.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Name:
+  description: The name of the setting to change.
+  required: true
+Value:
+  description: The value to set.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `songpal.set_sound_setting`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: songpal.set_sound_setting
+  target:
+    entity_id: media_player.soundbar
+  data:
+    name: "nightMode"
+    value: "on"
+{% endexample %}
+
+This turns on night mode on `media_player.soundbar`.
+
+### Options in YAML
+
+{% options_yaml %}
+name:
+  description: >
+    The name of the setting to change.
+  required: true
+  type: string
+value:
+  description: >
+    The value to set.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="media_player" %}
+
+## Good to know
+
+- To list the available settings and their possible values, use the [`songpal sound`](https://github.com/rytilahti/python-songpal#sound-settings) command from the python-songpal library.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: turn on night mode in the evening
+
+In the evening, switch on night mode on your soundbar so late-night viewing stays quiet.
+
+- **Trigger**: Every day at 22:00
+- **Action**: Set sound setting
+  - **Target**: Soundbar
+  - **Name**: nightMode
+  - **Value**: on
+
+{% details "YAML example for turning on night mode" %}
+
+{% example %}
+automation: |
+  alias: "Turn on Songpal night mode"
+  triggers:
+    - trigger: time
+      at: "22:00:00"
+  actions:
+    - action: songpal.set_sound_setting
+      target:
+        entity_id: media_player.soundbar
+      data:
+        name: "nightMode"
+        value: "on"
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/songpal.markdown
+++ b/source/_integrations/songpal.markdown
@@ -33,8 +33,6 @@ A few notes:
 
 See [python-songpal's documentation](https://github.com/rytilahti/python-songpal#locating-the-endpoint) how to get your API endpoint.
 
-## Actions
-
-In addition to the general [media player actions](/integrations/media_player/#actions), the following actions are provided.
-
 {% include integrations/actions.md %}
+
+In addition to these, Sony Songpal devices support the general [media player actions](/integrations/media_player/#list-of-actions).

--- a/source/_integrations/songpal.markdown
+++ b/source/_integrations/songpal.markdown
@@ -35,14 +35,6 @@ See [python-songpal's documentation](https://github.com/rytilahti/python-songpal
 
 ## Actions
 
-In addition to the general [media player actions](/integrations/media_player/#actions), the following actions are provided:
+In addition to the general [media player actions](/integrations/media_player/#actions), the following actions are provided.
 
-### Action: Set sound setting
-
-The `songpal.set_sound_setting` action sets a sound setting. For a list of available settings and their values use the [`songpal sound`](https://github.com/rytilahti/python-songpal#sound-settings) command.
-
-| Data attribute | Optional | Description                                      |
-|------------------------|----------|--------------------------------------------------|
-| `entity_id`            |      yes | Target entity. To target all songpal devices, use `all` |
-| `name`                 |       no | Configuration variable, e.g., `nightmode`         |
-| `value`                |       no | New configuration value, e.g., `on`               |
+{% include integrations/actions.md %}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change

Migrates the inline `songpal.set_sound_setting` action documentation into a dedicated action page under `source/_actions/`, replacing the inline `## Actions` block on the Sony Songpal integration page with the standard `{% include integrations/actions.md %}`.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

