### PR TITLE
Blink: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/blink.record.markdown
+++ b/source/_actions/blink.record.markdown
@@ -21,7 +21,7 @@ To record a clip from an automation or a script:
 2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
 3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
 4. In the **Then do** section, select **Add action**.
-5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Blink camera you want to record.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Blink camera you want to record with.
 6. From the actions shown for that target, select **Blink: Record**.
 7. Select **Save**.
 

--- a/source/_actions/blink.record.markdown
+++ b/source/_actions/blink.record.markdown
@@ -1,0 +1,53 @@
+---
+title: "Record"
+action: blink.record
+domain: blink
+description: "Requests a Blink camera to record a new video clip."
+related_actions:
+  - blink.trigger_camera
+  - blink.save_video
+  - blink.save_recent_clips
+---
+
+The **Record** action asks a Blink camera to record a new video clip.
+
+This is handy when you want to capture a clip from an automation or a script, for example when motion is detected somewhere else in your home.
+
+{% include actions/ui_header.md %}
+
+To record a clip from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Blink camera you want to record.
+6. From the actions shown for that target, select **Blink: Record**.
+7. Select **Save**.
+
+This action has no additional options in the UI.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `blink.record`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: blink.record
+  target:
+    entity_id: camera.blink_front_door
+{% endexample %}
+
+This action has no additional options in YAML.
+
+{% include actions/targets.md domain="camera" %}
+
+## Good to know
+
+- Keep a minimum of 5 seconds between sequential Blink actions. Calls made too quickly after each other can be throttled and ignored.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/blink.save_recent_clips.markdown
+++ b/source/_actions/blink.save_recent_clips.markdown
@@ -1,0 +1,102 @@
+---
+title: "Save recent clips"
+action: blink.save_recent_clips
+domain: blink
+description: "Saves all recent video clips of a Blink camera to a local directory."
+related_actions:
+  - blink.save_video
+  - blink.record
+  - blink.trigger_camera
+---
+
+The **Save recent clips** action saves all recent video clips of a Blink camera to a local directory.
+
+This is handy when you want to keep your own copies of recent recordings. Blink keeps recent clips available for download for up to an hour, and a clip is removed from the list once it has been downloaded. Each clip is saved with the file pattern `%Y%m%d_%H%M%S_[camera name].mp4`.
+
+{% include actions/ui_header.md %}
+
+To save recent clips from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Blink camera whose clips you want to save.
+6. From the actions shown for that target, select **Blink: Save recent clips**.
+7. Enter the **Output directory** where the clips are saved.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Output directory:
+  description: The path to the directory where the clips are saved.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `blink.save_recent_clips`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: blink.save_recent_clips
+  target:
+    entity_id: camera.blink_front_door
+  data:
+    file_path: "/config/www/blink"
+{% endexample %}
+
+This saves the recent clips of `camera.blink_front_door` to the `/config/www/blink` directory.
+
+### Options in YAML
+
+{% options_yaml %}
+file_path:
+  description: The path to the directory where the clips are saved.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="camera" %}
+
+## Good to know
+
+- The directory in `file_path` must be one that Home Assistant is allowed to write to. By default, the `www` folder in your configuration directory and each configured [media directory](/integrations/homeassistant/#media_dirs) are allowed. To save somewhere else, such as `/tmp`, add that directory to [`allowlist_external_dirs`](/integrations/homeassistant/#allowlist_external_dirs) in the [`homeassistant:`](/integrations/homeassistant/) section of your {% term "`configuration.yaml`" %} file.
+- The filename of each saved clip follows the pattern `%Y%m%d_%H%M%S_[camera name].mp4` and is not configurable.
+- Keep a minimum of 5 seconds between sequential Blink actions. Calls made too quickly after each other can be throttled and ignored.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: save recent clips on a schedule
+
+Save the recent clips of a camera every few minutes, so new recordings are downloaded before they expire.
+
+- **Trigger**: every 3 minutes
+- **Action**: Blink: Save recent clips
+  - **Target**: Front door camera
+  - **Output directory**: the directory where the clips are saved
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  - alias: "Save recent Blink clips"
+    triggers:
+      - trigger: time_pattern
+        minutes: "/3"
+    actions:
+      - action: blink.save_recent_clips
+        target:
+          entity_id: camera.blink_front_door
+        data:
+          file_path: "/config/www/blink"
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/blink.save_recent_clips.markdown
+++ b/source/_actions/blink.save_recent_clips.markdown
@@ -79,11 +79,11 @@ Save the recent clips of a camera every few minutes, so new recordings are downl
   - **Target**: Front door camera
   - **Output directory**: the directory where the clips are saved
 
-{% details "Show example YAML" %}
+{% details "YAML example for saving recent clips on a schedule" %}
 
 {% example %}
 automation: |
-  - alias: "Save recent Blink clips"
+    alias: "Save recent Blink clips"
     triggers:
       - trigger: time_pattern
         minutes: "/3"

--- a/source/_actions/blink.save_video.markdown
+++ b/source/_actions/blink.save_video.markdown
@@ -78,11 +78,11 @@ When motion is detected, save the last recorded clip locally with the date and t
   - **Target**: Front door camera
   - **File name**: a path that includes the current date and time
 
-{% details "Show example YAML" %}
+{% details "YAML example for saving Blink video on motion" %}
 
 {% example %}
 automation: |
-  - alias: "Save Blink video on motion"
+    alias: "Save Blink video on motion"
     triggers:
       - trigger: state
         entity_id: binary_sensor.blink_front_door_motion_detected

--- a/source/_actions/blink.save_video.markdown
+++ b/source/_actions/blink.save_video.markdown
@@ -1,0 +1,102 @@
+---
+title: "Save video"
+action: blink.save_video
+domain: blink
+description: "Saves the last recorded video clip of a Blink camera to a local file."
+related_actions:
+  - blink.save_recent_clips
+  - blink.record
+  - blink.trigger_camera
+---
+
+The **Save video** action saves the last recorded video clip of a Blink camera to a local file.
+
+This is handy when you want to keep a copy of a clip on your own system instead of relying on Blink's servers, for example to save the latest recording when motion is detected.
+
+{% include actions/ui_header.md %}
+
+To save a video from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Blink camera whose last clip you want to save.
+6. From the actions shown for that target, select **Blink: Save video**.
+7. Enter the **File name** where the clip is saved.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+File name:
+  description: The full path to the file where the clip is saved.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `blink.save_video`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: blink.save_video
+  target:
+    entity_id: camera.blink_front_door
+  data:
+    filename: "/config/www/blink_front_door.mp4"
+{% endexample %}
+
+This saves the last recorded clip of `camera.blink_front_door` to `/config/www/blink_front_door.mp4`.
+
+### Options in YAML
+
+{% options_yaml %}
+filename:
+  description: The full path to the file where the clip is saved.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="camera" %}
+
+## Good to know
+
+- The path in `filename` must be inside a directory that Home Assistant is allowed to write to. By default, the `www` folder in your configuration directory and each configured [media directory](/integrations/homeassistant/#media_dirs) are allowed, so a path like `/config/www/blink.mp4` or `/media/blink.mp4` works without extra setup. To save somewhere else, such as `/tmp`, add that directory to [`allowlist_external_dirs`](/integrations/homeassistant/#allowlist_external_dirs) in the [`homeassistant:`](/integrations/homeassistant/) section of your {% term "`configuration.yaml`" %} file.
+- Keep a minimum of 5 seconds between sequential Blink actions. Calls made too quickly after each other can be throttled and ignored.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: save the latest clip when motion is detected
+
+When motion is detected, save the last recorded clip locally with the date and time in the filename, so each recording is kept as a separate file.
+
+- **Trigger**: Motion is detected
+- **Action**: Blink: Save video
+  - **Target**: Front door camera
+  - **File name**: a path that includes the current date and time
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  - alias: "Save Blink video on motion"
+    triggers:
+      - trigger: state
+        entity_id: binary_sensor.blink_front_door_motion_detected
+        to: "on"
+    actions:
+      - action: blink.save_video
+        target:
+          entity_id: camera.blink_front_door
+        data:
+          filename: "/config/www/blink_{{ now().strftime('%Y%m%d_%H%M%S') }}.mp4"
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/blink.trigger_camera.markdown
+++ b/source/_actions/blink.trigger_camera.markdown
@@ -62,7 +62,7 @@ Take a new image with a Blink camera and then save it to a local file using the 
   - **Target**: Front door camera
   - **Filename**: the path where the image is saved
 
-{% details "Show example YAML" %}
+{% details "YAML example for taking a picture and saving it locally" %}
 
 {% example %}
 script: |

--- a/source/_actions/blink.trigger_camera.markdown
+++ b/source/_actions/blink.trigger_camera.markdown
@@ -1,0 +1,85 @@
+---
+title: "Trigger camera"
+action: blink.trigger_camera
+domain: blink
+description: "Requests a Blink camera to take a new image."
+related_actions:
+  - blink.record
+  - blink.save_video
+  - blink.save_recent_clips
+---
+
+The **Trigger camera** action asks a Blink camera to take a new still image.
+
+This is handy when you want an up-to-date snapshot from an automation or a script, for example before saving the image somewhere with the [camera](/integrations/camera/) actions.
+
+{% include actions/ui_header.md %}
+
+To trigger a camera from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Blink camera you want to trigger.
+6. From the actions shown for that target, select **Blink: Trigger camera**.
+7. Select **Save**.
+
+This action has no additional options in the UI.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `blink.trigger_camera`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: blink.trigger_camera
+  target:
+    entity_id: camera.blink_front_door
+{% endexample %}
+
+This action has no additional options in YAML.
+
+{% include actions/targets.md domain="camera" %}
+
+## Good to know
+
+- The camera sensors, such as temperature and Wi-Fi strength, only update when a new image is requested. Triggering the camera is one way to refresh them.
+- Keep a minimum of 5 seconds between sequential Blink actions. Calls made too quickly after each other can be throttled and ignored.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: snap a picture and save it locally
+
+Take a new image with a Blink camera and then save it to a local file using the [camera snapshot](/integrations/camera/#action-snapshot) action.
+
+- **Trigger**: whatever should start the snapshot, such as a motion sensor
+- **Action 1**: Blink: Trigger camera
+  - **Target**: Front door camera
+- **Action 2**: Camera: Take snapshot
+  - **Target**: Front door camera
+  - **Filename**: the path where the image is saved
+
+{% details "Show example YAML" %}
+
+{% example %}
+script: |
+  alias: "Blink snap picture"
+  sequence:
+    - action: blink.trigger_camera
+      target:
+        entity_id: camera.blink_front_door
+    - action: camera.snapshot
+      target:
+        entity_id: camera.blink_front_door
+      data:
+        filename: "/config/www/my_image.jpg"
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/blink.markdown
+++ b/source/_integrations/blink.markdown
@@ -57,54 +57,9 @@ Since the cameras are battery operated, polling must be done with care so as to 
 
 Each camera reports two different states: one as `sensor.blink_<camera_name>_status` and the other as `binary_sensor.blink_<camera_name>_motion_enabled`. The `motion_enabled` property reports if the `camera` is ready to detect motion **regardless if the system is actually armed**.
 
-## Actions
+{% include integrations/actions.md %}
 
-Any sequential calls to {% term actions %} relating to blink should have a minimum of a 5 second delay in between them to prevent the calls from being throttled and ignored. The actions that act on a camera needs a target parameter.
-
-### Action: Record
-
-The `blink.record` action allows you to trigger a camera to record a new video clip.
-
-### Action: Trigger camera
-
-The `blink.trigger_camera` action allows you to trigger a camera to take a new still image.
-
-### Action: Save video
-
-The `blink.save_video` action allows you to save the last recorded video of a camera to a local file. Note that in most cases, Home Assistant will need to know that the directory is writable via the `allowlist_external_dirs` in your {% term "`configuration.yaml`" %} file (see example below).
-
-| Data attribute | Optional | Description            |
-| ---------------------- | -------- | ---------------------- |
-| `filename`             | no       | Location of save file. |
-
-```yaml
-homeassistant:
-  allowlist_external_dirs:
-    - '/tmp'
-    - '/path/to/whitelist'
-```
-
-### Action: Save recent clips
-
-
-The `blink.save_recent_clips` action allows you to save the recent video clips of a camera to a local file in the pattern `%Y%m%d_%H%M%S_{name}.mp4`. Note that in most cases, Home Assistant will need to know that the directory is writable via the `allowlist_external_dirs` in your {% term "`configuration.yaml`" %} file.
-
-| Data attribute | Optional | Description             |
-| ---------------------- | -------- | ----------------------- |
-| `file_path`            | no       | Location of save files. |
-
-### Action: Send pin
-
-The `blink.send_pin` action allows you to send a new pin to blink. Since Blink's 2FA implementation is new and changing, this is to allow the integration to continue to work with user intervention. The intent is to handle all of this behind the scenes, but until the login implementation is settled this was added. To use it, perform the action with the pin you receive from Blink as the payload (for a simple "Allow this Device" email, you may keep the `pin` value empty).
-
-| Data attribute | Optional | Description                  |
-| ---------------------- | -------- | ---------------------------- |
-| `config_entry_id`      | no       | Blink config to send pin to. |
-| `pin`                  | no       | 2FA Pin received from blink. |
-
-### Other actions
-
-In addition to the actions mentioned above, there are generic `camera`, `alarm_control_panel`, and `homeassistant` actions available. The `camera.enable_motion_detection` and `camera.disable_motion_detection` actions allow for individual cameras to be enabled and disabled, respectively, within the Blink system. The `alarm_control_panel.alarm_arm_away` and `alarm_control_panel.alarm_disarm` actions allow for the whole system to be armed and disarmed, respectively. The `homeassistant.update_entity` action will force an update of the blink system. Blink Mini cameras linked to an existing sync module cannot be armed/disarmed individually via Home Assistant.
+In addition to these actions, the generic [camera](/integrations/camera/), [alarm control panel](/integrations/alarm_control_panel/), and [Home Assistant Core](/integrations/homeassistant/) actions are available. The `camera.enable_motion_detection` and `camera.disable_motion_detection` actions enable and disable motion detection for individual cameras. The `alarm_control_panel.alarm_arm_away` and `alarm_control_panel.alarm_disarm` actions arm and disarm the whole system. The `homeassistant.update_entity` action forces an update of the Blink system. Blink Mini cameras linked to an existing sync module cannot be armed or disarmed individually in Home Assistant.
 
 ## Examples
 


### PR DESCRIPTION
## Proposed change

Migrates the Blink actions (`record`, `trigger_camera`, `save_video`, and `save_recent_clips`) from the inline `## Actions` block on the integration page into dedicated action pages under `source/_actions/`, using `{% include integrations/actions.md %}`.

While migrating, the documentation for the `send_pin` action was removed, as that action no longer exists in the integration.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

