### PR TITLE
Sure Petcare: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/surepetcare.set_lock_state.markdown
+++ b/source/_actions/surepetcare.set_lock_state.markdown
@@ -1,0 +1,75 @@
+---
+title: "Set lock state"
+action: surepetcare.set_lock_state
+domain: surepetcare
+description: "Changes the locking state of a Sure Petcare flap."
+---
+
+Use this action to change the locking state of a cat or pet flap.
+
+{% include actions/ui_header.md %}
+
+To set the lock state from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Sure Petcare: Set lock state**.
+6. Enter the **Flap ID** and select a **Lock state**.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Flap ID:
+  description: The ID of the flap to lock or unlock.
+  required: true
+Lock state:
+  description: "The new lock state: locked_all, locked_in, locked_out, or unlocked."
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `surepetcare.set_lock_state`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: surepetcare.set_lock_state
+  data:
+    flap_id: 123456
+    lock_state: locked_in
+{% endexample %}
+
+This sets the flap to "in only", so pets can come in but not go back out.
+
+### Options in YAML
+
+{% options_yaml %}
+flap_id:
+  description: The ID of the flap to lock or unlock.
+  required: true
+  type: integer
+lock_state:
+  description: >
+    The new lock state. One of `unlocked` (pets are allowed both in and out),
+    `locked_in` (pets can come in but not go back out), `locked_out` (pets can
+    go out but not back in), or `locked_all` (the flap is locked both ways).
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+## Good to know
+
+- To find a flap's ID, log in to [surepetcare.io](https://surepetcare.io/), open the sidebar, and select your flap. The flap ID is the last part of the URL, for example `https://surepetcare.io/control/device/FLAP-ID`.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/surepetcare.set_pet_location.markdown
+++ b/source/_actions/surepetcare.set_pet_location.markdown
@@ -1,0 +1,68 @@
+---
+title: "Set pet location"
+action: surepetcare.set_pet_location
+domain: surepetcare
+description: "Manually sets the location of a pet to inside or outside."
+---
+
+Use this action to manually set the location of a pet to inside or outside. This is handy to correct the location when a pet was not detected entering or leaving.
+
+{% include actions/ui_header.md %}
+
+To set a pet's location from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Sure Petcare: Set pet location**.
+6. Enter the **Pet name** and select a **Location**.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Pet name:
+  description: The name of the pet whose location you want to set.
+  required: true
+Location:
+  description: "The pet's location: Inside or Outside."
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `surepetcare.set_pet_location`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: surepetcare.set_pet_location
+  data:
+    pet_name: My_cat
+    location: Inside
+{% endexample %}
+
+This sets the location of the pet named "My_cat" to inside.
+
+### Options in YAML
+
+{% options_yaml %}
+pet_name:
+  description: The name of the pet whose location you want to set.
+  required: true
+  type: string
+location:
+  description: "The pet's location. One of `Inside` or `Outside`."
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/surepetcare.markdown
+++ b/source/_integrations/surepetcare.markdown
@@ -81,43 +81,7 @@ These are the entities available in the Sure Petcare integration.
 
 - **Connectivity**: Hub connectivity (online); attributes include `led_mode` and `pairing_mode`.
 
-## Actions
-
-### Action: Set lock state
-
-The `surepetcare.set_lock_state` action changes the locking state of a flap.
-
-| Data attribute | Required | Type | Description |
-| ---------------------- | -------- | -------- | ----------- |
-| `flap_id` | `True` | integer | Flap ID to change - see below for instructions on finding device ID
-| `lock_state` | `True` | string | New state to change the flap to
-
-The `flap_id` can be found following these instructions:
-
-- Log into [surepetcare.io](https://surepetcare.io/).
-- Open the sidebar and click your flap.
-- The `flap_id` will be at the end of the URL (for example, `https://surepetcare.io/control/device/FLAP-ID`)
-
-`lock_state` should be one of:
-
-- `unlocked` - flap is unlocked, pets are allowed both in and out.
-- `locked_in` - flap is 'in only' - pets can come in but not go back out.
-- `locked_out` - flap is 'out only' - pets can go out, but not back in.
-- `locked_all` - flap is locked both ways.
-
-### Action: Set pet location
-
-The `surepetcare.set_pet_location` action sets the pet location.
-
-| Data attribute | Required | Type | Description |
-| ---------------------- | -------- | -------- | ----------- |
-| `name` | yes | string | Pet name
-| `location` | yes | string | Pet location
-
-`location` should be one of:
-
-- `Inside` - Pet is inside.
-- `Outside` - Pet is outside.
+{% include integrations/actions.md %}
 
 ## Blueprints
 


### PR DESCRIPTION
## Proposed change

Migrates the inline Sure Petcare action documentation into dedicated action pages under `source/_actions/`, and replaces the inline action block with the standard `{% include integrations/actions.md %}`.

Both actions (`set_lock_state` and `set_pet_location`) are domain-level actions without a target, documented as such. While here, the `set_pet_location` field name was corrected from `name` to `pet_name` to match the integration source. Tables were converted to lists per the documentation style.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

