### PR TITLE
StarLine: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/starline.set_scan_interval.markdown
+++ b/source/_actions/starline.set_scan_interval.markdown
@@ -1,0 +1,61 @@
+---
+title: "Set scan interval"
+action: starline.set_scan_interval
+domain: starline
+description: "Sets how often Home Assistant fetches StarLine entity updates."
+---
+
+Use this action to set how often Home Assistant fetches updates for your StarLine entities.
+
+{% include actions/ui_header.md %}
+
+To set the scan interval from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **StarLine: Set scan interval**.
+6. Enter the **Scan interval** in seconds.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Scan interval:
+  description: How often to fetch updates, in seconds. Must be between 10 and 86400.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `starline.set_scan_interval`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: starline.set_scan_interval
+  data:
+    scan_interval: 180
+{% endexample %}
+
+This fetches StarLine entity updates every three minutes.
+
+### Options in YAML
+
+{% options_yaml %}
+scan_interval:
+  description: >
+    How often to fetch updates, in seconds. Must be between 10 and 86400.
+  required: true
+  type: integer
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/starline.set_scan_interval.markdown
+++ b/source/_actions/starline.set_scan_interval.markdown
@@ -25,7 +25,7 @@ This action does not support targets. In the UI, you are not prompted to choose 
 
 {% options_ui %}
 Scan interval:
-  description: How often to fetch updates, in seconds. Must be between 10 and 86400.
+  description: How often to fetch updates, in seconds. Supported range is 10 to 86400. Values below 90 are not recommended because of StarLine API rate limits.
   required: true
 {% endoptions_ui %}
 
@@ -47,7 +47,7 @@ This fetches StarLine entity updates every three minutes.
 {% options_yaml %}
 scan_interval:
   description: >
-    How often to fetch updates, in seconds. Must be between 10 and 86400.
+    How often to fetch updates, in seconds. Supported range is 10 to 86400. Values below 90 are not recommended because of StarLine API rate limits.
   required: true
   type: integer
 {% endoptions_yaml %}

--- a/source/_actions/starline.set_scan_obd_interval.markdown
+++ b/source/_actions/starline.set_scan_obd_interval.markdown
@@ -1,0 +1,61 @@
+---
+title: "Set scan OBD interval"
+action: starline.set_scan_obd_interval
+domain: starline
+description: "Sets how often Home Assistant fetches StarLine OBD updates."
+---
+
+Use this action to set how often Home Assistant fetches <abbr title="On-board diagnostics">OBD</abbr> information from your StarLine devices.
+
+{% include actions/ui_header.md %}
+
+To set the OBD scan interval from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **StarLine: Set scan OBD interval**.
+6. Enter the **Scan interval** in seconds.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Scan interval:
+  description: How often to fetch OBD updates, in seconds. Must be between 180 and 86400.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `starline.set_scan_obd_interval`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: starline.set_scan_obd_interval
+  data:
+    scan_interval: 600
+{% endexample %}
+
+This fetches OBD information every 10 minutes.
+
+### Options in YAML
+
+{% options_yaml %}
+scan_interval:
+  description: >
+    How often to fetch OBD updates, in seconds. Must be between 180 and 86400.
+  required: true
+  type: integer
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/starline.update_state.markdown
+++ b/source/_actions/starline.update_state.markdown
@@ -1,0 +1,46 @@
+---
+title: "Update state"
+action: starline.update_state
+domain: starline
+description: "Fetches the latest state of your StarLine devices from the StarLine server."
+---
+
+Use this action to fetch the latest state of your StarLine devices from the StarLine server, instead of waiting for the next scheduled update.
+
+{% include actions/ui_header.md %}
+
+To update the state from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **StarLine: Update state**.
+6. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+This action has no additional options in the UI.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `starline.update_state`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: starline.update_state
+{% endexample %}
+
+This fetches the latest state of your StarLine devices.
+
+### Options in YAML
+
+This action has no additional options in YAML.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/starline.markdown
+++ b/source/_integrations/starline.markdown
@@ -50,29 +50,7 @@ It is not recommended to set an update interval of less than 90 seconds.
 
 {% include integrations/config_flow.md %}
 
-## Actions
-
-### Update the state
-
-The `starline.update_state` action fetches the last state of the device from the StarLine server.
-
-This action does not require any attributes.
-
-### Set scan interval
-
-The `starline.set_scan_interval` action sets update frequency for entities.
-
-| Data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `scan_interval` | no | Update frequency in seconds.
-
-### Set scan OBD interval
-
-The `starline.set_scan_obd_interval` action sets update frequency for OBD information.
-
-| Data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `scan_interval` | no | Update frequency in seconds.
+{% include integrations/actions.md %}
 
 ## Disclaimer
 


### PR DESCRIPTION
## Proposed change

Migrates the inline StarLine action documentation into dedicated action pages under `source/_actions/`, and replaces the inline action block with the standard `{% include integrations/actions.md %}`.

The three actions (`update_state`, `set_scan_interval`, `set_scan_obd_interval`) are domain-level actions without a target, documented as such. Tables were converted to lists per the documentation style.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

