### PR TITLE
Guardian: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/guardian.pair_sensor.markdown
+++ b/source/_actions/guardian.pair_sensor.markdown
@@ -1,0 +1,73 @@
+---
+title: "Pair sensor"
+action: guardian.pair_sensor
+domain: guardian
+description: "Adds a new paired sensor to the valve controller."
+related_actions:
+  - guardian.unpair_sensor
+  - guardian.upgrade_firmware
+---
+
+The **Pair sensor** action adds a new paired sensor to a Guardian valve controller.
+
+This is handy when you want to add a leak sensor from an automation or a script instead of pairing it by hand, for example as part of a setup routine when you install a new sensor.
+
+{% include actions/ui_header.md %}
+
+To pair a sensor from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Guardian: Pair sensor**.
+6. Select the **Valve controller** to add the sensor to, and enter the sensor **UID**.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Valve controller:
+  description: The valve controller to add the sensor to.
+  required: true
+UID:
+  description: The unique device ID printed on the bottom of the sensor.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `guardian.pair_sensor`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: guardian.pair_sensor
+  data:
+    device_id: 1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
+    uid: "5410EC688BCF"
+{% endexample %}
+
+This pairs the sensor with the given UID to the selected valve controller.
+
+### Options in YAML
+
+{% options_yaml %}
+device_id:
+  description: >
+    The ID of the valve controller device to add the sensor to.
+  required: true
+  type: string
+uid:
+  description: >
+    The unique device ID printed on the bottom of the sensor.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/guardian.pair_sensor.markdown
+++ b/source/_actions/guardian.pair_sensor.markdown
@@ -23,9 +23,7 @@ To pair a sensor from an automation or a script:
 5. From the search box, search for and select **Guardian: Pair sensor**.
 6. Select the **Valve controller** to add the sensor to, and enter the sensor **UID**.
 7. Select **Save**.
-
-This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
-
+This action does not support targets. In the UI, you are not prompted to choose an area, entity, or label. You select the valve controller through the **Valve controller** option instead.
 ### Options in the UI
 
 {% options_ui %}

--- a/source/_actions/guardian.unpair_sensor.markdown
+++ b/source/_actions/guardian.unpair_sensor.markdown
@@ -23,9 +23,7 @@ To unpair a sensor from an automation or a script:
 5. From the search box, search for and select **Guardian: Unpair sensor**.
 6. Select the **Valve controller** to remove the sensor from, and enter the sensor **UID**.
 7. Select **Save**.
-
-This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
-
+This action does not support targets. In the UI, you are not prompted to choose an area, entity, or label. You select the valve controller through the **Valve controller** option instead.
 ### Options in the UI
 
 {% options_ui %}

--- a/source/_actions/guardian.unpair_sensor.markdown
+++ b/source/_actions/guardian.unpair_sensor.markdown
@@ -1,0 +1,73 @@
+---
+title: "Unpair sensor"
+action: guardian.unpair_sensor
+domain: guardian
+description: "Removes a paired sensor from the valve controller."
+related_actions:
+  - guardian.pair_sensor
+  - guardian.upgrade_firmware
+---
+
+The **Unpair sensor** action removes a paired sensor from a Guardian valve controller.
+
+This is handy when you want to remove a leak sensor from an automation or a script instead of unpairing it by hand, for example when you move a sensor to another location.
+
+{% include actions/ui_header.md %}
+
+To unpair a sensor from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Guardian: Unpair sensor**.
+6. Select the **Valve controller** to remove the sensor from, and enter the sensor **UID**.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Valve controller:
+  description: The valve controller to remove the sensor from.
+  required: true
+UID:
+  description: The unique device ID printed on the bottom of the sensor.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `guardian.unpair_sensor`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: guardian.unpair_sensor
+  data:
+    device_id: 1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
+    uid: "5410EC688BCF"
+{% endexample %}
+
+This unpairs the sensor with the given UID from the selected valve controller.
+
+### Options in YAML
+
+{% options_yaml %}
+device_id:
+  description: >
+    The ID of the valve controller device to remove the sensor from.
+  required: true
+  type: string
+uid:
+  description: >
+    The unique device ID printed on the bottom of the sensor.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/guardian.upgrade_firmware.markdown
+++ b/source/_actions/guardian.upgrade_firmware.markdown
@@ -23,9 +23,7 @@ To upgrade the firmware from an automation or a script:
 5. From the search box, search for and select **Guardian: Upgrade firmware**.
 6. Select the **Valve controller** to upgrade. Optionally, enter a custom **URL**, **Port**, and **Filename**.
 7. Select **Save**.
