### PR TITLE
LinkPlay: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/linkplay.play_preset.markdown
+++ b/source/_actions/linkplay.play_preset.markdown
@@ -1,0 +1,69 @@
+---
+title: "Play preset"
+action: linkplay.play_preset
+domain: linkplay
+description: "Plays a preset stored on a LinkPlay media player."
+---
+
+Use this action to play one of the presets stored on your LinkPlay media player. Companion apps, such as 4stream, let you save music presets, like a Spotify playlist or a radio station. This action starts playing one of those presets by its number.
+
+This is handy in automations, for example to start your favorite radio station on a speaker when your morning alarm goes off.
+
+{% include actions/ui_header.md %}
+
+To play a preset from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select a LinkPlay media player.
+6. From the actions shown for that target, select **Play preset**.
+7. Set the **Preset number** you want to play.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Preset number:
+  description: The number of the preset to play.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `linkplay.play_preset`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: linkplay.play_preset
+  target:
+    entity_id: media_player.living_room_speaker
+  data:
+    preset_number: 1
+{% endexample %}
+
+This plays the first preset on the selected LinkPlay media player.
+
+### Options in YAML
+
+{% options_yaml %}
+preset_number:
+  description: The number of the preset to play.
+  required: true
+  type: integer
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="media_player" %}
+
+## Good to know
+
+- Presets are stored on the device itself. Use a companion app, such as 4stream, to save presets before you can play them with this action.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/linkplay.markdown
+++ b/source/_integrations/linkplay.markdown
@@ -38,6 +38,5 @@ The button entities provide some additional LinkPlay features available on the d
 - **Time Sync**: Synchronize the device's internal clock with the current time in Home Assistant. 
 - **Restart Device**: Reboot the device, allowing for convenient troubleshooting and maintenance.
 
-The LinkPlay integration makes various custom actions available in addition to the [standard media player actions](/integrations/media_player/#actions).
 
 {% include integrations/actions.md %}

--- a/source/_integrations/linkplay.markdown
+++ b/source/_integrations/linkplay.markdown
@@ -38,19 +38,6 @@ The button entities provide some additional LinkPlay features available on the d
 - **Time Sync**: Synchronize the device's internal clock with the current time in Home Assistant. 
 - **Restart Device**: Reboot the device, allowing for convenient troubleshooting and maintenance.
 
-## Actions
-
 The LinkPlay integration makes various custom actions available in addition to the [standard media player actions](/integrations/media_player/#actions).
 
-### Action: Play preset
-
-The `linkplay.play_preset` action plays a preset on a LinkPlay media player. 
-
-{% note %}
-Companion apps, such as 4stream, allow you to save music presets (for example, Spotify playlists). This action can be used to start playing these presets. 
-{% endnote %}
-
-| Data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `entity_id` | no | The speakers to target. To target all LinkPlay devices, use `all`.
-| `preset_number` | no | The number of the preset to play.
+{% include integrations/actions.md %}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change

Migrates the inline `play_preset` action documentation on the LinkPlay integration page into a dedicated action page under `source/_actions/`, replacing the inline section with the standard actions include.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

