### PR TITLE
Switcher: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/switcher_kis.set_auto_off.markdown
+++ b/source/_actions/switcher_kis.set_auto_off.markdown
@@ -1,0 +1,65 @@
+---
+title: "Set auto-off"
+action: switcher_kis.set_auto_off
+domain: switcher_kis
+description: "Sets the auto-off time for a Switcher power device."
+---
+
+Use this action to set the auto-off time for a Switcher power device. Once the auto-off time is reached, the device turns itself off.
+
+{% include actions/ui_header.md %}
+
+To set the auto-off time from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Switcher: Set auto-off**.
+6. Select what you want to control. Under **By target** (see [Targets](#targets)), select your Switcher device.
+7. Enter the **Auto-off** time.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Auto-off:
+  description: The auto-off time as a period of hours and minutes, for example, 02:30 for two and a half hours.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `switcher_kis.set_auto_off`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: switcher_kis.set_auto_off
+  target:
+    entity_id: switch.switcher_kis_boiler
+  data:
+    auto_off: "02:30"
+{% endexample %}
+
+This sets the device to turn itself off after two hours and 30 minutes.
+
+### Options in YAML
+
+{% options_yaml %}
+auto_off:
+  description: >
+    The auto-off time as a period of hours and minutes, for example, "02:30"
+    for two and a half hours.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="switch" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/switcher_kis.turn_on_with_timer.markdown
+++ b/source/_actions/switcher_kis.turn_on_with_timer.markdown
@@ -1,0 +1,64 @@
+---
+title: "Turn on with timer"
+action: switcher_kis.turn_on_with_timer
+domain: switcher_kis
+description: "Turns on a Switcher power device for a set number of minutes."
+---
+
+Use this action to turn on a Switcher power device with a timer. Once the timer ends, the device turns itself off. This does not affect the device's auto-off setting.
+
+{% include actions/ui_header.md %}
+
+To turn on a device with a timer from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Switcher: Turn on with timer**.
+6. Select what you want to control. Under **By target** (see [Targets](#targets)), select your Switcher device.
+7. Enter the **Timer** in minutes.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Timer:
+  description: How long the device stays on, in minutes. Must be between 1 and 150.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `switcher_kis.turn_on_with_timer`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: switcher_kis.turn_on_with_timer
+  target:
+    entity_id: switch.switcher_kis_boiler
+  data:
+    timer_minutes: 90
+{% endexample %}
+
+This turns the device on for 90 minutes, after which it turns itself off.
+
+### Options in YAML
+
+{% options_yaml %}
+timer_minutes:
+  description: >
+    How long the device stays on, in minutes. Must be between 1 and 150.
+  required: true
+  type: integer
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="switch" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/switcher_kis.markdown
+++ b/source/_integrations/switcher_kis.markdown
@@ -113,31 +113,7 @@ For Switcher Breeze the integration provides the following sensor:
 
 For Switcher cover control devices (Switcher Runner, Switcher Runner S11, Switcher Runner S12), the integration allows you to control its child lock state; ON means locked, and OFF means unlocked.
 
-## Actions
-
-For Switcher power control devices (Switcher Touch, Switcher V2/V4) the integration provides the following sensors:
-
-### Action: Set auto off
-
-The `switcher_kis.set_auto_off` action sets the auto-off configuration setting for the device.
-
-Meaning the device will turn itself off when reaching the auto-off configuration limit.
-
-| Data attribute | Mandatory | Description                                                                            | Example                    |
-| ------------- | --------- | -------------------------------------------------------------------------------------- | -------------------------- |
-| `entity_id`   | Yes       | Name of the entity id associated with the integration, used for permission validation  | switch.switcher_kis_boiler |
-| `auto_off`    | Yes       | Time period string containing hours and minutes                                        | "02:30"                    |
-
-### Action: Turn on with timer
-
-The `switcher_kis.turn_on_with_timer` action turns on the switcher device with a timer.
-
-Meaning the device will turn itself off when timer ends.
-Note: This does not affect the auto off timer.
-| Data attribute | Mandatory | Description                                                                            | Example                    |
-| ------------- | --------- | -------------------------------------------------------------------------------------- | -------------------------- |
-| `entity_id`   | Yes       | Name of the entity id associated with the integration, used for permission validation  | switch.switcher_kis_boiler |
-| `timer_minutes`    | Yes       | Integer containing timer minutes (valid range 1 to 150)                                      | 90                    |
+{% include integrations/actions.md %}
 
 ## Notes
 


### PR DESCRIPTION
## Proposed change

Migrates the inline `switcher_kis.set_auto_off` and `switcher_kis.turn_on_with_timer` action documentation into dedicated action pages under `source/_actions/`, and replaces the inline action block with the standard `{% include integrations/actions.md %}`.

Both actions are entity-targeted (registered as entity services on the switch entity), so the pages document the switch entity as the target instead of listing `entity_id` as a data attribute. Tables were converted to lists per the documentation style.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