-
-This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
-
+This action does not support targets. In the UI, you are not prompted to choose an area, entity, or label. You select the valve controller through the **Valve controller** option instead.
 ### Options in the UI
 
 {% options_ui %}

--- a/source/_actions/guardian.upgrade_firmware.markdown
+++ b/source/_actions/guardian.upgrade_firmware.markdown
@@ -1,0 +1,89 @@
+---
+title: "Upgrade firmware"
+action: guardian.upgrade_firmware
+domain: guardian
+description: "Upgrades the device firmware."
+related_actions:
+  - guardian.pair_sensor
+  - guardian.unpair_sensor
+---
+
+The **Upgrade firmware** action upgrades the firmware on a Guardian valve controller.
+
+By default, the valve controller upgrades to the latest firmware published by Guardian. If you need to install a specific firmware image, you can point the action at a custom URL, port, and filename.
+
+{% include actions/ui_header.md %}
+
+To upgrade the firmware from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Guardian: Upgrade firmware**.
+6. Select the **Valve controller** to upgrade. Optionally, enter a custom **URL**, **Port**, and **Filename**.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Valve controller:
+  description: The valve controller to upgrade.
+  required: true
+URL:
+  description: The URL of the server hosting the firmware image. If not provided, the latest firmware from Guardian is used.
+  required: false
+Port:
+  description: The port on the server hosting the firmware image.
+  required: false
+Filename:
+  description: The filename of the firmware image on the server.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `guardian.upgrade_firmware`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: guardian.upgrade_firmware
+  data:
+    device_id: 1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
+{% endexample %}
+
+This upgrades the selected valve controller to the latest firmware from Guardian.
+
+### Options in YAML
+
+{% options_yaml %}
+device_id:
+  description: >
+    The ID of the valve controller device to upgrade.
+  required: true
+  type: string
+url:
+  description: >
+    The URL of the server hosting the firmware image. If not provided, the
+    latest firmware from Guardian is used.
+  required: false
+  type: string
+port:
+  description: >
+    The port on the server hosting the firmware image.
+  required: false
+  type: integer
+filename:
+  description: >
+    The filename of the firmware image on the server.
+  required: false
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/guardian.markdown
+++ b/source/_integrations/guardian.markdown
@@ -38,35 +38,9 @@ There is currently support for the following device types within Home Assistant:
 
 {% include integrations/config_flow.md %}
 
-## Actions
+{% include integrations/actions.md %}
 
-### Action: Pair sensor
-
-The `guardian.pair_sensor` action adds a new paired sensor to the valve controller.
-
-| Data attribute | Optional | Description                                      |
-| ---------------------- | -------- | ------------------------------------------------ |
-| `uid`                    | yes      | The unique device ID on the bottom of the sensor.|
-
-### Action: Unpair sensor
-
-The `guardian.unpair_sensor` action removes a paired sensor from the valve controller.
-
-| Data attribute | Optional | Description                                      |
-| ---------------------- | -------- | ------------------------------------------------ |
-| `uid`                    | yes      | The unique device ID on the bottom of the sensor.|
-
-### Action: Upgrade firmware
-
-The `guardian.upgrade_firmware` action upgrades the device firmware.
-
-| Data attribute | Optional | Description                                      |
-| ---------------------- | -------- | ------------------------------------------------ |
-| `url`                    | yes      | The URL of the server hosting the firmware file. |
-| `port`                   | yes      | The port on which the firmware file is served.   |
-| `filename`               | yes      | The firmware filename.                           |
-
-{% note %} 
+{% note %}
 Not all actions are available on all Guardian valve controller firmwares.
 Please ensure you upgrade your valve controller to the latest firmware before opening
 bugs related to non-working actions.


### PR DESCRIPTION
## Proposed change

Migrates the Guardian actions (`pair_sensor`, `unpair_sensor`, and `upgrade_firmware`) from the inline `## Actions` block on the integration page into dedicated action pages under `source/_actions/`, using `{% include integrations/actions.md %}`.

While migrating, the action documentation was corrected against the integration's source: the required `device_id` (Valve controller) field was added, the `uid` field is now correctly documented as required, and the optional URL, port, and filename fields for the firmware upgrade are described.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

