### PR TITLE
Simplisafe: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/simplisafe.remove_pin.markdown
+++ b/source/_actions/simplisafe.remove_pin.markdown
@@ -1,0 +1,75 @@
+---
+title: "Remove PIN"
+action: simplisafe.remove_pin
+domain: simplisafe
+description: "Removes a SimpliSafe PIN by its label or value."
+related_actions:
+  - simplisafe.set_pin
+  - simplisafe.set_system_properties
+---
+
+The **Remove PIN** action deletes a PIN from your SimpliSafe system. You can identify the PIN to remove either by the label it shows in the SimpliSafe app or by the PIN value itself.
+
+This is handy for cleaning up access automatically, for example removing a guest's temporary PIN once their stay ends.
+
+{% include actions/ui_header.md %}
+
+To remove a PIN from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **SimpliSafe: Remove PIN**.
+6. Choose the **System** to remove the PIN from, and enter the **Label/PIN** to remove.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+System:
+  description: The SimpliSafe system to remove the PIN from.
+  required: true
+Label/PIN:
+  description: The label or value of the PIN to remove.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `simplisafe.remove_pin`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: simplisafe.remove_pin
+  data:
+    device_id: a1b2c3d4e5f6
+    label_or_pin: "Guest"
+{% endexample %}
+
+This removes the PIN labeled `Guest` from the selected system.
+
+### Options in YAML
+
+{% options_yaml %}
+device_id:
+  description: >
+    The SimpliSafe system to remove the PIN from.
+  required: true
+  type: string
+label_or_pin:
+  description: >
+    The label or value of the PIN to remove.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/simplisafe.set_pin.markdown
+++ b/source/_actions/simplisafe.set_pin.markdown
@@ -1,0 +1,84 @@
+---
+title: "Set PIN"
+action: simplisafe.set_pin
+domain: simplisafe
+description: "Sets or updates a SimpliSafe PIN."
+related_actions:
+  - simplisafe.remove_pin
+  - simplisafe.set_system_properties
+---
+
+The **Set PIN** action adds a new PIN to your SimpliSafe system or updates an existing one. You give the PIN a label so it is easy to recognize in the SimpliSafe app, along with the PIN value people will use to arm and disarm the system.
+
+This is handy for granting temporary access automatically, for example creating a guest PIN when a booking starts and removing it again when the stay ends.
+
+{% include actions/ui_header.md %}
+
+To set a PIN from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **SimpliSafe: Set PIN**.
+6. Choose the **System**, then enter a **Label** and a **PIN** value.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+System:
+  description: The SimpliSafe system to set the PIN on.
+  required: true
+Label:
+  description: The label to show for this PIN in the SimpliSafe app.
+  required: true
+PIN:
+  description: The PIN value to use.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `simplisafe.set_pin`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: simplisafe.set_pin
+  data:
+    device_id: a1b2c3d4e5f6
+    label: "Guest"
+    pin: "1256"
+{% endexample %}
+
+This creates or updates a PIN labeled `Guest` on the selected system.
+
+### Options in YAML
+
+{% options_yaml %}
+device_id:
+  description: >
+    The SimpliSafe system to set the PIN on.
+  required: true
+  type: string
+label:
+  description: >
+    The label to show for this PIN in the SimpliSafe app.
+  required: true
+  type: string
+pin:
+  description: >
+    The PIN value to use.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/simplisafe.set_system_properties.markdown
+++ b/source/_actions/simplisafe.set_system_properties.markdown
@@ -1,0 +1,148 @@
+---
+title: "Set system properties"
+action: simplisafe.set_system_properties
+domain: simplisafe
+description: "Sets one or more properties on a SimpliSafe system."
+related_actions:
+  - simplisafe.set_pin
+  - simplisafe.remove_pin
+---
+
+The **Set system properties** action changes the settings of your SimpliSafe base station, such as how long the alarm sounds, the entry and exit delays, the chime and voice prompt volumes, and whether the base station light shows when the system is armed.
+
+You only need to provide the properties you want to change. Anything you leave out keeps its current value. This is handy for adapting your system to the time of day, for example using a longer entry delay during the day and a shorter one at night.
+
+{% include actions/ui_header.md %}
+
+To change system properties from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **SimpliSafe: Set system properties**.
+6. Choose the **System**, then set the properties you want to change.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+System:
+  description: The SimpliSafe system whose properties should be set.
+  required: true
+Alarm duration:
+  description: The length, in seconds, of a triggered alarm (30 to 480).
+  required: false
+Alarm volume:
+  description: The volume level of a triggered alarm. One of `off`, `low`, `medium`, or `high`.
+  required: false
+Chime volume:
+  description: The volume level of the door chime. One of `off`, `low`, `medium`, or `high`.
+  required: false
+Entry delay away:
+  description: How long, in seconds, to delay triggering when entering while armed away (30 to 255).
+  required: false
+Entry delay home:
+  description: How long, in seconds, to delay triggering when entering while armed home (0 to 255).
+  required: false
+Exit delay away:
+  description: How long, in seconds, to delay triggering when exiting while armed away (45 to 255).
+  required: false
+Exit delay home:
+  description: How long, in seconds, to delay triggering when exiting while armed home (0 to 255).
+  required: false
+Light:
+  description: Whether the base station light shows when the system is armed.
+  required: false
+Voice prompt volume:
+  description: The volume level of the voice prompts. One of `off`, `low`, `medium`, or `high`.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `simplisafe.set_system_properties`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: simplisafe.set_system_properties
+  data:
+    device_id: a1b2c3d4e5f6
+    alarm_duration: 120
+    chime_volume: "high"
+{% endexample %}
+
+This sets the alarm duration to 120 seconds and the chime volume to high on the selected system.
+
+### Options in YAML
+
+{% options_yaml %}
+device_id:
+  description: >
+    The SimpliSafe system whose properties should be set.
+  required: true
+  type: string
+alarm_duration:
+  description: >
+    The length, in seconds, of a triggered alarm (30 to 480).
+  required: false
+  type: integer
+alarm_volume:
+  description: >
+    The volume level of a triggered alarm. One of `off`, `low`,
+    `medium`, or `high`.
+  required: false
+  type: string
+chime_volume:
+  description: >
+    The volume level of the door chime. One of `off`, `low`, `medium`,
+    or `high`.
+  required: false
+  type: string
+entry_delay_away:
+  description: >
+    How long, in seconds, to delay triggering when entering while armed
+    away (30 to 255).
+  required: false
+  type: integer
+entry_delay_home:
+  description: >
+    How long, in seconds, to delay triggering when entering while armed
+    home (0 to 255).
+  required: false
+  type: integer
+exit_delay_away:
+  description: >
+    How long, in seconds, to delay triggering when exiting while armed
+    away (45 to 255).
+  required: false
+  type: integer
+exit_delay_home:
+  description: >
+    How long, in seconds, to delay triggering when exiting while armed
+    home (0 to 255).
+  required: false
+  type: integer
+light:
+  description: >
+    Whether the base station light shows when the system is armed.
+  required: false
+  type: boolean
+  default: true
+voice_prompt_volume:
+  description: >
+    The volume level of the voice prompts. One of `off`, `low`,
+    `medium`, or `high`.
+  required: false
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/simplisafe.markdown
+++ b/source/_integrations/simplisafe.markdown
@@ -54,39 +54,7 @@ You must have multi-factor authentication (MFA) enabled on your SimpliSafe accou
 
 SimpliSafe authenticates users via its web app. Due to technical limitations, there is a manual step when adding the integration. For in-depth guidance, refer to step 6 of [the `simplisafe-python` documentation on authentication](https://simplisafe-python.readthedocs.io/en/latest/usage.html#authentication).
 
-## Actions
-
-### `simplisafe.remove_pin`
-
-Remove a SimpliSafe PIN (by label or PIN value).
-
-| Data attribute | Optional | Description                      |
-| ---------------------- | -------- | -------------------------------- |
-| `label_or_pin`         | no       | The PIN label or value to remove |
-
-### `simplisafe.set_pin`
-
-Set a SimpliSafe PIN.
-
-| Data attribute | Optional | Description                            |
-| ---------------------- | -------- | -------------------------------------- |
-| `label`                | no       | The label to show in the SimpliSafe UI |
-| `pin`                  | no       | The PIN value to use                   |
-
-### `simplisafe.system_properties`
-
-Set one or more system properties.
-
-| Data attribute | Optional | Description                                                                  |
-| ---------------------- | -------- | ---------------------------------------------------------------------------- |
-| `alarm_duration`       | yes      | The number of seconds a triggered alarm should sound                         |
-| `chime_volume`         | yes      | The volume of the door chime                                                 |
-| `entry_delay_away`     | yes      | The number of seconds to delay triggering when entering with an "away" state |
-| `entry_delay_home`     | yes      | The number of seconds to delay triggering when entering with a "home" state  |
-| `exit_delay_away`      | yes      | The number of seconds to delay triggering when exiting with an "away" state  |
-| `exit_delay_home`      | yes      | The number of seconds to delay triggering when exiting with a "home" state   |
-| `light`                | yes      | Whether the light on the base station should display when armed              |
-| `voice_prompt_volume`  | yes      | The volume of the base station's voice prompts                               |
+{% include integrations/actions.md %}
 
 ## Events
 


### PR DESCRIPTION
## Proposed change

Migrates the SimpliSafe actions from the inline `## Actions` block on the integration page into dedicated pages under `source/_actions/`, and replaces the inline block with `{% include integrations/actions.md %}`. This brings SimpliSafe in line with the standardized action documentation used across other integrations.

While migrating, the documentation was corrected against the integration's `services.yaml` and `strings.json` in core. The third action is `set_system_properties` (the page incorrectly called it `system_properties`), all three actions take a required `device_id` ("System") that was previously undocumented, and `set_system_properties` now lists the `alarm_volume` field and documents the volume fields as the `off`/`low`/`medium`/`high` options they actually accept.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

