### PR TITLE
Bosch Alarm: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/bosch_alarm.set_date_time.markdown
+++ b/source/_actions/bosch_alarm.set_date_time.markdown
@@ -1,0 +1,78 @@
+---
+title: "Set date & time"
+action: bosch_alarm.set_date_time
+domain: bosch_alarm
+description: "Sets the date and time on a Bosch alarm panel."
+---
+
+Use this action to set the date and time on your Bosch alarm panel. When you do not provide a date and time, the current date and time of your Home Assistant instance is used.
+
+This is handy to keep the clock on your panel in sync, for example with an automation that updates it after a power outage or on a regular schedule.
+
+{% include actions/ui_header.md %}
+
+To set the panel date and time from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Bosch Alarm: Set date & time**.
+6. Select the **Config entry** of the panel to update. Optionally, set the **Date & time** you want.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Config entry:
+  description: The Bosch alarm panel to update.
+  required: true
+Date & time:
+  description: The date and time to set. When not provided, the current date and time is used.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `bosch_alarm.set_date_time`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: bosch_alarm.set_date_time
+  data:
+    config_entry_id: a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4
+    datetime: "2025-05-01T12:00:00"
+{% endexample %}
+
+This sets the date and time on the selected panel to the given value.
+
+### Options in YAML
+
+{% options_yaml %}
+config_entry_id:
+  description: >
+    The Bosch alarm panel to update.
+  required: true
+  type: string
+datetime:
+  description: >
+    The date and time to set. The time zone of your Home Assistant instance
+    is assumed. When not provided, the current date and time is used.
+  required: false
+  type: string
+{% endoptions_yaml %}
+
+## Good to know
+
+- When you do not provide a date and time, the current date and time of your Home Assistant instance is used.
+- The time zone of your Home Assistant instance is assumed for the value you provide.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/bosch_alarm.set_date_time.markdown
+++ b/source/_actions/bosch_alarm.set_date_time.markdown
@@ -59,7 +59,7 @@ config_entry_id:
 datetime:
   description: >
     The date and time to set. The time zone of your Home Assistant instance
-    is assumed. When not provided, the current date and time is used.
+    is assumed. When not provided, the current date and time are used.
   required: false
   type: string
 {% endoptions_yaml %}
@@ -72,6 +72,29 @@ datetime:
 {% include actions/try_it.md %}
 
 {% include actions/more_examples.md %}
+
+### Automation: keep the panel clock in sync
+
+Bosch alarm panels can drift over time. This automation re-syncs the panel clock to your Home Assistant time every night, so the panel always shows the correct date and time. Because no date and time are provided, the current Home Assistant time is used.
+
+- **Trigger**: A scheduled time
+- **Action**: Bosch Alarm: Set date & time
+
+{% details "YAML example for syncing the panel clock every night" %}
+
+{% example %}
+automation: |
+  alias: "Sync Bosch alarm panel clock"
+  triggers:
+    - trigger: time
+      at: "04:00:00"
+  actions:
+    - action: bosch_alarm.set_date_time
+      data:
+        config_entry_id: a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4
+{% endexample %}
+
+{% enddetails %}
 
 {% include actions/stuck.md %}
 

--- a/source/_actions/bosch_alarm.set_date_time.markdown
+++ b/source/_actions/bosch_alarm.set_date_time.markdown
@@ -5,7 +5,7 @@ domain: bosch_alarm
 description: "Sets the date and time on a Bosch alarm panel."
 ---
 
-Use this action to set the date and time on your Bosch alarm panel. When you do not provide a date and time, the current date and time of your Home Assistant instance is used.
+Use this action to set the date and time on your Bosch alarm panel. When you do not provide a date and time, the current date and time of your Home Assistant instance are used.
 
 This is handy to keep the clock on your panel in sync, for example with an automation that updates it after a power outage or on a regular schedule.
 
@@ -30,7 +30,7 @@ Config entry:
   description: The Bosch alarm panel to update.
   required: true
 Date & time:
-  description: The date and time to set. When not provided, the current date and time is used.
+  description: The date and time to set. When not provided, the current date and time are used.
   required: false
 {% endoptions_ui %}
 
@@ -66,7 +66,7 @@ datetime:
 
 ## Good to know
 
-- When you do not provide a date and time, the current date and time of your Home Assistant instance is used.
+- When you do not provide a date and time, the current date and time of your Home Assistant instance are used.
 - The time zone of your Home Assistant instance is assumed for the value you provide.
 
 {% include actions/try_it.md %}

--- a/source/_integrations/bosch_alarm.markdown
+++ b/source/_integrations/bosch_alarm.markdown
@@ -107,31 +107,7 @@ A switch is added for each output configured on the panel. Note that for some pa
 
 Three switches are added per door, which allow for locking, securing, or momentarily unlocking the door.
 
-## Actions
-
-The integration provides the following actions.
-
-### Action: Set panel date and time
-
-The `bosch_alarm.set_date_time` action is used to update the date and time on the panel.
-
-- **Data attribute**: `config_entry_id`
-  - **Description**: The ID of the config entry of the panel being updated.
-  - **Optional**: No
-
-- **Data attribute**: `datetime`
-  - **Description**: The date and time to set. Defaults to the current date and time if it is not set.
-  - **Optional**: Yes
-
-
-```yaml
-# Example: Update the panel’s date and time
-action: bosch_alarm.set_date_time
-data:
-  config_entry_id: "YOUR_CONFIG_ENTRY_ID"
-  datetime: "2025-05-01T12:00:00"
-```
-
+{% include integrations/actions.md %}
 
 ## Authentication
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change

Migrates the inline `set_date_time` action documentation on the Bosch Alarm integration page into a dedicated action page under `source/_actions/`, replacing the inline section with the standard actions include.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

