### PR TITLE
Google Mail: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/google_mail.set_vacation.markdown
+++ b/source/_actions/google_mail.set_vacation.markdown
@@ -118,6 +118,8 @@ end:
   type: string
 {% endoptions_yaml %}
 
+{% include actions/targets.md %}
+
 ## Good to know
 
 - To end the vacation responses, call this action again with **Enabled** turned off.

--- a/source/_actions/google_mail.set_vacation.markdown
+++ b/source/_actions/google_mail.set_vacation.markdown
@@ -1,0 +1,131 @@
+---
+title: "Set vacation"
+action: google_mail.set_vacation
+domain: google_mail
+description: "Sets the vacation auto-responder for a Google Mail account."
+---
+
+Use this action to set the vacation auto-responder for your Google Mail account. You can set the subject and message of the automatic reply, choose when it starts and ends, and limit who receives it.
+
+This is handy in automations, for example to turn on your out-of-office reply when a vacation calendar event starts and turn it off again when you return.
+
+{% include actions/ui_header.md %}
+
+To set the vacation responder from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select your Google Mail account.
+6. From the actions shown for that target, select **Set vacation**.
+7. Turn **Enabled** on and enter a **Message**. Optionally, set a **Title**, a **Start** and **End** date, and the other options.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Enabled:
+  description: Turn this on to start vacation responses, or off to end them.
+  required: true
+Message:
+  description: The body of the automatic reply email.
+  required: true
+Title:
+  description: The subject for the automatic reply email.
+  required: false
+Plain text:
+  description: Choose whether to send the message as plain text or HTML.
+  required: false
+Restrict to contacts:
+  description: Restrict the automatic reply to your contacts only.
+  required: false
+Restrict to domain:
+  description: Restrict the automatic reply to your domain only. This only affects Google Workspace accounts.
+  required: false
+Start:
+  description: The first day of the vacation.
+  required: false
+End:
+  description: The last day of the vacation.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `google_mail.set_vacation`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: google_mail.set_vacation
+  target:
+    entity_id: sensor.example_gmail_com_vacation_end_date
+  data:
+    enabled: true
+    title: "On vacation"
+    message: "I am on vacation and will reply when I am back."
+{% endexample %}
+
+This turns on the vacation responder with the given subject and message.
+
+### Options in YAML
+
+{% options_yaml %}
+enabled:
+  description: >
+    Turn this on to start vacation responses, or off to end them.
+  required: true
+  type: boolean
+  default: true
+message:
+  description: >
+    The body of the automatic reply email.
+  required: true
+  type: string
+title:
+  description: >
+    The subject for the automatic reply email.
+  required: false
+  type: string
+plain_text:
+  description: >
+    Choose whether to send the message as plain text or HTML.
+  required: false
+  type: boolean
+  default: true
+restrict_contacts:
+  description: >
+    Restrict the automatic reply to your contacts only.
+  required: false
+  type: boolean
+  default: false
+restrict_domain:
+  description: >
+    Restrict the automatic reply to your domain only. This only affects
+    Google Workspace accounts.
+  required: false
+  type: boolean
+  default: false
+start:
+  description: >
+    The first day of the vacation.
+  required: false
+  type: string
+end:
+  description: >
+    The last day of the vacation.
+  required: false
+  type: string
+{% endoptions_yaml %}
+
+## Good to know
+
+- To end the vacation responses, call this action again with **Enabled** turned off.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/google_mail.markdown
+++ b/source/_integrations/google_mail.markdown
@@ -32,44 +32,17 @@ These are not the same as *Device Auth* credentials previously recommended for [
 
 {% include integrations/google_oauth.md %}
 
-## Troubleshooting
+## Sending emails
 
-If you have an error with your credentials you can delete them in the [Application Credentials](/integrations/application_credentials/) user interface.
-
-### Action: Set vacation
-
-The `google_mail.set_vacation` action allows you to set vacation options.
-
-{% details "Create event action  details" %}
-
-| Data attribute | Optional | Description | Example |
-| ---------------------- | -------- | ----------- | --------|
-| `enabled` | yes | Turn this off to end vacation responses. | True
-| `title` | no | The subject for the email. | Vacation
-| `message` | yes | Body of the email. | I am on vacation.
-| `plain_text` | no | Choose to send message in plain text or HTML. | True
-| `restrict_contacts` | no | Restrict automatic reply to contacts. | True
-| `restrict_domain` | no | Restrict automatic reply to domain. This only affects GSuite accounts. | False
-| `start` | no | First day of the vacation. | 11-20-2022
-| `end` | no | Last day of the vacation. | 11-26-2022
-
-{% enddetails %}
-
-The added `notify` service will be named after the email address you chose on the consent screen. For example, an email address named "example@gmail.com" wil display as `notify.example_gmail_com`.
-
-### Google Mail notify action data
+The `notify` action added by this integration is named after the email address you chose on the consent screen. For example, an email address named "example@gmail.com" will display as `notify.example_gmail_com`.
 
 The following attributes can be placed inside the `data` key of the action for extended functionality:
 
-| Attribute              | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `cc`               |      yes | List of recipients to be carbon-copied.
-| `bcc`                   |      yes | List of recipients to be blind-carbon-copied.
-| `from`                   |      yes | Default is current authenticated user. Typically only applies to GSuite accounts where the user has delegate access to a shared mailbox.
-| `send`                 |      yes | Default is true. Set this to false to create a draft instead. Recipients are not required in this instance.
-| `alias_from`           |      yes | Name that will be showed to the receivers instead of the user email. You have to set `from` if you want to use this option. |
-
-### Examples
+- `cc`: List of recipients to be carbon-copied.
+- `bcc`: List of recipients to be blind-carbon-copied.
+- `from`: Defaults to the current authenticated user. Typically only applies to Google Workspace accounts where the user has delegate access to a shared mailbox.
+- `send`: Defaults to `true`. Set this to `false` to create a draft instead. Recipients are not required in this case.
+- `alias_from`: Name that is shown to the receivers instead of the user email. You have to set `from` if you want to use this option.
 
 This is the full action to send an email:
 
@@ -89,8 +62,14 @@ data:
     alias_from: "Example alias"
 ```
 
-### Video tutorial
+{% include integrations/actions.md %}
+
+## Video tutorial
 
 This video tutorial explains how to set up Gmail in Home Assistant and how you can create a dashboard and automations to send email and toggle your out-of-office notice.
 
 <lite-youtube videoid="IHKliqSFZvM" videotitle="How To send e-mail PERFECTLY using Gmail in Home Assistant - Tutorial" posterquality="maxresdefault"></lite-youtube>
+
+## Troubleshooting
+
+If you have an error with your credentials, you can delete them in the [Application Credentials](/integrations/application_credentials/) user interface.

--- a/source/_integrations/google_mail.markdown
+++ b/source/_integrations/google_mail.markdown
@@ -42,7 +42,7 @@ The following attributes can be placed inside the `data` key of the action for e
 - `bcc`: List of recipients to be blind-carbon-copied.
 - `from`: Defaults to the current authenticated user. Typically only applies to Google Workspace accounts where the user has delegate access to a shared mailbox.
 - `send`: Defaults to `true`. Set this to `false` to create a draft instead. Recipients are not required in this case.
-- `alias_from`: Name that is shown to the receivers instead of the user email. You have to set `from` if you want to use this option.
+- `alias_from`: Name that is shown to the recipients instead of your email address. To use this option, you must also set `from`.
 
 This is the full action to send an email:
 


### PR DESCRIPTION
## Proposed change

Migrates the inline `google_mail.set_vacation` action documentation into a dedicated action page under `source/_actions/`, and replaces the inline action block with the standard `{% include integrations/actions.md %}`.

While here, the page structure is corrected: the action and `notify` usage docs were incorrectly nested under `## Troubleshooting`. The `notify` usage now lives under its own `## Sending emails` section, and Troubleshooting is moved to the end. The action's option requirements were corrected to match the integration source (`enabled` and `message` are required; `title` is optional). Tables were converted to lists per the documentation style.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

