### PR TITLE
Bluesound: remove deprecated actions documentation

### DIFF
--- a/source/_integrations/bluesound.markdown
+++ b/source/_integrations/bluesound.markdown
@@ -50,52 +50,6 @@ Clear the sleep timer on a speaker, if one is set.
 This button is disabled by default.
 {% endnote %}
 
-## Actions
-
-The Bluesound integration makes some custom actions available in addition to the [standard media player actions](/integrations/media_player/#actions).
-
-### Action: Join
-
-The `bluesound.join` action allows you to group players together under a single master speaker. That will make a new group or join an existing group.
-
-| Data attribute | Optional | Description                                                               |
-| ---------------------- | -------- | ------------------------------------------------------------------------- |
-| `master`               | no       | A single `entity_id` that will become/hold the master speaker.            |
-| `entity_id`            | no       | String or list of a single `entity_id` that will group to master speaker. |
-
-### Action: Unjoin
-
-The `bluesound.unjoin` action allows you to remove one or more speakers from a group of speakers. If no `entity_id` is provided, all speakers are unjoined.
-
-| Data attribute | Optional | Description                                                                      |
-| ---------------------- | -------- | -------------------------------------------------------------------------------- |
-| `entity_id`            | yes      | String or list of `entity_id`s that will be separated from their master speaker. |
-
-### Action: Set sleep timer
-
-{% note %}
-This action is deprecated. Use `button.<player_name>_set_set_timer` instead.
-{% endnote %}
-
-The `bluesound.set_sleep_timer` action allows you to set a timer that will turn off the speaker. For each time you call this it will increase the time by one step. The steps are (in minutes): 15, 30, 45, 60, 90, 0.
-If you increase an ongoing timer of for example 13 minutes, it will increase it to 15. If the timer is set to 90, it will remove the time (hence the 0).
-
-| Data attribute | Optional | Description                                                     |
-| ---------------------- | -------- | --------------------------------------------------------------- |
-| `entity_id`            | no       | String or list of `entity_id`s that will have their timers set. |
-
-### Action: Clear sleep timer
-
-{% note %}
-This action is deprecated. Use `button.<player_name>_clear_set_timer` instead.
-{% endnote %}
-
-The `bluesound.clear_sleep_timer` action allows you to clear the sleep timer on a speaker, if one is set.
-
-| Data attribute | Optional | Description                                                         |
-| ---------------------- | -------- | ------------------------------------------------------------------- |
-| `entity_id`            | no       | String or list of `entity_id`s that will have their timers cleared. |
-
 ## Removing the integration
 
 This integration follows standard integration removal. No extra steps are required.


### PR DESCRIPTION
## Proposed change

Removes the `## Actions` section from the Bluesound integration page. All four custom actions documented there are deprecated in Home Assistant Core:

- `bluesound.join` and `bluesound.unjoin` raise a deprecation repair issue and stop working in Home Assistant 2026.7.0. The standard `media_player.join` and `media_player.unjoin` actions replace them.
- `bluesound.set_sleep_timer` and `bluesound.clear_sleep_timer` are already replaced by the sleep timer button entities, which the page documents in the Buttons section.

Following the documentation standard of removing deprecated feature documentation rather than keeping it with a deprecation notice.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

