### PR TITLE
Nzbget: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/nzbget.pause.markdown
+++ b/source/_actions/nzbget.pause.markdown
@@ -10,7 +10,7 @@ related_actions:
 
 The **Pause** action pauses the NZBGet download queue. Downloads stop until you resume them again with [Resume](/actions/nzbget.resume/).
 
-This is handy for freeing up your internet connection automatically, for example pausing downloads while you are on a video call or streaming a movie.
+This is handy for freeing up your internet connection automatically, for example, pausing downloads while you are on a video call or streaming a movie.
 
 {% include actions/ui_header.md %}
 

--- a/source/_actions/nzbget.pause.markdown
+++ b/source/_actions/nzbget.pause.markdown
@@ -1,0 +1,75 @@
+---
+title: "Pause"
+action: nzbget.pause
+domain: nzbget
+description: "Pauses the NZBGet download queue."
+related_actions:
+  - nzbget.resume
+  - nzbget.set_speed
+---
+
+The **Pause** action pauses the NZBGet download queue. Downloads stop until you resume them again with [Resume](/actions/nzbget.resume/).
+
+This is handy for freeing up your internet connection automatically, for example pausing downloads while you are on a video call or streaming a movie.
+
+{% include actions/ui_header.md %}
+
+To pause the download queue from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **NZBGet: Pause**.
+6. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+This action has no additional options in the UI.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `nzbget.pause`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: nzbget.pause
+{% endexample %}
+
+This pauses the download queue.
+
+### Options in YAML
+
+This action has no additional options in YAML.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: pause downloads during a video call
+
+When a video call starts, pause NZBGet so it does not compete for bandwidth.
+
+- **Trigger**: A "video call" helper turns on
+- **Action**: NZBGet: Pause
+
+{% details "YAML example for pausing downloads during a call" %}
+
+{% example %}
+automation: |
+  alias: "Pause downloads during calls"
+  triggers:
+    - trigger: state
+      entity_id: input_boolean.video_call
+      to: "on"
+  actions:
+    - action: nzbget.pause
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/nzbget.resume.markdown
+++ b/source/_actions/nzbget.resume.markdown
@@ -10,7 +10,7 @@ related_actions:
 
 The **Resume** action restarts the NZBGet download queue after it has been paused. It is the counterpart to [Pause](/actions/nzbget.pause/).
 
-This is handy for picking downloads back up automatically, for example resuming them once a video call ends or overnight when your connection is quiet.
+This is handy for picking downloads back up automatically, for example, resuming them once a video call ends or overnight when your connection is quiet.
 
 {% include actions/ui_header.md %}
 

--- a/source/_actions/nzbget.resume.markdown
+++ b/source/_actions/nzbget.resume.markdown
@@ -1,0 +1,74 @@
+---
+title: "Resume"
+action: nzbget.resume
+domain: nzbget
+description: "Resumes the NZBGet download queue."
+related_actions:
+  - nzbget.pause
+  - nzbget.set_speed
+---
+
+The **Resume** action restarts the NZBGet download queue after it has been paused. It is the counterpart to [Pause](/actions/nzbget.pause/).
+
+This is handy for picking downloads back up automatically, for example resuming them once a video call ends or overnight when your connection is quiet.
+
+{% include actions/ui_header.md %}
+
+To resume the download queue from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **NZBGet: Resume**.
+6. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+This action has no additional options in the UI.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `nzbget.resume`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: nzbget.resume
+{% endexample %}
+
+This resumes the download queue.
+
+### Options in YAML
+
+This action has no additional options in YAML.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: resume downloads overnight
+
+When everyone is asleep, resume NZBGet so downloads run while the connection is quiet.
+
+- **Trigger**: Time, 02:00
+- **Action**: NZBGet: Resume
+
+{% details "YAML example for resuming downloads overnight" %}
+
+{% example %}
+automation: |
+  alias: "Resume downloads overnight"
+  triggers:
+    - trigger: time
+      at: "02:00:00"
+  actions:
+    - action: nzbget.resume
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/nzbget.set_speed.markdown
+++ b/source/_actions/nzbget.set_speed.markdown
@@ -10,7 +10,7 @@ related_actions:
 
 The **Set speed** action sets the download speed limit for the NZBGet queue, in kilobytes per second. Set it to `0` to remove the limit and let downloads run at full speed.
 
-This is handy for throttling downloads automatically, for example capping the speed during the day and lifting the limit at night.
+This is handy for throttling downloads automatically, for example, capping the speed during the day and lifting the limit at night.
 
 {% include actions/ui_header.md %}
 

--- a/source/_actions/nzbget.set_speed.markdown
+++ b/source/_actions/nzbget.set_speed.markdown
@@ -1,0 +1,91 @@
+---
+title: "Set speed"
+action: nzbget.set_speed
+domain: nzbget
+description: "Sets the NZBGet download queue speed limit."
+related_actions:
+  - nzbget.pause
+  - nzbget.resume
+---
+
+The **Set speed** action sets the download speed limit for the NZBGet queue, in kilobytes per second. Set it to `0` to remove the limit and let downloads run at full speed.
+
+This is handy for throttling downloads automatically, for example capping the speed during the day and lifting the limit at night.
+
+{% include actions/ui_header.md %}
+
+To set the download speed limit from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **NZBGet: Set speed**.
+6. Enter the **Speed** limit you want to apply.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Speed:
+  description: The download speed limit, in kilobytes per second. Set to 0 for no limit.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `nzbget.set_speed`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: nzbget.set_speed
+  data:
+    speed: 500
+{% endexample %}
+
+This limits the download queue to 500 kilobytes per second.
+
+### Options in YAML
+
+{% options_yaml %}
+speed:
+  description: >
+    The download speed limit, in kilobytes per second. Set to 0 for
+    no limit.
+  required: false
+  type: integer
+  default: 1000
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: throttle downloads during the day
+
+Cap the download speed during the day and lift the limit again overnight.
+
+- **Trigger**: Time, 08:00
+- **Action**: NZBGet: Set speed
+
+{% details "YAML example for throttling downloads during the day" %}
+
+{% example %}
+automation: |
+  alias: "Throttle downloads during the day"
+  triggers:
+    - trigger: time
+      at: "08:00:00"
+  actions:
+    - action: nzbget.set_speed
+      data:
+        speed: 500
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/nzbget.markdown
+++ b/source/_integrations/nzbget.markdown
@@ -61,18 +61,4 @@ Example automation to send a Telegram message on a completed download:
         message: "{{trigger.event.data.name}}"
 ```
 
-## Actions
-
-Available actions:
-
-- `pause`: Pause the download queue.
-- `resume`: Resume the download queue.
-- `set_speed`: Set the download queue speed limit.
-
-### Action: Set speed
-
-The `nzbget.set_speed` action sets the download queue speed limit.
-
-| Data attribute | Optional | Description                                                                                     |
-| ---------------------- | -------- | ----------------------------------------------------------------------------------------------- |
-| `speed`                | yes      | Sets the download speed limit, specified in Kb/s. 0 disables the speed limit. Defaults to 1000. |
+{% include integrations/actions.md %}


### PR DESCRIPTION
## Proposed change

Migrates the NZBGet actions from the inline `## Actions` block on the integration page into dedicated pages under `source/_actions/`, and replaces the inline block with `{% include integrations/actions.md %}`. This brings NZBGet in line with the standardized action documentation used across other integrations.

The three actions (`pause`, `resume`, `set_speed`) are targetless. Field names, types, and the speed unit (kB/s) were verified against the integration's `services.yaml` and `strings.json` in core.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

