### PR TITLE
Abode: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/abode.capture_image.markdown
+++ b/source/_actions/abode.capture_image.markdown
@@ -1,0 +1,67 @@
+---
+title: "Capture image"
+action: abode.capture_image
+domain: abode
+description: "Requests a new still image from an Abode camera."
+related_actions:
+  - abode.change_setting
+  - abode.trigger_automation
+---
+
+The **Capture image** action requests a new still image from an Abode camera.
+
+This is handy when you want an up-to-date image from an automation or a script, for example when a door opens.
+
+{% include actions/ui_header.md %}
+
+To capture an image from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Abode: Capture image**.
+6. Select the **Entity** to request an image from.
+7. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Entity:
+  description: The Abode camera, or cameras, to request an image from.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `abode.capture_image`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: abode.capture_image
+  data:
+    entity_id: camera.front_door
+{% endexample %}
+
+This requests a new still image from `camera.front_door`.
+
+### Options in YAML
+
+{% options_yaml %}
+entity_id:
+  description: >
+    The entity ID, or list of entity IDs, of the Abode cameras to request an
+    image from.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+## Good to know
+
+- When the image is captured, an `abode_capture` event is fired, which you can use as a trigger in other automations.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/abode.change_setting.markdown
+++ b/source/_actions/abode.change_setting.markdown
@@ -1,0 +1,71 @@
+---
+title: "Change setting"
+action: abode.change_setting
+domain: abode
+description: "Changes a setting on your Abode system."
+related_actions:
+  - abode.capture_image
+  - abode.trigger_automation
+---
+
+The **Change setting** action changes a setting on your Abode system.
+
+For a full list of settings and valid values, see the [`jaraco.abode` settings section](https://github.com/jaraco/jaraco.abode/blob/main/README.rst#settings).
+
+{% include actions/ui_header.md %}
+
+To change a setting from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Abode: Change setting**.
+6. Enter the **Setting** to change and its new **Value**.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Setting:
+  description: The setting to change.
+  required: true
+Value:
+  description: The value to change the setting to.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `abode.change_setting`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: abode.change_setting
+  data:
+    setting: "beeper_mute"
+    value: "1"
+{% endexample %}
+
+This changes the `beeper_mute` setting to `1`.
+
+### Options in YAML
+
+{% options_yaml %}
+setting:
+  description: The setting to change.
+  required: true
+  type: string
+value:
+  description: The value to change the setting to.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/abode.trigger_automation.markdown
+++ b/source/_actions/abode.trigger_automation.markdown
@@ -1,0 +1,63 @@
+---
+title: "Trigger automation"
+action: abode.trigger_automation
+domain: abode
+description: "Triggers an automation on your Abode system."
+related_actions:
+  - abode.capture_image
+  - abode.change_setting
+---
+
+The **Trigger automation** action triggers an automation that is set up in your Abode system.
+
+Abode automations are represented in Home Assistant as switch entities, so you select the switch that matches the automation you want to run.
+
+{% include actions/ui_header.md %}
+
+To trigger an Abode automation from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Abode: Trigger automation**.
+6. Select the **Entity** for the Abode automation to trigger.
+7. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Entity:
+  description: The switch, or switches, that represent the Abode automations to trigger.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `abode.trigger_automation`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: abode.trigger_automation
+  data:
+    entity_id: switch.away_mode
+{% endexample %}
+
+This triggers the Abode automation represented by `switch.away_mode`.
+
+### Options in YAML
+
+{% options_yaml %}
+entity_id:
+  description: >
+    The entity ID, or list of entity IDs, of the switches that represent your
+    Abode automations.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/abode.markdown
+++ b/source/_integrations/abode.markdown
@@ -86,33 +86,4 @@ There is a unique list of known event_codes are defined in
 and the inferred groups and their ranges of event codes are defined in
 [timeline.py](https://github.com/jaraco/jaraco.abode/blob/main/jaraco/abode/helpers/timeline.py).
 
-## Actions
-
-Available {% term actions %}: `change_setting`, `capture_image`, `trigger_automation`
-
-### Action: Change setting
-
-The `abode.change_setting` action is used to change settings on your Abode system.
-For a full list of settings and valid values, consult the
-[`jaraco.abode` settings section](https://github.com/jaraco/jaraco.abode/blob/main/README.rst#settings).
-
-| Data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `setting` | No | The setting you wish to change. |
-| `value` | No | The value you wish to change the setting to. |
-
-### Action: Capture image
-
-The `abode.capture_image` action is used to request a new still image from your Abode camera.
-
-| Data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `entity_id` | No | String or list of strings that point at `entity_id`s of Abode cameras. |
-
-### Action: Trigger automation
-
-The `abode.trigger_automation` action is used to trigger an automation on your Abode system.
-
-| Data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `entity_id` | No | String or list of strings that point at `entity_id`s of switches that represent your Abode automations. |
+{% include integrations/actions.md %}


### PR DESCRIPTION
## Proposed change

Migrates the Abode actions (`capture_image`, `change_setting`, and `trigger_automation`) from the inline `## Actions` block on the integration page into dedicated action pages under `source/_actions/`, using `{% include integrations/actions.md %}`.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

