### PR TITLE
Snapcast: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/snapcast.restore.markdown
+++ b/source/_actions/snapcast.restore.markdown
@@ -1,0 +1,60 @@
+---
+title: "Restore"
+action: snapcast.restore
+domain: snapcast
+description: "Restores a previously taken snapshot of one or more Snapcast speakers."
+related_actions:
+  - snapcast.snapshot
+  - snapcast.set_latency
+---
+
+The **Restore** action returns one or more Snapcast speakers to the playback state you saved earlier with [Snapshot](/actions/snapcast.snapshot/).
+
+This pair is handy when you want to interrupt playback for a doorbell or a notification sound and then pick up right where you left off.
+
+{% include actions/ui_header.md %}
+
+To restore a snapshot from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Snapcast speakers you want to restore.
+6. From the actions shown for that target, select **Restore**.
+7. Select **Save**.
+
+### Options in the UI
+
+This action has no additional options in the UI.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `snapcast.restore`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: snapcast.restore
+  target:
+    entity_id: media_player.snapcast_living_room
+{% endexample %}
+
+This returns the selected speaker to its saved playback state.
+
+### Options in YAML
+
+This action has no additional options in YAML.
+
+{% include actions/targets.md domain="media_player" %}
+
+## Good to know
+
+- Restore only works after a [Snapshot](/actions/snapcast.snapshot/) has been taken for the same speaker. See the snapshot page for a full doorbell example.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/snapcast.set_latency.markdown
+++ b/source/_actions/snapcast.set_latency.markdown
@@ -10,7 +10,7 @@ related_actions:
 
 The **Set latency** action adjusts the audio latency of a Snapcast speaker, in milliseconds. Use it to fine-tune the timing so a speaker stays in sync with the rest of your multi-room audio.
 
-This is handy when one speaker sounds slightly ahead of or behind the others, for example a speaker connected over a slower link.
+This is handy when one speaker sounds slightly ahead of or behind the others, for example, a speaker connected over a slower link.
 
 {% include actions/ui_header.md %}
 

--- a/source/_actions/snapcast.set_latency.markdown
+++ b/source/_actions/snapcast.set_latency.markdown
@@ -1,0 +1,69 @@
+---
+title: "Set latency"
+action: snapcast.set_latency
+domain: snapcast
+description: "Sets the latency of a Snapcast speaker."
+related_actions:
+  - snapcast.snapshot
+  - snapcast.restore
+---
+
+The **Set latency** action adjusts the audio latency of a Snapcast speaker, in milliseconds. Use it to fine-tune the timing so a speaker stays in sync with the rest of your multi-room audio.
+
+This is handy when one speaker sounds slightly ahead of or behind the others, for example a speaker connected over a slower link.
+
+{% include actions/ui_header.md %}
+
+To set a speaker's latency from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Snapcast speaker you want to adjust.
+6. From the actions shown for that target, select **Set latency**.
+7. Enter the **Latency** in milliseconds.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Latency:
+  description: The latency in milliseconds, from 1 to 1000.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `snapcast.set_latency`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: snapcast.set_latency
+  target:
+    entity_id: media_player.snapcast_kitchen
+  data:
+    latency: 100
+{% endexample %}
+
+This sets the kitchen speaker's latency to 100 milliseconds.
+
+### Options in YAML
+
+{% options_yaml %}
+latency:
+  description: >
+    The latency in milliseconds, from 1 to 1000.
+  required: true
+  type: integer
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="media_player" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/snapcast.snapshot.markdown
+++ b/source/_actions/snapcast.snapshot.markdown
@@ -1,0 +1,90 @@
+---
+title: "Snapshot"
+action: snapcast.snapshot
+domain: snapcast
+description: "Takes a snapshot of what is currently playing on one or more Snapcast speakers."
+related_actions:
+  - snapcast.restore
+  - snapcast.set_latency
+---
+
+The **Snapshot** action saves the current playback state of one or more Snapcast speakers, so you can return to it later with [Restore](/actions/snapcast.restore/).
+
+This pair is handy when you want to interrupt playback for a doorbell or a notification sound and then pick up right where you left off.
+
+{% include actions/ui_header.md %}
+
+To take a snapshot from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Snapcast speakers you want to snapshot.
+6. From the actions shown for that target, select **Snapshot**.
+7. Select **Save**.
+
+### Options in the UI
+
+This action has no additional options in the UI.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `snapcast.snapshot`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: snapcast.snapshot
+  target:
+    entity_id: media_player.snapcast_living_room
+{% endexample %}
+
+This saves the current playback state of the selected speaker.
+
+### Options in YAML
+
+This action has no additional options in YAML.
+
+{% include actions/targets.md domain="media_player" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: pause for a doorbell and resume afterwards
+
+When the doorbell rings, snapshot the speakers, play a chime, then restore playback.
+
+- **Trigger**: The doorbell button is pressed
+- **Action**: Snapcast: Snapshot, play the chime, then Snapcast: Restore
+
+{% details "YAML example for snapshot and restore around a doorbell chime" %}
+
+{% example %}
+automation: |
+  alias: "Doorbell chime with resume"
+  triggers:
+    - trigger: state
+      entity_id: binary_sensor.doorbell
+      to: "on"
+  actions:
+    - action: snapcast.snapshot
+      target:
+        entity_id: media_player.snapcast_living_room
+    - action: media_player.play_media
+      target:
+        entity_id: media_player.snapcast_living_room
+      data:
+        media_content_id: "media-source://media_source/local/doorbell.mp3"
+        media_content_type: music
+    - delay: "00:00:10"
+    - action: snapcast.restore
+      target:
+        entity_id: media_player.snapcast_living_room
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/snapcast.markdown
+++ b/source/_integrations/snapcast.markdown
@@ -18,31 +18,4 @@ The **Snapcast** {% term integration %} allows you to control [Snapcast](https:/
 
 {% include integrations/config_flow.md %}
 
-## Actions
-
-The snapcast integration provides a few actions registered under the media_player integration.
-
-### Action: Snapshot
-
-The `snapcast.snapshot` action takes a snapshot of what is currently playing on one or more speakers. This action, and the following one, are useful if you want to play a doorbell or notification sound and resume playback afterwards.
-
-| Data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `entity_id` | no | The speakers to snapshot.
-
-### Action: Restore
-
-The `snapcast.restore` action restores a previously taken snapshot of one or more speakers.
-
-| Data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `entity_id` | no | String or list of `entity_id`s that should have their snapshot restored.
-
-### Action: Set latency
-
-The `snapcast.set_latency` action sets the latency of a speaker.
-
-| Data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `entity_id` | yes | String or list of `entity_id`s for which latency will be adjusted.
-| `latency` | no | Latency in ms.
+{% include integrations/actions.md %}


### PR DESCRIPTION
## Proposed change

Migrates the Snapcast actions from the inline `## Actions` block on the integration page into dedicated pages under `source/_actions/`, and replaces the inline block with `{% include integrations/actions.md %}`. This brings Snapcast in line with the standardized action documentation used across other integrations.

The three actions (`snapshot`, `restore`, `set_latency`) are entity-targeted on Snapcast media player entities. Field names, types, and targeting were verified against the integration's `services.yaml` and `strings.json` in core.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

