### PR TITLE
VIZIO SmartCast: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/vizio.update_setting.markdown
+++ b/source/_actions/vizio.update_setting.markdown
@@ -78,6 +78,34 @@ new_value:
 
 {% include actions/more_examples.md %}
 
+### Automation: switch the equalizer when a movie starts
+
+This automation switches the TV's audio equalizer to the "Movie" preset whenever the VIZIO media player starts playing, giving you better sound for films.
+
+- **Trigger**: The VIZIO media player starts playing
+- **Action**: VIZIO SmartCast: Update setting
+
+{% details "YAML example for switching the equalizer on playback" %}
+
+{% example %}
+automation: |
+  alias: "VIZIO movie equalizer"
+  triggers:
+    - trigger: state
+      entity_id: media_player.vizio_smartcast
+      to: "playing"
+  actions:
+    - action: vizio.update_setting
+      target:
+        entity_id: media_player.vizio_smartcast
+      data:
+        setting_type: audio
+        setting_name: eq
+        new_value: Movie
+{% endexample %}
+
+{% enddetails %}
+
 {% include actions/stuck.md %}
 
 {% include actions/related.md %}

--- a/source/_actions/vizio.update_setting.markdown
+++ b/source/_actions/vizio.update_setting.markdown
@@ -1,0 +1,83 @@
+---
+title: "Update setting"
+action: vizio.update_setting
+domain: vizio
+description: "Updates the value of a setting on a VIZIO SmartCast device."
+---
+
+Use this action to update a setting on a VIZIO SmartCast device. You need to know the type and name of the setting you want to change.
+
+You can find these in the SmartCast app, under the device settings for your device. The setting type is the lowercase version of the first menu item you select, such as `display`, `audio`, or `system`. The setting name is what you see in the app, in lowercase and with spaces replaced by underscores, so "AV delay" becomes `av_delay`.
+
+{% include actions/ui_header.md %}
+
+To update a setting from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **VIZIO SmartCast: Update setting**.
+6. Select what you want to control. Under **By target** (see [Targets](#targets)), select your VIZIO media player entity.
+7. Enter the **Setting type**, **Setting name**, and **New value**.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Setting type:
+  description: "The type of setting to change, such as audio, display, or system."
+  required: true
+Setting name:
+  description: "The name of the setting to change, such as eq."
+  required: true
+New value:
+  description: The new value for the setting.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `vizio.update_setting`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: vizio.update_setting
+  target:
+    entity_id: media_player.vizio_smartcast
+  data:
+    setting_type: audio
+    setting_name: eq
+    new_value: Music
+{% endexample %}
+
+This sets the audio equalizer preset to "Music".
+
+### Options in YAML
+
+{% options_yaml %}
+setting_type:
+  description: >
+    The type of setting to change, such as `audio`, `display`, or `system`.
+  required: true
+  type: string
+setting_name:
+  description: >
+    The name of the setting to change, such as `eq`.
+  required: true
+  type: string
+new_value:
+  description: The new value for the setting.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="media_player" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/vizio.markdown
+++ b/source/_integrations/vizio.markdown
@@ -213,16 +213,7 @@ The list of apps that are provided by default is statically defined [here](https
 pyvizio --ip=0 get-apps-list
 ```
 
-## Action `vizio.update_setting`
-
-This action allows you to update a setting on a given VIZIO device. You will need to know the type of setting and the name of the setting to perform this action. You can determine this by using the SmartCast app and going to device settings for your target device. The setting type is the lowercase version of the first menu item you'd select (e.g., display, audio, system), and the setting name is what you see in the app, but spaces are replaced with underscores and it is also all lowercase (e.g., AV delay would be called `av_delay`).
-
-| Data attribute | Optional | Description | Example |
-| ---------------------- | -------- | ----------- | ------- |
-| `entity_id` | yes | The devices to update a setting for. | `media_player.vizio_smartcast`
-| `setting_type` | no | The type of setting. | `audio`
-| `setting_name` | no | The name of the setting. | `eq`
-| `new_value` | no | The new value to set the setting to. | `Music`
+{% include integrations/actions.md %}
 
 ## Remote
 


### PR DESCRIPTION
## Proposed change

Migrates the inline `vizio.update_setting` action documentation into a dedicated action page under `source/_actions/`, and replaces the inline action block with the standard `{% include integrations/actions.md %}`.

This action is entity-targeted (registered as a platform entity service on the media player entity), so the page documents the media player entity as the target instead of listing `entity_id` as a data attribute. The table was converted to a list per the documentation style. The generic `remote.send_command` documentation in the Remote section is left unchanged.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

