### PR TITLE
Bose SoundTouch: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/soundtouch.add_zone_slave.markdown
+++ b/source/_actions/soundtouch.add_zone_slave.markdown
@@ -24,7 +24,7 @@ To add a follower from an automation or a script:
 7. Select one or more **Follower** media players to add to the zone.
 8. Select **Save**.
 
-This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+This action does not support targets. In the UI, you choose the devices in the **Leader** and **Follower** fields.
 
 ### Options in the UI
 

--- a/source/_actions/soundtouch.add_zone_slave.markdown
+++ b/source/_actions/soundtouch.add_zone_slave.markdown
@@ -1,0 +1,74 @@
+---
+title: "Add zone follower"
+action: soundtouch.add_zone_slave
+domain: soundtouch
+description: "Adds media players to an existing Bose SoundTouch zone."
+related_actions:
+  - soundtouch.create_zone
+  - soundtouch.remove_zone_slave
+  - soundtouch.play_everywhere
+---
+
+Use this action to add one or more follower devices to an existing multi-room zone.
+
+{% include actions/ui_header.md %}
+
+To add a follower from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Bose SoundTouch: Add zone follower**.
+6. Select the **Leader**: the media player that coordinates the existing zone.
+7. Select one or more **Follower** media players to add to the zone.
+8. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Leader:
+  description: The media player that coordinates the existing zone.
+  required: true
+Follower:
+  description: The media players to add to the existing zone.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `soundtouch.add_zone_slave`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: soundtouch.add_zone_slave
+  data:
+    master: media_player.living_room
+    slaves:
+      - media_player.office
+{% endexample %}
+
+This adds the office device to the zone led by the living room device.
+
+### Options in YAML
+
+{% options_yaml %}
+master:
+  description: >
+    The media player that coordinates the existing zone.
+  required: true
+  type: string
+slaves:
+  description: >
+    The media players to add to the existing zone.
+  required: true
+  type: list
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/soundtouch.create_zone.markdown
+++ b/source/_actions/soundtouch.create_zone.markdown
@@ -24,7 +24,7 @@ To create a zone from an automation or a script:
 7. Select one or more **Follower** media players to add to the zone.
 8. Select **Save**.
 
-This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+This action does not support targets. In the UI, you choose the devices in the **Leader** and **Follower** fields.
 
 ### Options in the UI
 

--- a/source/_actions/soundtouch.create_zone.markdown
+++ b/source/_actions/soundtouch.create_zone.markdown
@@ -1,0 +1,75 @@
+---
+title: "Create zone"
+action: soundtouch.create_zone
+domain: soundtouch
+description: "Creates a Bose SoundTouch multi-room zone."
+related_actions:
+  - soundtouch.play_everywhere
+  - soundtouch.add_zone_slave
+  - soundtouch.remove_zone_slave
+---
+
+Use this action to create a multi-room zone from a leader device and one or more follower devices. The followers play the same content as the leader.
+
+{% include actions/ui_header.md %}
+
+To create a zone from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Bose SoundTouch: Create zone**.
+6. Select the **Leader**: the media player that coordinates the zone.
+7. Select one or more **Follower** media players to add to the zone.
+8. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Leader:
+  description: The media player that coordinates the new zone.
+  required: true
+Follower:
+  description: The media players to add to the new zone.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `soundtouch.create_zone`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: soundtouch.create_zone
+  data:
+    master: media_player.living_room
+    slaves:
+      - media_player.kitchen
+      - media_player.bedroom
+{% endexample %}
+
+This creates a zone led by the living room device, with the kitchen and bedroom devices as followers.
+
+### Options in YAML
+
+{% options_yaml %}
+master:
+  description: >
+    The media player that coordinates the new zone.
+  required: true
+  type: string
+slaves:
+  description: >
+    The media players to add to the new zone.
+  required: true
+  type: list
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/soundtouch.play_everywhere.markdown
+++ b/source/_actions/soundtouch.play_everywhere.markdown
@@ -23,7 +23,7 @@ To play everywhere from an automation or a script:
 6. Select the **Leader**: the media player that coordinates the grouping and provides the content.
 7. Select **Save**.
 
-This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+This action does not support targets. In the UI, you choose the device in the **Leader** field.
 
 ### Options in the UI
 

