### PR TITLE
Swiss public transport: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/swiss_public_transport.fetch_connections.markdown
+++ b/source/_actions/swiss_public_transport.fetch_connections.markdown
@@ -1,0 +1,90 @@
+---
+title: "Fetch connections"
+action: swiss_public_transport.fetch_connections
+domain: swiss_public_transport
+description: "Fetches a list of upcoming connections from Swiss public transport."
+---
+
+Use this action to fetch a list of upcoming connections for one of your configured Swiss public transport instances. Each instance represents a specific start and destination, so the action returns the next departures for that route.
+
+This action returns its result in a response variable, which you can use in later steps of the same automation or script. For example, you can read out the next train departure on a dashboard or send it in a notification.
+
+{% include actions/ui_header.md %}
+
+To fetch connections from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Swiss public transport: Fetch connections**.
+6. Select the **Instance** to fetch connections for. Optionally, set a **Limit** for the number of connections to return.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Instance:
+  description: The Swiss public transport instance to fetch connections for.
+  required: true
+Limit:
+  description: The number of connections to fetch.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `swiss_public_transport.fetch_connections`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: swiss_public_transport.fetch_connections
+  data:
+    config_entry_id: zurich_geneva
+    limit: 3
+  response_variable: connections
+{% endexample %}
+
+This fetches the next three connections for the selected instance.
+
+### Options in YAML
+
+{% options_yaml %}
+config_entry_id:
+  description: >
+    The Swiss public transport instance to fetch connections for.
+  required: true
+  type: string
+limit:
+  description: >
+    The number of connections to fetch, between 1 and 15.
+  required: false
+  type: integer
+{% endoptions_yaml %}
+
+## Response data
+
+The action returns a `connections` list. Each connection includes the following information:
+
+- `departure`: The departure time of the connection.
+- `duration`: The travel duration, in seconds.
+- `platform`: The platform the connection departs from.
+- `remaining_time`: The time remaining until departure.
+- `start`: The name of the start station.
+- `destination`: The name of the destination station.
+- `train_number`: The train number of the connection.
+- `transfers`: The number of transfers along the way.
+- `delay`: The departure delay, in minutes.
+- `line`: The line name of the connection.
+
+## Good to know
+
+- When you do not set a limit, the action returns three connections.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/swiss_public_transport.markdown
+++ b/source/_integrations/swiss_public_transport.markdown
@@ -84,20 +84,7 @@ When configured for arrival time, the sensor will display the arrival time at th
 
 A popular use case would be to know if your family member is running late and sending out a push notification or displaying their arrival time at home.
 
-## Actions
-
-The Swiss public transport integration has the following action:
-
-- `swiss_public_transport.fetch_connections`
-
-### Action: Fetch connections
-
-The `swiss_public_transport.fetch_connections` action fetches the connections for a specific instance.
-
-| Data attribute | Optional | Description                                              |
-|------------------------|----------|----------------------------------------------------------|
-| `config_entry_id`      | No       | The ID of the Swiss public transport config entry to get data from. For example, in YAML: `config_entry_id: zurich_geneva` or in UI `Instance: zurich_geneva`)|
-| `limit`                | Yes      | The number of connections to fetch. (default: 3, range: [1,15])|
+{% include integrations/actions.md %}
 
 ## Defining a custom polling interval
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change

Migrates the inline `fetch_connections` action documentation on the Swiss public transport integration page into a dedicated action page under `source/_actions/`, replacing the inline section with the standard actions include. Also documents the response data returned by the action.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

