### PR TITLE
Hydrawise: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/hydrawise.resume.markdown
+++ b/source/_actions/hydrawise.resume.markdown
@@ -1,0 +1,50 @@
+---
+title: "Resume automatic watering"
+action: hydrawise.resume
+domain: hydrawise
+description: "Resumes an irrigation zone's automatic watering schedule."
+related_actions:
+  - hydrawise.suspend
+  - hydrawise.start_watering
+---
+
+The **Resume automatic watering** action restarts an irrigation zone's automatic watering schedule after it has been suspended.
+
+This is handy when you want to bring a zone back to its normal schedule early, for example resuming watering once a dry spell returns instead of waiting for a suspension to expire.
+
+{% include actions/ui_header.md %}
+
+To resume watering from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the irrigation zone's watering sensor.
+6. From the actions shown for that target, select **Resume automatic watering**.
+7. Select **Save**.
+
+This action has no additional options in the UI.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `hydrawise.resume`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: hydrawise.resume
+  target:
+    entity_id: binary_sensor.front_lawn_watering
+{% endexample %}
+
+This resumes automatic watering on the front lawn zone.
+
+This action has no additional options in YAML.
+
+{% include actions/targets.md domain="binary_sensor" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/hydrawise.resume.markdown
+++ b/source/_actions/hydrawise.resume.markdown
@@ -20,7 +20,7 @@ To resume watering from an automation or a script:
 2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
 3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
 4. In the **Then do** section, select **Add action**.
-5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the irrigation zone's watering sensor.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the irrigation zone's auto watering switch.
 6. From the actions shown for that target, select **Resume automatic watering**.
 7. Select **Save**.
 
@@ -34,14 +34,14 @@ In YAML, refer to this action as `hydrawise.resume`. A basic example looks like 
 action: |
   action: hydrawise.resume
   target:
-    entity_id: binary_sensor.front_lawn_watering
+    entity_id: switch.front_lawn_auto_watering
 {% endexample %}
 
 This resumes automatic watering on the front lawn zone.
 
 This action has no additional options in YAML.
 
-{% include actions/targets.md domain="binary_sensor" %}
+{% include actions/targets.md domain="switch" %}
 
 {% include actions/try_it.md %}
 

--- a/source/_actions/hydrawise.start_watering.markdown
+++ b/source/_actions/hydrawise.start_watering.markdown
@@ -1,0 +1,68 @@
+---
+title: "Start watering"
+action: hydrawise.start_watering
+domain: hydrawise
+description: "Starts a watering cycle in the selected irrigation zone."
+related_actions:
+  - hydrawise.suspend
+  - hydrawise.resume
+---
+
+The **Start watering** action starts a watering cycle in an irrigation zone.
+
+This is handy when you want to water on demand or from an automation, for example giving the lawn an extra run on a hot afternoon. You can set how long the cycle runs, or let it fall back to the default duration configured in the Hydrawise app.
+
+{% include actions/ui_header.md %}
+
+To start watering from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the irrigation zone's watering sensor.
+6. From the actions shown for that target, select **Start watering**.
+7. Optionally set the **Duration**.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Duration:
+  description: Length of time in minutes to run the watering cycle. If not specified or zero, the default watering duration set in the Hydrawise app for the zone is used.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `hydrawise.start_watering`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: hydrawise.start_watering
+  target:
+    entity_id: binary_sensor.front_lawn_watering
+  data:
+    duration: 15
+{% endexample %}
+
+This runs a 15-minute watering cycle on the front lawn zone.
+
+### Options in YAML
+
+{% options_yaml %}
+duration:
+  description: >
+    Length of time in minutes to run the watering cycle. If not specified or
+    zero, the default watering duration set in the Hydrawise app for the zone
+    is used.
+  required: false
+  type: integer
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="binary_sensor" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/hydrawise.start_watering.markdown
+++ b/source/_actions/hydrawise.start_watering.markdown
@@ -20,7 +20,7 @@ To start watering from an automation or a script:
 2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
 3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
 4. In the **Then do** section, select **Add action**.
-5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the irrigation zone's watering sensor.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the irrigation zone's manual watering switch.
 6. From the actions shown for that target, select **Start watering**.
 7. Optionally set the **Duration**.
 8. Select **Save**.
@@ -40,7 +40,7 @@ In YAML, refer to this action as `hydrawise.start_watering`. A basic example loo
 action: |
   action: hydrawise.start_watering
   target:
-    entity_id: binary_sensor.front_lawn_watering
+    entity_id: switch.front_lawn_manual_watering
   data:
     duration: 15
 {% endexample %}
@@ -59,7 +59,7 @@ duration:
   type: integer
 {% endoptions_yaml %}
 
-{% include actions/targets.md domain="binary_sensor" %}
+{% include actions/targets.md domain="switch" %}
 
 {% include actions/try_it.md %}
 

--- a/source/_actions/hydrawise.suspend.markdown
+++ b/source/_actions/hydrawise.suspend.markdown
@@ -1,0 +1,68 @@
+---
+title: "Suspend automatic watering"
+action: hydrawise.suspend
+domain: hydrawise
+description: "Suspends an irrigation zone's automatic watering schedule until the given date and time."
+related_actions:
+  - hydrawise.resume
+  - hydrawise.start_watering
+---
+
+The **Suspend automatic watering** action pauses an irrigation zone's automatic watering schedule until a date and time you choose.
+
+This is handy when you want to hold off watering for a while, for example suspending a zone over a rainy weekend or while you reseed part of the lawn. Automatic watering resumes on its own once the suspension ends.
+
+{% include actions/ui_header.md %}
+
+To suspend watering from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the irrigation zone's watering sensor.
+6. From the actions shown for that target, select **Suspend automatic watering**.
+7. Set the **Until** date and time.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Until:
+  description: The date and time when automatic watering should resume.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `hydrawise.suspend`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: hydrawise.suspend
+  target:
+    entity_id: binary_sensor.front_lawn_watering
+  data:
+    until: "2024-08-30 08:30:00"
+{% endexample %}
+
+This suspends automatic watering on the front lawn zone until the morning of August 30.
+
+### Options in YAML
+
+{% options_yaml %}
+until:
+  description: >
+    The date and time when automatic watering should resume, in the format
+    YYYY-MM-DD HH:MM:SS.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="binary_sensor" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/hydrawise.suspend.markdown
+++ b/source/_actions/hydrawise.suspend.markdown
@@ -20,7 +20,7 @@ To suspend watering from an automation or a script:
 2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
 3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
 4. In the **Then do** section, select **Add action**.
-5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the irrigation zone's watering sensor.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the irrigation zone's auto watering switch.
 6. From the actions shown for that target, select **Suspend automatic watering**.
 7. Set the **Until** date and time.
 8. Select **Save**.
@@ -41,7 +41,7 @@ In YAML, refer to this action as `hydrawise.suspend`. A basic example looks like
 action: |
   action: hydrawise.suspend
   target:
-    entity_id: binary_sensor.front_lawn_watering
+    entity_id: switch.front_lawn_auto_watering
   data:
     until: "2024-08-30 08:30:00"
 {% endexample %}
@@ -59,7 +59,7 @@ until:
   type: string
 {% endoptions_yaml %}
 
-{% include actions/targets.md domain="binary_sensor" %}
+{% include actions/targets.md domain="switch" %}
 
 {% include actions/try_it.md %}
 

--- a/source/_integrations/hydrawise.markdown
+++ b/source/_integrations/hydrawise.markdown
@@ -82,35 +82,7 @@ When `manual_watering` is `on` the zone will run for 15 minutes.
 Due to changes in the Hydrawise API the status of the Auto Watering switches has changed. Under normal conditions the Auto Watering switches correctly reflect the Smart Watering schedule on the Hydrawise mobile or web app. However, if a rain sensor is connected to the system and it is active (rain detected), or the zone is running the Auto Watering switch will turn off. After both of those conditions are removed the switch will again show the correct Auto Watering condition.
 {% endnote %}
 
-## Actions
-
-The Hydrawise integration makes various custom {% term actions %} available.
-
-### Action: Start watering
-
-The `hydrawise.start_watering` action starts a watering cycle in an irrigation zone.
-
-| Data attribute | Optional | Description                                                                                                                                                                                     |
-| -------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `entity_id`    | no       | The irrigation zone in which to start watering.                                                                                                                                                 |
-| `duration`     | yes      | The length of time (in minutes) to run a watering cycle. If not specified (or zero), the default watering duration set in the Hydrawise mobile or web app for the irrigation zone will be used. |
-
-### Action: Suspend
-
-The `hydrawise.suspend` action suspends automatic watering in an irrigation zone until a specified date.
-
-| Data attribute | Optional | Description                                                                                |
-| -------------- | -------- | ------------------------------------------------------------------------------------------ |
-| `entity_id`    | no       | The irrigation zone in which to suspend watering.                                          |
-| `until`        | no       | The date & time when automatic watering should be resumed. For example, `2024-08-30 08:30` |
-
-### Action: Resume
-
-The `hydrawise.resume` action resumes automatic watering in an irrigation zone.
-
-| Data attribute | Optional | Description                                      |
-| -------------- | -------- | ------------------------------------------------ |
-| `entity_id`    | no       | The irrigation zone in which to resume watering. |
+{% include integrations/actions.md %}
 
 ## Valve
 


### PR DESCRIPTION
## Proposed change

Migrates the Hydrawise actions from the inline `## Actions` block on the integration page into dedicated action pages under `source/_actions/`, replacing the inline documentation with `{% include integrations/actions.md %}`.

This covers `start_watering`, `suspend`, and `resume`. All three are entity-targeted irrigation zone actions, so each page documents the UI and YAML usage, the available options, and the targets.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

