### PR TITLE
SmartTub: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/smarttub.reset_reminder.markdown
+++ b/source/_actions/smarttub.reset_reminder.markdown
@@ -60,6 +60,31 @@ days:
 
 {% include actions/more_examples.md %}
 
+### Automation: reset the reminder after refreshing the water
+
+When you mark the water as refreshed, here by pressing a button helper, reset the reminder so it triggers again in 180 days.
+
+- **Trigger**: The water refreshed button is pressed
+- **Action**: SmartTub: Reset a reminder
+
+{% details "YAML example for resetting the reminder after refreshing the water" %}
+
+{% example %}
+automation: |
+  alias: "Reset hot tub reminder after water change"
+  triggers:
+    - trigger: state
+      entity_id: input_button.hot_tub_water_refreshed
+  actions:
+    - action: smarttub.reset_reminder
+      target:
+        entity_id: binary_sensor.jacuzzi_j_335_refresh_water_reminder
+      data:
+        days: 180
+{% endexample %}
+
+{% enddetails %}
+
 {% include actions/stuck.md %}
 
 {% include actions/related.md %}

--- a/source/_actions/smarttub.reset_reminder.markdown
+++ b/source/_actions/smarttub.reset_reminder.markdown
@@ -1,0 +1,65 @@
+---
+title: "Reset reminder"
+action: smarttub.reset_reminder
+domain: smarttub
+description: "Resets a maintenance reminder on a hot tub."
+---
+
+Use this action to reset a maintenance reminder on your hot tub, setting when the next reminder should trigger.
+
+{% include actions/ui_header.md %}
+
+To reset a reminder from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **SmartTub: Reset a reminder**.
+6. Select what you want to control. Under **By target** (see [Targets](#targets)), select your hot tub's reminder binary sensor.
+7. Enter the number of **Days** until the next reminder.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Days:
+  description: The number of days until the next reminder triggers. Must be between 30 and 365.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `smarttub.reset_reminder`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: smarttub.reset_reminder
+  target:
+    entity_id: binary_sensor.jacuzzi_j_335_refresh_water_reminder
+  data:
+    days: 180
+{% endexample %}
+
+This resets the reminder so it triggers again in 180 days.
+
+### Options in YAML
+
+{% options_yaml %}
+days:
+  description: >
+    The number of days until the next reminder triggers. Must be between 30
+    and 365.
+  required: true
+  type: integer
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="binary_sensor" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/smarttub.set_primary_filtration.markdown
+++ b/source/_actions/smarttub.set_primary_filtration.markdown
@@ -72,6 +72,25 @@ start_hour:
 
 {% include actions/more_examples.md %}
 
+### Script: schedule filtration for off-peak hours
+
+Run this script to set the primary filtration cycle to run overnight, when electricity is often cheaper.
+
+{% details "YAML example for scheduling filtration overnight" %}
+
+{% example %}
+script: |
+  sequence:
+    - action: smarttub.set_primary_filtration
+      target:
+        entity_id: sensor.jacuzzi_j_335_primary_filtration_cycle
+      data:
+        duration: 6
+        start_hour: 1
+{% endexample %}
+
+{% enddetails %}
+
 {% include actions/stuck.md %}
 
 {% include actions/related.md %}

--- a/source/_actions/smarttub.set_primary_filtration.markdown
+++ b/source/_actions/smarttub.set_primary_filtration.markdown
@@ -1,0 +1,77 @@
+---
+title: "Set primary filtration"
+action: smarttub.set_primary_filtration
+domain: smarttub
+description: "Updates the primary filtration cycle settings on a hot tub."
+---
+
+Use this action to update the primary filtration cycle settings on your hot tub. You can set how long the cycle runs and when it starts.
+
+{% include actions/ui_header.md %}
+
+To update the primary filtration settings from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **SmartTub: Update primary filtration settings**.
+6. Select what you want to control. Under **By target** (see [Targets](#targets)), select your hot tub's primary filtration cycle sensor.
+7. Optionally, set a **Duration** and a **Start hour**.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Duration:
+  description: How long the primary filtration cycle runs, in hours. Must be between 1 and 24. Defaults to 8.
+  required: false
+Start hour:
+  description: The hour of the day at which the primary filtration cycle begins, from 0 (midnight) to 23. Defaults to 0.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `smarttub.set_primary_filtration`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: smarttub.set_primary_filtration
+  target:
+    entity_id: sensor.jacuzzi_j_335_primary_filtration_cycle
+  data:
+    duration: 4
+    start_hour: 2
+{% endexample %}
+
+This sets the primary filtration cycle to run for four hours, starting at 02:00.
+
+### Options in YAML
+
+{% options_yaml %}
+duration:
+  description: >
+    How long the primary filtration cycle runs, in hours. Must be between 1
+    and 24.
+  required: false
+  type: integer
+  default: 8
+start_hour:
+  description: >
+    The hour of the day at which the primary filtration cycle begins, from 0
+    (midnight) to 23.
+  required: false
+  type: integer
+  default: 0
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="sensor" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/smarttub.set_secondary_filtration.markdown
+++ b/source/_actions/smarttub.set_secondary_filtration.markdown
@@ -1,0 +1,64 @@
+---
+title: "Set secondary filtration"
+action: smarttub.set_secondary_filtration
+domain: smarttub
+description: "Updates the secondary filtration mode on a hot tub."
+---
+
+Use this action to update the secondary filtration mode on your hot tub.
+
+{% include actions/ui_header.md %}
+
+To update the secondary filtration settings from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **SmartTub: Update secondary filtration settings**.
+6. Select what you want to control. Under **By target** (see [Targets](#targets)), select your hot tub's secondary filtration cycle sensor.
+7. Select a **Mode**.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Mode:
+  description: "The secondary filtration mode: frequent, infrequent, or away."
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `smarttub.set_secondary_filtration`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: smarttub.set_secondary_filtration
+  target:
+    entity_id: sensor.jacuzzi_j_335_secondary_filtration_cycle
+  data:
+    mode: away
+{% endexample %}
+
+This sets the secondary filtration cycle to away mode.
+
+### Options in YAML
+
+{% options_yaml %}
+mode:
+  description: >
+    The secondary filtration mode. One of `frequent`, `infrequent`, or `away`.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="sensor" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/smarttub.set_secondary_filtration.markdown
+++ b/source/_actions/smarttub.set_secondary_filtration.markdown
@@ -59,6 +59,32 @@ mode:
 
 {% include actions/more_examples.md %}
 
+### Automation: reduce filtration when you leave home
+
+Switch the secondary filtration to away mode when you leave home, so the hot tub filters less while no one is around to use it.
+
+- **Trigger**: You leave home
+- **Action**: SmartTub: Update secondary filtration settings
+
+{% details "YAML example for switching to away mode when leaving home" %}
+
+{% example %}
+automation: |
+  alias: "Hot tub away filtration when not home"
+  triggers:
+    - trigger: state
+      entity_id: person.sam
+      to: not_home
+  actions:
+    - action: smarttub.set_secondary_filtration
+      target:
+        entity_id: sensor.jacuzzi_j_335_secondary_filtration_cycle
+      data:
+        mode: away
+{% endexample %}
+
+{% enddetails %}
+
 {% include actions/stuck.md %}
 
 {% include actions/related.md %}

--- a/source/_actions/smarttub.snooze_reminder.markdown
+++ b/source/_actions/smarttub.snooze_reminder.markdown
@@ -59,6 +59,32 @@ days:
 
 {% include actions/more_examples.md %}
 
+### Automation: snooze the reminder while you are away
+
+When you go on holiday, snooze the maintenance reminder so it does not keep notifying you while you are away.
+
+- **Trigger**: Holiday mode is turned on
+- **Action**: SmartTub: Snooze a reminder
+
+{% details "YAML example for snoozing a reminder during a holiday" %}
+
+{% example %}
+automation: |
+  alias: "Snooze hot tub reminder during holiday"
+  triggers:
+    - trigger: state
+      entity_id: input_boolean.holiday_mode
+      to: "on"
+  actions:
+    - action: smarttub.snooze_reminder
+      target:
+        entity_id: binary_sensor.jacuzzi_j_335_refresh_water_reminder
+      data:
+        days: 30
+{% endexample %}
+
+{% enddetails %}
+
 {% include actions/stuck.md %}
 
 {% include actions/related.md %}

--- a/source/_actions/smarttub.snooze_reminder.markdown
+++ b/source/_actions/smarttub.snooze_reminder.markdown
@@ -1,0 +1,64 @@
+---
+title: "Snooze reminder"
+action: smarttub.snooze_reminder
+domain: smarttub
+description: "Temporarily suppresses a maintenance reminder on a hot tub."
+---
+
+Use this action to temporarily suppress a maintenance reminder on your hot tub for a number of days.
+
+{% include actions/ui_header.md %}
+
+To snooze a reminder from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **SmartTub: Snooze a reminder**.
+6. Select what you want to control. Under **By target** (see [Targets](#targets)), select your hot tub's reminder binary sensor.
+7. Enter the number of **Days** to snooze the reminder.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Days:
+  description: The number of days to snooze the reminder. Must be between 10 and 120.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `smarttub.snooze_reminder`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: smarttub.snooze_reminder
+  target:
+    entity_id: binary_sensor.jacuzzi_j_335_refresh_water_reminder
+  data:
+    days: 10
+{% endexample %}
+
+This snoozes the reminder for 10 days.
+
+### Options in YAML
+
+{% options_yaml %}
+days:
+  description: >
+    The number of days to snooze the reminder. Must be between 10 and 120.
+  required: true
+  type: integer
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="binary_sensor" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/smarttub.markdown
+++ b/source/_integrations/smarttub.markdown
@@ -31,42 +31,4 @@ The **SmartTub** {% term integration %} allows you to view and control hot tubs 
 
 {% include integrations/config_flow.md %}
 
-## Actions
-
-### Action: Set primary filtration
-
-The `smarttub.set_primary_filtration` action updates the settings for the primary filtration cycle on a hot tub.
-
-| Data attribute | Optional | Description | Example |
-| ---------------------- | -------- | ----------- | ------- |
-| `entity_id` | no | The entity to update. | sensor.jacuzzi_j_335_primary_filtration_cycle
-| `duration` | no | The desired duration of the primary filtration cycle, in hours. | 4
-| `start_hour` | no | The desired starting hour of the day for the primary filtration cycle. | 2 (that is, 02:00 or 2:00am)
-
-
-### Action: Set secondary filtration
-
-The `smarttub.set_secondary_filtration` action updates the settings for the secondary filtration cycle on a hot tub.
-
-| Data attribute | Optional | Description | Example |
-| ---------------------- | -------- | ----------- | ------- |
-| `entity_id` | no | The entity to update. | sensor.jacuzzi_j_335_secondary_filtration_cycle
-| `mode` | no | The desired secondary filtration mode. Can be frequent, infrequent or away. | away
-
-### Action: Snooze reminder
-
-The `smarttub.snooze_reminder` action temporarily suppresses a maintenance reminder on a hot tub.
-
-| Data attribute | Optional | Description | Example |
-| ---------------------- | -------- | ----------- | ------- |
-| `entity_id` | no | The entity to update. | binary_sensor.jacuzzi_j_335_refresh_water_reminder
-| `days` | no | The number of days to snooze the reminder (minimum 10). | 10
-
-### Action: Reset reminder
-
-The `smarttub.reset_reminder` action resets a maintenance reminder on a hot tub.
-
-| Data attribute | Optional | Description | Example |
-| ---------------------- | -------- | ----------- | ------- |
-| `entity_id` | no | The entity to update. | binary_sensor.jacuzzi_j_335_refresh_water_reminder
-| `days` | no | The number of days when reminder should trigger next (minimum 30). | 180
+{% include integrations/actions.md %}


### PR DESCRIPTION
## Proposed change

Migrates the inline SmartTub action documentation into dedicated action pages under `source/_actions/`, and replaces the inline action block with the standard `{% include integrations/actions.md %}`.

The four actions (`set_primary_filtration`, `set_secondary_filtration`, `snooze_reminder`, `reset_reminder`) are all entity-targeted, so the pages document the target entity instead of listing `entity_id` as a data attribute. Tables were converted to lists per the documentation style.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

