### PR TITLE
Blue Current: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/blue_current.start_charge_session.markdown
+++ b/source/_actions/blue_current.start_charge_session.markdown
@@ -7,7 +7,7 @@ description: "Starts a new charge session on a Blue Current charge point."
 
 Use this action to start a new charge session on one of your Blue Current charge points. You can optionally provide a charging card ID to start the session with a specific card.
 
-This is handy in automations, for example to start charging your car automatically when cheaper night-time electricity rates begin.
+This is handy in an automation, for example, to start charging your car automatically when cheaper night-time electricity rates begin.
 
 {% include actions/ui_header.md %}
 

--- a/source/_actions/blue_current.start_charge_session.markdown
+++ b/source/_actions/blue_current.start_charge_session.markdown
@@ -1,0 +1,98 @@
+---
+title: "Start charge session"
+action: blue_current.start_charge_session
+domain: blue_current
+description: "Starts a new charge session on a Blue Current charge point."
+---
+
+Use this action to start a new charge session on one of your Blue Current charge points. You can optionally provide a charging card ID to start the session with a specific card.
+
+This is handy in automations, for example to start charging your car automatically when cheaper night-time electricity rates begin.
+
+{% include actions/ui_header.md %}
+
+To start a charge session from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Blue Current: Start charge session**.
+6. Select the **Device ID** of the charge point. Optionally, set a charging card ID.
+7. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Device ID:
+  description: The Blue Current charge point to start the session on.
+  required: true
+Charging card ID:
+  description: The charging card ID used to start the session. When not provided, no charging card is used.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `blue_current.start_charge_session`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: blue_current.start_charge_session
+  data:
+    device_id: a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4
+{% endexample %}
+
+This starts a charge session on the selected charge point without a charging card.
+
+### Options in YAML
+
+{% options_yaml %}
+device_id:
+  description: >
+    The Blue Current charge point to start the session on.
+  required: true
+  type: string
+charging_card_id:
+  description: >
+    The charging card ID used to start the session. When not provided,
+    no charging card is used.
+  required: false
+  type: string
+{% endoptions_yaml %}
+
+## Good to know
+
+- When you do not provide a charging card ID, the session starts without a charging card.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: start charging when night rates begin
+
+When the cheaper night-time electricity rate starts, begin a charge session on your charge point.
+
+- **Trigger**: Night-time tariff helper turns on
+- **Action**: Blue Current: Start charge session
+
+{% details "YAML example for starting a charge session at night" %}
+
+{% example %}
+automation: |
+  alias: "Start charging at night rate"
+  triggers:
+    - trigger: state
+      entity_id: binary_sensor.night_tariff
+      to: "on"
+  actions:
+    - action: blue_current.start_charge_session
+      data:
+        device_id: a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/blue_current.start_charge_session.markdown
+++ b/source/_actions/blue_current.start_charge_session.markdown
@@ -18,13 +18,13 @@ To start a charge session from an automation or a script:
 3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
 4. In the **Then do** section, select **Add action**.
 5. From the search box, search for and select **Blue Current: Start charge session**.
-6. Select the **Device ID** of the charge point. Optionally, set a charging card ID.
+6. Select the **Device** to start the session on. Optionally, set **Charging card ID**.
 7. Select **Save**.
 
 ### Options in the UI
 
 {% options_ui %}
-Device ID:
+Device:
   description: The Blue Current charge point to start the session on.
   required: true
 Charging card ID:

--- a/source/_integrations/blue_current.markdown
+++ b/source/_integrations/blue_current.markdown
@@ -79,17 +79,7 @@ The Blue Current integration provides the following buttons:
 - Reboot
 - Stop charge session
 
-## Actions
-The following actions are provided by the Blue Current integration:
-
-### Action: Start charge session
-
-The `blue_current.start_charge_session` action allows you to start a new charge session. When no charging card ID is provided, no charging card will be used.
-
-| Data attribute | Optional | Description |
-| -------------- | -------- | ----------- |
-| `device_id` | no | Charge point device ID |
-| `charging_card_id` | yes | Charging card ID that will be used to start a charge session. |
+{% include integrations/actions.md %}
 
 ## Switch
 

--- a/source/_integrations/blue_current.markdown
+++ b/source/_integrations/blue_current.markdown
@@ -79,8 +79,6 @@ The Blue Current integration provides the following buttons:
 - Reboot
 - Stop charge session
 
-{% include integrations/actions.md %}
-
 ## Switch
 
 The Blue Current integration provides the following switches:
@@ -91,3 +89,5 @@ The Blue Current integration provides the following switches:
   - When enabled, visitors can't use the charge point. Only linked charging cards are allowed.
 - Toggle charge point block
   - Enables or disables a charge point.
+ 
+{% include integrations/actions.md %}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change

Migrates the inline `start_charge_session` action documentation on the Blue Current integration page into a dedicated action page under `source/_actions/`, replacing the inline section with the standard actions include.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

