### PR TITLE
BSB-Lan: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/bsblan.set_hot_water_schedule.markdown
+++ b/source/_actions/bsblan.set_hot_water_schedule.markdown
@@ -1,0 +1,177 @@
+---
+title: "Set hot water schedule"
+action: bsblan.set_hot_water_schedule
+domain: bsblan
+description: "Sets the hot water heating schedule for a BSB-LAN device."
+related_actions:
+  - bsblan.sync_time
+---
+
+Use this action to set the hot water heating schedule for your BSB-LAN device. Each day of the week can have one or more time slots during which hot water heating is active. You only need to set the days you want to change.
+
+This is handy in automations, for example to switch between a winter and a summer heating schedule based on the season.
+
+{% include actions/ui_header.md %}
+
+To set the hot water schedule from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **BSB-LAN: Set hot water schedule**.
+6. Select the **Device** to configure.
+7. For each day you want to change, add one or more time slots with a start and end time.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Device:
+  description: The BSB-LAN device to configure.
+  required: true
+Monday time slots:
+  description: The time periods for Monday. Add multiple slots for different heating periods throughout the day.
+  required: false
+Tuesday time slots:
+  description: The time periods for Tuesday.
+  required: false
+Wednesday time slots:
+  description: The time periods for Wednesday.
+  required: false
+Thursday time slots:
+  description: The time periods for Thursday.
+  required: false
+Friday time slots:
+  description: The time periods for Friday.
+  required: false
+Saturday time slots:
+  description: The time periods for Saturday.
+  required: false
+Sunday time slots:
+  description: The time periods for Sunday.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `bsblan.set_hot_water_schedule`. Each day's slots are a list of time periods, where each period has a `start_time` and an `end_time`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: bsblan.set_hot_water_schedule
+  data:
+    device_id: a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4
+    monday_slots:
+      - start_time: "06:00:00"
+        end_time: "08:00:00"
+      - start_time: "17:00:00"
+        end_time: "21:00:00"
+{% endexample %}
+
+This sets two heating periods for Monday and leaves the other days unchanged.
+
+### Options in YAML
+
+{% options_yaml %}
+device_id:
+  description: >
+    The BSB-LAN device to configure.
+  required: true
+  type: string
+monday_slots:
+  description: >
+    The time periods for Monday. Each period has a `start_time` and an
+    `end_time`. Add multiple periods for different heating periods
+    throughout the day.
+  required: false
+  type: list
+tuesday_slots:
+  description: >
+    The time periods for Tuesday.
+  required: false
+  type: list
+wednesday_slots:
+  description: >
+    The time periods for Wednesday.
+  required: false
+  type: list
+thursday_slots:
+  description: >
+    The time periods for Thursday.
+  required: false
+  type: list
+friday_slots:
+  description: >
+    The time periods for Friday.
+  required: false
+  type: list
+saturday_slots:
+  description: >
+    The time periods for Saturday.
+  required: false
+  type: list
+sunday_slots:
+  description: >
+    The time periods for Sunday.
+  required: false
+  type: list
+{% endoptions_yaml %}
+
+## Good to know
+
+- You only need to set the days you want to change. Days you leave out keep their current schedule.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Set a weekday and weekend schedule
+
+This example sets one schedule for the weekdays and a different one for the weekend.
+
+{% details "YAML example for a weekday and weekend schedule" %}
+
+{% example %}
+action: |
+  action: bsblan.set_hot_water_schedule
+  data:
+    device_id: a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4
+    monday_slots:
+      - start_time: "06:00:00"
+        end_time: "08:00:00"
+      - start_time: "17:00:00"
+        end_time: "21:00:00"
+    tuesday_slots:
+      - start_time: "06:00:00"
+        end_time: "08:00:00"
+      - start_time: "17:00:00"
+        end_time: "21:00:00"
+    wednesday_slots:
+      - start_time: "06:00:00"
+        end_time: "08:00:00"
+      - start_time: "17:00:00"
+        end_time: "21:00:00"
+    thursday_slots:
+      - start_time: "06:00:00"
+        end_time: "08:00:00"
+      - start_time: "17:00:00"
+        end_time: "21:00:00"
+    friday_slots:
+      - start_time: "06:00:00"
+        end_time: "08:00:00"
+      - start_time: "17:00:00"
+        end_time: "21:00:00"
+    saturday_slots:
+      - start_time: "08:00:00"
+        end_time: "22:00:00"
+    sunday_slots:
+      - start_time: "08:00:00"
+        end_time: "22:00:00"
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/bsblan.sync_time.markdown
+++ b/source/_actions/bsblan.sync_time.markdown
@@ -1,0 +1,87 @@
+---
+title: "Sync time"
+action: bsblan.sync_time
+domain: bsblan
+description: "Synchronizes the Home Assistant time to a BSB-LAN device."
+related_actions:
+  - bsblan.set_hot_water_schedule
+---
+
+Use this action to synchronize the time of your Home Assistant instance to your BSB-LAN device. The device time is only updated when it differs from the Home Assistant time.
+
+This is handy in automations, for example to keep the device clock accurate by syncing it once a day.
+
+{% include actions/ui_header.md %}
+
+To synchronize the time from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **BSB-LAN: Sync time**.
+6. Select the **Device** to synchronize.
+7. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Device:
+  description: The BSB-LAN device to synchronize the time for.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `bsblan.sync_time`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: bsblan.sync_time
+  data:
+    device_id: a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4
+{% endexample %}
+
+This synchronizes the time of the selected BSB-LAN device.
+
+### Options in YAML
+
+{% options_yaml %}
+device_id:
+  description: >
+    The BSB-LAN device to synchronize the time for.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+## Good to know
+
+- The device time is only updated when it differs from the Home Assistant time.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Synchronize the time daily
+
+This automation synchronizes the BSB-LAN device time every day at 3:00.
+
+{% details "YAML example for a daily time sync" %}
+
+{% example %}
+automation: |
+  alias: "Sync BSB-LAN time daily"
+  triggers:
+    - trigger: time
+      at: "03:00:00"
+  actions:
+    - action: bsblan.sync_time
+      data:
+        device_id: a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/bsblan.markdown
+++ b/source/_integrations/bsblan.markdown
@@ -86,72 +86,7 @@ To use the **Total Energy** sensor, [enable the entity](/common-tasks/general/#e
 The **Total Energy** sensor is not real-time. It updates in 1 kWh steps, so the value changes only after another 1 kWh has been used.
 {% endnote %}
 
-## Actions
-
-The integration provides the following actions.
-
-### Action: Set hot water schedule
-
-The `bsblan.set_hot_water_schedule` action allows you to set the hot water heating schedule for your BSB-LAN device. Each day of the week can have one or more time slots when hot water heating should be active.
-
-- **Target**: `device_id`
-  - **Description**: The BSB-LAN device to configure.
-  - **Required**: Yes
-- **Data attributes**:
-  - **`monday_slots`**: List of time slots for Monday. Each slot contains `start_time` and `end_time`.
-    - **Optional**: Yes
-  - **`tuesday_slots`**: List of time slots for Tuesday. Each slot contains `start_time` and `end_time`.
-    - **Optional**: Yes
-  - **`wednesday_slots`**: List of time slots for Wednesday. Each slot contains `start_time` and `end_time`.
-    - **Optional**: Yes
-  - **`thursday_slots`**: List of time slots for Thursday. Each slot contains `start_time` and `end_time`.
-    - **Optional**: Yes
-  - **`friday_slots`**: List of time slots for Friday. Each slot contains `start_time` and `end_time`.
-    - **Optional**: Yes
-  - **`saturday_slots`**: List of time slots for Saturday. Each slot contains `start_time` and `end_time`.
-    - **Optional**: Yes
-  - **`sunday_slots`**: List of time slots for Sunday. Each slot contains `start_time` and `end_time`.
-    - **Optional**: Yes
-  - **`standard_values_slots`**: List of standard/default time slots. Each slot contains `start_time` and `end_time`.
-    - **Optional**: Yes
-
-Time slots are defined using time pickers for easy configuration without manual formatting. You only need to specify the days you want to configure.
-
-### Action `bsblan.sync_time`
-
-Synchronize Home Assistant time to the BSB-LAN device. Only updates if device time differs from Home Assistant time.
-
-- **Target**: `device_id`
-  - **Description**: The BSB-LAN device to sync time for.
-  - **Required**: Yes
-
-#### Examples
-
-Sync time for all BSB-LAN devices:
-
-```yaml
-action: bsblan.sync_time
-```
-
-Sync time for a specific device:
-
-```yaml
-action: bsblan.sync_time
-target:
-  device_id: "your_device_id"
-```
-
-Use in an automation to sync time daily:
-
-```yaml
-automation:
-  - alias: "Sync BSB-LAN time daily"
-    triggers:
-      - trigger: time
-        at: "03:00:00"
-    actions:
-      - action: bsblan.sync_time
-```
+{% include integrations/actions.md %}
 
 ## Examples
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change

Migrates the inline `set_hot_water_schedule` and `sync_time` action documentation on the BSB-LAN integration page into dedicated action pages under `source/_actions/`, replacing the inline sections with the standard actions include. Also drops the non-existent `standard_values_slots` field that was documented but is not provided by the integration.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

