### PR TITLE
Rain Bird: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/rainbird.start_irrigation.markdown
+++ b/source/_actions/rainbird.start_irrigation.markdown
@@ -1,0 +1,64 @@
+---
+title: "Start irrigation"
+action: rainbird.start_irrigation
+domain: rainbird
+description: "Starts a Rain Bird sprinkler zone for a set number of minutes."
+---
+
+Use this action to start a Rain Bird sprinkler zone for a set number of minutes. Unlike turning on the zone switch directly, this action lets you choose a custom run time, which is handy for building your own watering schedules in automations.
+
+{% include actions/ui_header.md %}
+
+To start a zone from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Rain Bird: Start irrigation**.
+6. Select what you want to control. Under **By target** (see [Targets](#targets)), select the zone switch you want to run.
+7. Enter the **Duration** in minutes.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Duration:
+  description: How long the zone runs, in minutes. Must be between 1 and 1440.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `rainbird.start_irrigation`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: rainbird.start_irrigation
+  target:
+    entity_id: switch.rain_bird_sprinkler_1
+  data:
+    duration: 5
+{% endexample %}
+
+This runs the selected zone for 5 minutes.
+
+### Options in YAML
+
+{% options_yaml %}
+duration:
+  description: >
+    How long the zone runs, in minutes. Must be between 1 and 1440.
+  required: true
+  type: integer
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="switch" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/rainbird.markdown
+++ b/source/_integrations/rainbird.markdown
@@ -103,37 +103,7 @@ The Rain Bird integration provides the following entities.
     configured controllers. Turning on the switch will open the irrigation valve for that zone.
   - **Available for devices**: All
 
-## Actions
-
-The integration exposes actions to give additional control over a Rain Bird device.
-
-### `rainbird.start_irrigation`
-
-Start a Rain Bird zone for a set number of minutes. This action accepts a Rain Bird sprinkler
-zone switch entity and allows a custom duration unlike the switch.
-
-| Data attribute | Optional | Description                                           |
-| ---------------------- | -------- | ----------------------------------------------------- |
-| `entity_id`            | no       | The Rain Bird Sprinkler zone switch to turn on.       |
-| `duration`             | no       | Number of minutes for this zone to be turned on.      |
-
-
-```yaml
-# Example configuration.yaml automation entry
-automation:
-  - alias: "Turn irrigation on"
-    triggers:
-      - trigger: time
-        at: "5:30:00"
-    actions:
-      - action: rainbird.start_irrigation
-        data:
-          entity_id: switch.rain_bird_sprinkler_1
-          duration: 5
-```
-
-This lets you other triggers in Home Assistant to set a more complex schedule
-than what is possible using the built in schedule in the Rain Bird app.
+{% include integrations/actions.md %}
 
 ## Known Limitations
 


### PR DESCRIPTION
## Proposed change

Migrates the Rain Bird `start_irrigation` action into a dedicated page under `source/_actions/` and replaces the inline action block on the integration page with `{% include integrations/actions.md %}`. The action is documented for both the UI and YAML and verified against the integration's core service registration. The stale `set_rain_delay` entry was not migrated, as it is no longer registered as an action (it is now a number entity) and was not documented on the page.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

