### PR TITLE
Verisure: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/verisure.capture_smartcam.markdown
+++ b/source/_actions/verisure.capture_smartcam.markdown
@@ -1,0 +1,46 @@
+---
+title: "Capture SmartCam image"
+action: verisure.capture_smartcam
+domain: verisure
+description: "Captures a new image from a Verisure SmartCam."
+related_actions:
+  - verisure.enable_autolock
+  - verisure.disable_autolock
+---
+
+Use this action to capture a new image from a Verisure SmartCam. This is handy in automations, for example to grab a fresh image when motion is detected.
+
+{% include actions/ui_header.md %}
+
+To capture an image from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Verisure: Capture SmartCam image**.
+6. Select what you want to control. Under **By target** (see [Targets](#targets)), select the SmartCam you want to use.
+7. Select **Save**.
+
+### Options in the UI
+
+This action has no additional options in the UI.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `verisure.capture_smartcam`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: verisure.capture_smartcam
+  target:
+    entity_id: camera.hallway
+{% endexample %}
+
+{% include actions/targets.md domain="camera" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/verisure.disable_autolock.markdown
+++ b/source/_actions/verisure.disable_autolock.markdown
@@ -1,0 +1,46 @@
+---
+title: "Disable autolock"
+action: verisure.disable_autolock
+domain: verisure
+description: "Disables autolock on a Verisure Lockguard Smartlock."
+related_actions:
+  - verisure.enable_autolock
+  - verisure.capture_smartcam
+---
+
+Use this action to disable autolock on a Verisure Lockguard Smartlock. When autolock is off, the lock stays unlocked until it is locked manually or by another action.
+
+{% include actions/ui_header.md %}
+
+To disable autolock from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Verisure: Disable autolock**.
+6. Select what you want to control. Under **By target** (see [Targets](#targets)), select the lock you want to update.
+7. Select **Save**.
+
+### Options in the UI
+
+This action has no additional options in the UI.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `verisure.disable_autolock`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: verisure.disable_autolock
+  target:
+    entity_id: lock.front_door
+{% endexample %}
+
+{% include actions/targets.md domain="lock" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/verisure.enable_autolock.markdown
+++ b/source/_actions/verisure.enable_autolock.markdown
@@ -1,0 +1,46 @@
+---
+title: "Enable autolock"
+action: verisure.enable_autolock
+domain: verisure
+description: "Enables autolock on a Verisure Lockguard Smartlock."
+related_actions:
+  - verisure.disable_autolock
+  - verisure.capture_smartcam
+---
+
+Use this action to enable autolock on a Verisure Lockguard Smartlock. When autolock is on, the lock locks itself automatically.
+
+{% include actions/ui_header.md %}
+
+To enable autolock from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Verisure: Enable autolock**.
+6. Select what you want to control. Under **By target** (see [Targets](#targets)), select the lock you want to update.
+7. Select **Save**.
+
+### Options in the UI
+
+This action has no additional options in the UI.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `verisure.enable_autolock`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: verisure.enable_autolock
+  target:
+    entity_id: lock.front_door
+{% endexample %}
+
+{% include actions/targets.md domain="lock" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/verisure.markdown
+++ b/source/_integrations/verisure.markdown
@@ -63,13 +63,7 @@ automation:
             by {{ trigger.to_state.attributes.changed_by }}
 ```
 
-## Actions
-
-| Service | Description |
-| ------- | ----------- |
-| disable_autolock | Disables autolock function for a specific lock. |
-| enable_autolock | Enables autolock function for a specific lock. |
-| smartcam_capture | Capture a new image from a specific smartcam. |
+{% include integrations/actions.md %}
 
 ## Binary sensor
 


### PR DESCRIPTION
## Proposed change

Migrates the Verisure actions into dedicated pages under `source/_actions/` and replaces the inline action table on the integration page with `{% include integrations/actions.md %}`. Covers `capture_smartcam`, `enable_autolock`, and `disable_autolock`, each documented for both the UI and YAML and verified against the integration's core service registration. This also corrects the action name, which the page previously listed as `smartcam_capture` (the registered action is `capture_smartcam`).

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

