### PR TITLE
Husqvarna Automower: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/husqvarna_automower.override_schedule.markdown
+++ b/source/_actions/husqvarna_automower.override_schedule.markdown
@@ -1,0 +1,79 @@
+---
+title: "Override schedule"
+action: husqvarna_automower.override_schedule
+domain: husqvarna_automower
+description: "Lets the mower either mow or park for a given duration, overriding all schedules."
+related_actions:
+  - husqvarna_automower.override_schedule_work_area
+---
+
+The **Override schedule** action lets your mower mow or park for a set duration, overriding all of its configured schedules for that time.
+
+This is handy when you want a one-off change without touching your regular schedule, for example sending the mower out for an extra hour before guests arrive, or parking it while the kids play in the garden. The duration can be between 1 minute and 42 days.
+
+{% include actions/ui_header.md %}
+
+To override the schedule from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the mower you want to control.
+6. From the actions shown for that target, select **Override schedule**.
+7. Set the **Duration** and the **Override mode**.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Duration:
+  description: How long the override should last. Minimum 1 minute, maximum 42 days.
+  required: true
+Override mode:
+  description: Whether the mower should mow or park during the override.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `husqvarna_automower.override_schedule`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: husqvarna_automower.override_schedule
+  target:
+    entity_id: lawn_mower.garden
+  data:
+    duration:
+      days: 1
+      hours: 12
+      minutes: 30
+    override_mode: mow
+{% endexample %}
+
+This sends `lawn_mower.garden` out to mow for one day, 12 hours, and 30 minutes, ignoring its schedules during that time.
+
+### Options in YAML
+
+{% options_yaml %}
+duration:
+  description: >
+    How long the override should last. Minimum 1 minute, maximum 42 days.
+  required: true
+  type: time
+override_mode:
+  description: >
+    Whether the mower should mow or park during the override. One of mow or
+    park.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="lawn_mower" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/husqvarna_automower.override_schedule.markdown
+++ b/source/_actions/husqvarna_automower.override_schedule.markdown
@@ -59,7 +59,9 @@ This sends `lawn_mower.garden` out to mow for one day, 12 hours, and 30 minutes,
 {% options_yaml %}
 duration:
   description: >
-    How long the override should last. Minimum 1 minute, maximum 42 days.
+    How long the override should last. Accepts a Home Assistant duration object
+    with `days`, `hours`, `minutes`, and `seconds` keys, or an ISO 8601 duration
+    string like "00:15:00". Minimum 1 minute, maximum 42 days.
   required: true
   type: time
 override_mode:

--- a/source/_actions/husqvarna_automower.override_schedule_work_area.markdown
+++ b/source/_actions/husqvarna_automower.override_schedule_work_area.markdown
@@ -1,0 +1,83 @@
+---
+title: "Override schedule work area"
+action: husqvarna_automower.override_schedule_work_area
+domain: husqvarna_automower
+description: "Lets the mower mow for a given duration in a specified work area, overriding all schedules."
+related_actions:
+  - husqvarna_automower.override_schedule
+---
+
+The **Override schedule work area** action lets your mower mow a specific work area for a set duration, overriding all of its configured schedules for that time.
+
+This is handy when you want to focus the mower on one part of the garden, for example mowing only the front lawn before a barbecue. The duration can be between 1 minute and 42 days. This action is available only on mowers that support work areas.
+
+{% include actions/ui_header.md %}
+
+To override the schedule for a work area from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the mower you want to control.
+6. From the actions shown for that target, select **Override schedule work area**.
+7. Set the **Duration** and the **Work area ID**.
+8. Select **Save**.
+
+You can find the work area ID on the **Work area** sensor of your mower.
+
+![Work area sensor](/images/integrations/husqvarna_automower/work_area_sensor.png)
+
+### Options in the UI
+
+{% options_ui %}
+Duration:
+  description: How long the override should last. Minimum 1 minute, maximum 42 days.
+  required: true
+Work area ID:
+  description: The work area the mower should mow. You can find it on the Work area sensor.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `husqvarna_automower.override_schedule_work_area`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: husqvarna_automower.override_schedule_work_area
+  target:
+    entity_id: lawn_mower.garden
+  data:
+    duration:
+      days: 1
+      hours: 12
+      minutes: 30
+    work_area_id: 123456
+{% endexample %}
+
+This sends `lawn_mower.garden` to mow work area `123456` for one day, 12 hours, and 30 minutes, ignoring its schedules during that time.
+
+### Options in YAML
+
+{% options_yaml %}
+duration:
+  description: >
+    How long the override should last. Minimum 1 minute, maximum 42 days.
+  required: true
+  type: time
+work_area_id:
+  description: >
+    The work area the mower should mow. You can find it on the Work area
+    sensor.
+  required: true
+  type: integer
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="lawn_mower" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/husqvarna_automower.override_schedule_work_area.markdown
+++ b/source/_actions/husqvarna_automower.override_schedule_work_area.markdown
@@ -35,7 +35,7 @@ Duration:
   description: How long the override should last. Minimum 1 minute, maximum 42 days.
   required: true
 Work area ID:
