### PR TITLE
Advantage Air: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/advantage_air.set_time_to.markdown
+++ b/source/_actions/advantage_air.set_time_to.markdown
@@ -7,7 +7,7 @@ description: "Sets the countdown timer that turns an Advantage Air system on or 
 
 Use this action to set the countdown timer that turns your Advantage Air system on or off after a set number of minutes. You target the relevant timer sensor entity, either the "time to on" or "time to off" sensor, and set how many minutes from now the system should switch.
 
-This is handy in automations, for example to turn the air conditioning off a set time after everyone has gone to bed.
+This is handy in an automation to turn the air conditioning off a set time after everyone has gone to bed, for example.
 
 {% include actions/ui_header.md %}
 

--- a/source/_actions/advantage_air.set_time_to.markdown
+++ b/source/_actions/advantage_air.set_time_to.markdown
@@ -66,6 +66,43 @@ minutes:
 
 {% include actions/more_examples.md %}
 
+### Automation: set the HVAC to turn off 30 minutes after everyone leaves home
+
+When the last person leaves the home zone, set the "time to off" timer to 30 minutes. This gives a short buffer in case someone returns quickly, while ensuring the system does not run indefinitely in an empty house.
+
+- **Trigger**: State
+  - **Entity**: Home
+  - **To**: 0
+- **Condition**: not
+  - **Condition**: State
+    - **Entity**: HVAC
+    - **State**: Off
+- **Action**: Set time to (30 minutes on the "time to off" sensor)
+
+{% details "YAML example for turning off HVAC when no one is at home" %}
+
+{% example %}
+automation: |
+  alias: "Set HVAC to turn off 30 minutes after everyone leaves"
+  triggers:
+    - trigger: state
+      entity_id: zone.home
+      to: "0"
+  conditions:
+    - condition: not
+      conditions:
+        - condition: state
+          entity_id: climate.my_hvac
+          state: "off"
+  actions:
+    - action: advantage_air.set_time_to
+      data:
+        entity_id: sensor.myair_time_to_off
+        minutes: 30
+{% endexample %}
+
+{% enddetails %}
+
 {% include actions/stuck.md %}
 
 {% include actions/related.md %}

--- a/source/_actions/advantage_air.set_time_to.markdown
+++ b/source/_actions/advantage_air.set_time_to.markdown
@@ -1,0 +1,71 @@
+---
+title: "Set time to"
+action: advantage_air.set_time_to
+domain: advantage_air
+description: "Sets the countdown timer that turns an Advantage Air system on or off."
+---
+
+Use this action to set the countdown timer that turns your Advantage Air system on or off after a set number of minutes. You target the relevant timer sensor entity, either the "time to on" or "time to off" sensor, and set how many minutes from now the system should switch.
+
+This is handy in automations, for example to turn the air conditioning off a set time after everyone has gone to bed.
+
+{% include actions/ui_header.md %}
+
+To set the timer from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select a "time to on" or "time to off" sensor.
+6. From the actions shown for that target, select **Set time to**.
+7. Set the number of **Minutes** until the system switches.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Minutes:
+  description: The number of minutes from now until the system switches on or off.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `advantage_air.set_time_to`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: advantage_air.set_time_to
+  target:
+    entity_id: sensor.living_room_time_to_off
+  data:
+    minutes: 30
+{% endexample %}
+
+This turns the system off 30 minutes from now.
+
+### Options in YAML
+
+{% options_yaml %}
+minutes:
+  description: >
+    The number of minutes from now until the system switches on or off,
+    between 0 and 1440.
+  required: true
+  type: integer
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="sensor" %}
+
+## Good to know
+
+- Target the "time to on" sensor to schedule the system turning on, or the "time to off" sensor to schedule it turning off.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/advantage_air.markdown
+++ b/source/_integrations/advantage_air.markdown
@@ -84,13 +84,4 @@ The update platform shows if the controller app requires an update.
 
 With MyLights or MyPlace, light entities will be created for each light.
 
-## Actions
-
-### Action: Set time to
-
-The `advantage_air.set_time_to` action is used to set the On/Off Timer using the relevant sensor entity.
-
-| Data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `entity_id` | yes | `sensor.[name]_time_to_on` or `sensor.[name]_time_to_off`
-| `minutes` | no | Number of minutes between `0` and `720`.
+{% include integrations/actions.md %}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change

Migrates the inline `set_time_to` action documentation on the Advantage Air integration page into a dedicated action page under `source/_actions/`, replacing the inline section with the standard actions include. Also corrects the documented maximum from 720 to 1440 minutes, matching the integration.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

