### PR TITLE
Flo: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/flo.run_health_test.markdown
+++ b/source/_actions/flo.run_health_test.markdown
@@ -1,0 +1,47 @@
+---
+title: "Run health test"
+action: flo.run_health_test
+domain: flo
+description: "Runs a health test on a Flo by Moen device."
+related_actions:
+  - flo.set_away_mode
+  - flo.set_home_mode
+  - flo.set_sleep_mode
+---
+
+Use this action to run a health test on a Flo by Moen device. The health test checks your plumbing for leaks by monitoring pressure while the valve is briefly closed.
+
+{% include actions/ui_header.md %}
+
+To run a health test from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select your Flo device.
+6. From the actions shown for that target, select **Run health test**.
+7. Select **Save**.
+
+### Options in the UI
+
+This action has no additional options in the UI.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `flo.run_health_test`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: flo.run_health_test
+  target:
+    entity_id: switch.flo_shutoff_valve
+{% endexample %}
+
+{% include actions/targets.md domain="switch" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/flo.set_away_mode.markdown
+++ b/source/_actions/flo.set_away_mode.markdown
@@ -1,0 +1,47 @@
+---
+title: "Set away mode"
+action: flo.set_away_mode
+domain: flo
+description: "Puts a Flo by Moen device into away mode."
+related_actions:
+  - flo.set_home_mode
+  - flo.set_sleep_mode
+  - flo.run_health_test
+---
+
+Use this action to put a Flo by Moen device into away mode. In away mode, Flo applies stricter monitoring rules, which is useful when nobody is home.
+
+{% include actions/ui_header.md %}
+
+To set away mode from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select your Flo device.
+6. From the actions shown for that target, select **Set away mode**.
+7. Select **Save**.
+
+### Options in the UI
+
+This action has no additional options in the UI.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `flo.set_away_mode`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: flo.set_away_mode
+  target:
+    entity_id: switch.flo_shutoff_valve
+{% endexample %}
+
+{% include actions/targets.md domain="switch" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/flo.set_home_mode.markdown
+++ b/source/_actions/flo.set_home_mode.markdown
@@ -1,0 +1,47 @@
+---
+title: "Set home mode"
+action: flo.set_home_mode
+domain: flo
+description: "Puts a Flo by Moen device into home mode."
+related_actions:
+  - flo.set_away_mode
+  - flo.set_sleep_mode
+  - flo.run_health_test
+---
+
+Use this action to put a Flo by Moen device into home mode. Home mode is the normal monitoring mode used when someone is home.
+
+{% include actions/ui_header.md %}
+
+To set home mode from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select your Flo device.
+6. From the actions shown for that target, select **Set home mode**.
+7. Select **Save**.
+
+### Options in the UI
+
+This action has no additional options in the UI.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `flo.set_home_mode`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: flo.set_home_mode
+  target:
+    entity_id: switch.flo_shutoff_valve
+{% endexample %}
+
+{% include actions/targets.md domain="switch" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/flo.set_sleep_mode.markdown
+++ b/source/_actions/flo.set_sleep_mode.markdown
@@ -1,0 +1,79 @@
+---
+title: "Set sleep mode"
+action: flo.set_sleep_mode
+domain: flo
+description: "Puts a Flo by Moen device into sleep mode for a set duration."
+related_actions:
+  - flo.set_away_mode
+  - flo.set_home_mode
+  - flo.run_health_test
+---
+
+Use this action to put a Flo by Moen device into sleep mode for a set duration. While in sleep mode, Flo pauses its monitoring rules. When the duration ends, the device reverts to the mode you choose.
+
+{% include actions/ui_header.md %}
+
+To set sleep mode from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select your Flo device.
+6. From the actions shown for that target, select **Set sleep mode**.
+7. Enter the **Sleep minutes** and the **Revert to mode**.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Sleep minutes:
+  description: How long the device stays in sleep mode, in minutes. Choose 120 (2 hours), 1440 (1 day), or 4320 (3 days).
+  required: true
+Revert to mode:
+  description: The mode the device returns to once the sleep duration ends. Choose away or home.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `flo.set_sleep_mode`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: flo.set_sleep_mode
+  target:
+    entity_id: switch.flo_shutoff_valve
+  data:
+    sleep_minutes: 120
+    revert_to_mode: home
+{% endexample %}
+
+This puts the device into sleep mode for 2 hours, after which it reverts to home mode.
+
+### Options in YAML
+
+{% options_yaml %}
+sleep_minutes:
+  description: >
+    How long the device stays in sleep mode, in minutes. Choose 120 (2 hours),
+    1440 (1 day), or 4320 (3 days).
+  required: true
+  type: integer
+revert_to_mode:
+  description: >
+    The mode the device returns to once the sleep duration ends. Choose away or
+    home.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="switch" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/flo.markdown
+++ b/source/_integrations/flo.markdown
@@ -30,20 +30,4 @@ There is currently support for the following device types within Home Assistant:
 
 {% include integrations/config_flow.md %}
 
-## Actions
-
-### `flo.run_health_test`
-
-Run a health test for the Flo device.
-
-### `flo.set_away_mode`
-
-Set the Flo device to away mode.
-
-### `flo.set_home_mode`
-
-Set the Flo device to home mode.
-
-### `flo.set_sleep_mode`
-
-Set the Flo device to sleep mode.
+{% include integrations/actions.md %}


### PR DESCRIPTION
## Proposed change

Migrates the Flo by Moen actions into dedicated pages under `source/_actions/` and replaces the inline action list on the integration page with `{% include integrations/actions.md %}`. Covers `set_away_mode`, `set_home_mode`, `run_health_test`, and `set_sleep_mode`, each documented for both the UI and YAML and verified against the integration's core service registration.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

