### PR TITLE
Saunum: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/saunum.start_session.markdown
+++ b/source/_actions/saunum.start_session.markdown
@@ -1,0 +1,91 @@
+---
+title: "Start session"
+action: saunum.start_session
+domain: saunum
+description: "Starts a sauna session with a custom duration, target temperature, and fan duration."
+---
+
+Use this action to start a sauna session with a custom duration, target temperature, and fan duration. It gives you more granular control than the climate entity, letting you set all session parameters in a single call.
+
+{% include actions/ui_header.md %}
+
+To start a sauna session from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Saunum: Start session**.
+6. Select what you want to control. Under **By target** (see [Targets](#targets)), select your Saunum climate entity.
+7. Optionally, set a **Duration**, a **Target temperature**, and a **Fan duration**.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Duration:
+  description: How long the sauna session runs. Defaults to 2 hours.
+  required: false
+Target temperature:
+  description: The target temperature in degrees Celsius. Must be between 40 and 100. Defaults to 80.
+  required: false
+Fan duration:
+  description: How long the fan runs. Defaults to 10 minutes.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `saunum.start_session`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: saunum.start_session
+  target:
+    entity_id: climate.saunum_leil
+  data:
+    duration:
+      hours: 2
+    target_temperature: 80
+    fan_duration:
+      minutes: 10
+{% endexample %}
+
+This starts a two-hour session at 80°C, with the fan running for the first 10 minutes.
+
+### Options in YAML
+
+{% options_yaml %}
+duration:
+  description: >
+    How long the sauna session runs. Accepts a duration object with `hours`,
+    `minutes`, and `seconds` keys. Defaults to 2 hours.
+  required: false
+  type: time
+target_temperature:
+  description: >
+    The target temperature in degrees Celsius. Must be between 40 and 100.
+    Defaults to 80.
+  required: false
+  type: integer
+fan_duration:
+  description: >
+    How long the fan runs. Accepts a duration object with `hours`, `minutes`,
+    and `seconds` keys. Defaults to 10 minutes.
+  required: false
+  type: time
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="climate" %}
+
+## Good to know
+
+- You cannot start a sauna session when the sauna door is open. The control unit prevents heating as a safety measure.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/saunum.markdown
+++ b/source/_integrations/saunum.markdown
@@ -231,47 +231,7 @@ The **Saunum** integration provides the following entities.
 Monitor the alarm binary sensors regularly. Any active alarm sensor indicates a potential safety or operational issue that should be addressed immediately. The sauna heater will automatically shut down when safety alarms are triggered.
 {% endimportant %}
 
-## Actions
-
-The **Saunum** integration provides the following actions.
-
-### Action: Start session
-
-The `saunum.start_session` action starts a sauna session with custom duration, target temperature, and fan duration. This action provides more granular control than the climate entity, allowing you to specify all session parameters in a single call.
-
-- **Data attribute**: `entity_id`
-  - **Description**: The entity ID of the Saunum climate entity.
-  - **Required**: Yes
-
-- **Data attribute**: `duration`
-  - **Description**: Session duration as a time period (for example, `{"hours": 2}`). Defaults to 2 hours.
-  - **Required**: No
-
-- **Data attribute**: `target_temperature`
-  - **Description**: Target temperature in Celsius (40-100). Defaults to 80.
-  - **Required**: No
-
-- **Data attribute**: `fan_duration`
-  - **Description**: Fan duration as a time period (for example, `{"minutes": 10}`). Defaults to 10 minutes.
-  - **Required**: No
-
-{% note %}
-You cannot start a sauna session when the sauna door is open. The control unit will prevent heating as a safety measure.
-{% endnote %}
-
-#### Example
-
-```yaml
-action: saunum.start_session
-target:
-  entity_id: climate.saunum_leil
-data:
-  duration:
-    hours: 2
-  target_temperature: 80
-  fan_duration:
-    minutes: 10
-```
+{% include integrations/actions.md %}
 
 ## Automations
 


### PR DESCRIPTION
## Proposed change

Migrates the inline `saunum.start_session` action documentation into a dedicated action page under `source/_actions/`, and replaces the inline action block with the standard `{% include integrations/actions.md %}`.

This action is entity-targeted (registered as a platform entity service on the climate entity), so the page documents the climate entity as the target instead of listing `entity_id` as a data attribute.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