--- a/source/_actions/soundtouch.play_everywhere.markdown
+++ b/source/_actions/soundtouch.play_everywhere.markdown
@@ -1,0 +1,66 @@
+---
+title: "Play everywhere"
+action: soundtouch.play_everywhere
+domain: soundtouch
+description: "Plays the same content on all Bose SoundTouch devices."
+related_actions:
+  - soundtouch.create_zone
+  - soundtouch.add_zone_slave
+  - soundtouch.remove_zone_slave
+---
+
+Use this action to play the same content on all your Bose SoundTouch devices at once. It is a shortcut for creating a multi-room zone that includes every device, using the device you pick as the leader.
+
+{% include actions/ui_header.md %}
+
+To play everywhere from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Bose SoundTouch: Play everywhere**.
+6. Select the **Leader**: the media player that coordinates the grouping and provides the content.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Leader:
+  description: The media player that coordinates the grouping. Its content plays on all devices.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `soundtouch.play_everywhere`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: soundtouch.play_everywhere
+  data:
+    master: media_player.living_room
+{% endexample %}
+
+This plays the content from the living room device on all your SoundTouch devices.
+
+### Options in YAML
+
+{% options_yaml %}
+master:
+  description: >
+    The media player that coordinates the grouping. Its content plays on all
+    devices.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/soundtouch.remove_zone_slave.markdown
+++ b/source/_actions/soundtouch.remove_zone_slave.markdown
@@ -24,7 +24,7 @@ To remove a follower from an automation or a script:
 7. Select one or more **Follower** media players to remove from the zone.
 8. Select **Save**.
 
-This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+This action does not support targets. In the UI, you choose the devices in the **Leader** and **Follower** fields.
 
 ### Options in the UI
 

--- a/source/_actions/soundtouch.remove_zone_slave.markdown
+++ b/source/_actions/soundtouch.remove_zone_slave.markdown
@@ -1,0 +1,74 @@
+---
+title: "Remove zone follower"
+action: soundtouch.remove_zone_slave
+domain: soundtouch
+description: "Removes media players from an existing Bose SoundTouch zone."
+related_actions:
+  - soundtouch.create_zone
+  - soundtouch.add_zone_slave
+  - soundtouch.play_everywhere
+---
+
+Use this action to remove one or more follower devices from an existing multi-room zone. Removing the last follower destroys the zone, and you need to create a new one to group devices again.
+
+{% include actions/ui_header.md %}
+
+To remove a follower from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Bose SoundTouch: Remove zone follower**.
+6. Select the **Leader**: the media player that coordinates the existing zone.
+7. Select one or more **Follower** media players to remove from the zone.
+8. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Leader:
+  description: The media player that coordinates the existing zone.
+  required: true
+Follower:
+  description: The media players to remove from the existing zone.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `soundtouch.remove_zone_slave`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: soundtouch.remove_zone_slave
+  data:
+    master: media_player.living_room
+    slaves:
+      - media_player.office
+{% endexample %}
+
+This removes the office device from the zone led by the living room device.
+
+### Options in YAML
+
+{% options_yaml %}
+master:
+  description: >
+    The media player that coordinates the existing zone.
+  required: true
+  type: string
+slaves:
+  description: >
+    The media players to remove from the existing zone.
+  required: true
+  type: list
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/soundtouch.markdown
+++ b/source/_integrations/soundtouch.markdown
@@ -51,42 +51,4 @@ You can use TTS services like [Google text-to-speech](/integrations/google_trans
 
 A workaround if you want to publish your Home Assistant installation on Internet in SSL is to configure an HTTPS Web Server as a reverse proxy ([NGINX](/docs/ecosystem/nginx/) for example) and let your Home Assistant configuration in HTTP on your local network. The SoundTouch devices will be available to access the TTS files in HTTP in local and your configuration will be in HTTPS on the Internet.
 
-## Actions
-
-### Action: Play everywhere
-
-The `soundtouch.play_everywhere` action creates a multi-room (zone) from a master and plays the same content on all other devices (slaves).
-
-| Data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `master` | no | `entity_id` of the master device
-
-### Action: Create zone
-
-The `soundtouch.create_zone` action creates a multi-room (zone) from a master and plays on selected slaves.
-
-| Data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `master` | no | `entity_id` of the master device|
-| `slaves` | no | List of slaves `entity_id`      |
-
-### Action: Add zone slave
-
-The `soundtouch.add_zone_slave` action adds slave(s) to an existing zone.
-
-| Data attribute | Optional | Description  |
-| ---------------------- | -------- | ------------ |
-| `master` | no | `entity_id` of the master device |
-| `slaves` | no | List of slaves `entity_id` to add|
-
-### Action: Remove zone slave
-
-The `soundtouch.remove_zone_slave` action removes slave(s) from an existing zone.
-
-Removing the last slave will destroy the zone. You will need to
-create a new zone to be able to add slave(s) again
-
-| Data attribute | Optional | Description      |
-| ---------------------- | -------- | ---------------- |
-| `master` | no | `entity_id` of the master device     |
-| `slaves` | no | List of slaves `entity_id` to remove |
+{% include integrations/actions.md %}


### PR DESCRIPTION
## Proposed change

Migrates the Bose SoundTouch multi-room actions into dedicated pages under `source/_actions/` and replaces the inline action blocks on the integration page with `{% include integrations/actions.md %}`. Covers `play_everywhere`, `create_zone`, `add_zone_slave`, and `remove_zone_slave`, each documented for both the UI and YAML and verified against the integration's core service registration. The leader and follower fields are described with the same labels used in the UI.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