-  description: The work area the mower should mow. You can find it on the Work area sensor.
+  description: The work area the mower should mow. You can find it on the **Work area** sensor.
   required: true
 {% endoptions_ui %}
 
@@ -63,12 +63,14 @@ This sends `lawn_mower.garden` to mow work area `123456` for one day, 12 hours, 
 {% options_yaml %}
 duration:
   description: >
-    How long the override should last. Minimum 1 minute, maximum 42 days.
+    How long the override should last. Accepts a Home Assistant duration object
+    with `days`, `hours`, `minutes`, and `seconds` keys, or an ISO 8601 duration
+    string like "00:15:00". Minimum 1 minute, maximum 42 days.
   required: true
   type: time
 work_area_id:
   description: >
-    The work area the mower should mow. You can find it on the Work area
+    The work area the mower should mow. You can find it on the **Work area**
     sensor.
   required: true
   type: integer

--- a/source/_integrations/husqvarna_automower.markdown
+++ b/source/_integrations/husqvarna_automower.markdown
@@ -210,45 +210,7 @@ The integration will create a switch to enable or disable the schedule of the mo
 
 The integration will create a switch for each work area defined for your mower. When the switch is on, the mower mows the corresponding area. When the switch is off, the mower doesn't mow the corresponding area.
 
-## Actions
-
-The integration offers the following actions:
-
-### Override schedule
-
-With this action, you can let your mower mow or park for a given time. You can select the override mode with the `override_mode` attribute. This will override all your schedules during this time. The duration can be given in days, hours and/or minutes. The values for the duration have to be between 1 minute and 42 days.
-
-```yaml
-# Replace <name> with the name of your mower.
-action: husqvarna_automower.override_schedule
-target:
-  entity_id: lawn_mower.<name>
-data:
-  duration:
-    days: 1
-    hours: 12
-    minutes: 30
-  override_mode: mow  ### alternative: `park`
-```
-
-### Override schedule work area (if available)
-
-With this action, you can let your mower mow for a given time in a certain work area. You can enter the work area with the `work_area_id` attribute. You can get the `work_area_id` from the `Work area` sensor.
-![Work area sensor](/images/integrations/husqvarna_automower/work_area_sensor.png)
-This will override all your schedules during this time. The duration can be given in days, hours, and/or minutes. The values for the duration have to be between 1 minute and 42 days.
-
-```yaml
-# Replace <name> with the name of your mower.
-action: husqvarna_automower.override_schedule_work_area
-target:
-  entity_id: lawn_mower.<name>
-data:
-  duration:
-    days: 1
-    hours: 12
-    minutes: 30
-  work_area_id: 123456 ### Work area ID for the "Front lawn" from the example above.
-```
+{% include integrations/actions.md %}
 
 ## Known limitations
 


### PR DESCRIPTION
## Proposed change

Migrates the Husqvarna Automower actions from the inline `## Actions` block on the integration page into dedicated action pages under `source/_actions/`, replacing the inline documentation with `{% include integrations/actions.md %}`.

This covers `override_schedule` and `override_schedule_work_area`. Both are entity-targeted lawn mower actions, so each page documents the UI and YAML usage, the duration and mode/work area options, and the targets. The work area ID screenshot is kept on the work area action page.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

