### PR TITLE
Tibber: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/tibber.get_prices.markdown
+++ b/source/_actions/tibber.get_prices.markdown
@@ -7,7 +7,7 @@ description: "Fetches hourly Tibber energy prices for a date range."
 
 Use this action to fetch the hourly energy prices for your Tibber homes. You can fetch the prices for today, or set a date range to get prices for a specific period.
 
-This action returns its result in a response variable, which you can use in later steps of the same automation or script, for example to find the cheapest hour to run an appliance.
+This action returns its result in a response variable, which you can use in later steps of the same automation or script, for example to find the cheapest time to run an appliance.
 
 {% include actions/ui_header.md %}
 
@@ -30,7 +30,7 @@ Start:
   description: The date and time from which to retrieve prices. Defaults to today if omitted.
   required: false
 End:
-  description: The date and time until which to retrieve prices. Defaults to the last hour of today if omitted.
+  description: The date and time until which to retrieve prices. Defaults to the end of today if omitted.
   required: false
 {% endoptions_ui %}
 
@@ -47,7 +47,7 @@ action: |
   response_variable: energy_prices
 {% endexample %}
 
-This fetches the hourly energy prices for the first of January 2024.
+This fetches the energy prices for the first of January 2024.
 
 ### Options in YAML
 
@@ -61,7 +61,7 @@ start:
 end:
   description: >
     The date and time until which to retrieve prices, such as
-    2024-01-01 23:00:00. Defaults to the last hour of today if omitted.
+    2024-01-01 23:00:00. Defaults to the end of today if omitted.
   required: false
   type: string
 {% endoptions_yaml %}
@@ -71,8 +71,7 @@ end:
 The response is a dictionary with a `prices` key, which holds an entry for each of your Tibber homes. Each home contains a list of price entries, and each entry includes the following fields:
 
 - `start_time`: The start time of the price, returned in local time.
-- `price`: The total energy price (energy and taxes) for that hour.
-
+- `price`: The total energy price (energy and taxes) for that interval.
 A shortened example of the response looks like this:
 
 ```yaml
@@ -80,7 +79,7 @@ prices:
   Nickname_Home:
     - start_time: "2023-12-09 03:00:00+02:00"
       price: 0.46914
-    - start_time: "2023-12-09 04:00:00+02:00"
+    - start_time: "2023-12-09 03:15:00+02:00"
       price: 0.46914
 ```
 

--- a/source/_actions/tibber.get_prices.markdown
+++ b/source/_actions/tibber.get_prices.markdown
@@ -1,0 +1,91 @@
+---
+title: "Get energy prices"
+action: tibber.get_prices
+domain: tibber
+description: "Fetches hourly Tibber energy prices for a date range."
+---
+
+Use this action to fetch the hourly energy prices for your Tibber homes. You can fetch the prices for today, or set a date range to get prices for a specific period.
+
+This action returns its result in a response variable, which you can use in later steps of the same automation or script, for example to find the cheapest hour to run an appliance.
+
+{% include actions/ui_header.md %}
+
+To get energy prices from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Tibber: Get energy prices**.
+6. Optionally, set a **Start** and **End** to fetch prices for a specific period.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Start:
+  description: The date and time from which to retrieve prices. Defaults to today if omitted.
+  required: false
+End:
+  description: The date and time until which to retrieve prices. Defaults to the last hour of today if omitted.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `tibber.get_prices`. Store the result in a response variable so you can use it in later steps:
+
+{% example %}
+action: |
+  action: tibber.get_prices
+  data:
+    start: "2024-01-01 00:00:00"
+    end: "2024-01-01 23:00:00"
+  response_variable: energy_prices
+{% endexample %}
+
+This fetches the hourly energy prices for the first of January 2024.
+
+### Options in YAML
+
+{% options_yaml %}
+start:
+  description: >
+    The date and time from which to retrieve prices, such as
+    2024-01-01 00:00:00. Defaults to today if omitted.
+  required: false
+  type: string
+end:
+  description: >
+    The date and time until which to retrieve prices, such as
+    2024-01-01 23:00:00. Defaults to the last hour of today if omitted.
+  required: false
+  type: string
+{% endoptions_yaml %}
+
+## Response data
+
+The response is a dictionary with a `prices` key, which holds an entry for each of your Tibber homes. Each home contains a list of price entries, and each entry includes the following fields:
+
+- `start_time`: The start time of the price, returned in local time.
+- `price`: The total energy price (energy and taxes) for that hour.
+
+A shortened example of the response looks like this:
+
+```yaml
+prices:
+  Nickname_Home:
+    - start_time: "2023-12-09 03:00:00+02:00"
+      price: 0.46914
+    - start_time: "2023-12-09 04:00:00+02:00"
+      price: 0.46914
+```
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/tibber.markdown
+++ b/source/_integrations/tibber.markdown
@@ -123,47 +123,9 @@ The Tibber integration provides binary sensors.
 
 ## Actions
 
-The hourly prices are exposed using [actions](/docs/scripts/perform-actions/). The actions populate [response data](/docs/scripts/perform-actions#use-templates-to-handle-response-data) with price data.
+The hourly prices are exposed using an action that returns [response data](/docs/scripts/perform-actions#use-templates-to-handle-response-data) with the price data.
 
-### Action: Get prices
-
-The `tibber.get_prices` action fetches hourly energy prices.
-
-| Data attribute | Optional | Description                                           | Example             |
-| -------------- | -------- | ----------------------------------------------------- | ------------------- |
-| `start`        | yes      | Start time to get prices. Defaults to today 00:00:00  | 2024-01-01 00:00:00 |
-| `end`          | yes      | End time to get prices. Defaults to tomorrow 00:00:00 | 2024-01-01 00:00:00 |
-
-#### Response data
-
-The response data is a dictionary with the energy prices for each Home. `start_time` is returned in local time from the API.
-
-```json
-{
-  "prices": {
-    "Nickname_Home":[
-      {
-        "start_time": "2023-12-09 03:00:00+02:00",
-        "price": 0.46914,
-      },
-      {
-        "start_time": "2023-12-09 04:00:00+02:00",
-        "price": 0.46914,
-      }
-    ],
-    "Nickname_Home_2":[
-      {
-        "start_time": "2023-12-09 03:00:00+02:00",
-        "price": 0.46914,
-      },
-      {
-        "start_time": "2023-12-09 04:00:00+02:00",
-        "price": 0.46914,
-      }
-    ]
-  }
-}
-```
+{% include integrations/actions.md %}
 
 ## Examples
 

--- a/source/_integrations/tibber.markdown
+++ b/source/_integrations/tibber.markdown
@@ -123,7 +123,7 @@ The Tibber integration provides binary sensors.
 
 ## Actions
 
-The hourly prices are exposed using an action that returns [response data](/docs/scripts/perform-actions#use-templates-to-handle-response-data) with the price data.
+The energy prices are exposed using an action that returns [response data](/docs/scripts/perform-actions#use-templates-to-handle-response-data) with the price data.
 
 {% include integrations/actions.md %}
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change

Migrates the inline `tibber.get_prices` action documentation into a dedicated action page under `source/_actions/`, replacing the inline `## Actions` block on the Tibber integration page with the standard `{% include integrations/actions.md %}`. The response data section was verified against the core source (only `start_time` and `price` are returned).

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

