### PR TITLE
PlayStation 4: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/ps4.send_command.markdown
+++ b/source/_actions/ps4.send_command.markdown
@@ -19,7 +19,7 @@ To send a command from an automation or a script:
 6. Choose the **Entity** and the **Command** you want to send.
 7. Select **Save**.
 
-This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+This action does not support targets. In the UI, you choose the PlayStation 4 in the **Entity** field.
 
 ### Options in the UI
 

--- a/source/_actions/ps4.send_command.markdown
+++ b/source/_actions/ps4.send_command.markdown
@@ -67,6 +67,32 @@ command:
 
 {% include actions/more_examples.md %}
 
+### Automation: Pause playback by pressing the PS button at bedtime
+
+This automation presses the PS button on your PlayStation 4 every night at bedtime, which opens the home screen and pauses whatever is playing.
+
+- Trigger: the time is 11:00 PM
+- Action: send the PS button press
+  - Entity: the PlayStation 4 media player
+  - Command: `ps`
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  alias: "Open PlayStation home screen at bedtime"
+  triggers:
+    - trigger: time
+      at: "23:00:00"
+  actions:
+    - action: ps4.send_command
+      data:
+        entity_id: media_player.ps4
+        command: ps
+{% endexample %}
+
+{% enddetails %}
+
 {% include actions/stuck.md %}
 
 {% include actions/related.md %}

--- a/source/_actions/ps4.send_command.markdown
+++ b/source/_actions/ps4.send_command.markdown
@@ -1,0 +1,72 @@
+---
+title: "Send command"
+action: ps4.send_command
+domain: ps4
+description: "Emulates a button press on a PlayStation 4."
+---
+
+The **Send command** action emulates a button press on your PlayStation 4. It mimics the buttons available in the PS4 Second Screen App. These are not the same as the DualShock 4 controller buttons.
+
+{% include actions/ui_header.md %}
+
+To send a command from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **PlayStation 4: Send command**.
+6. Choose the **Entity** and the **Command** you want to send.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Entity:
+  description: The PlayStation 4 media player entity to send the command to.
+  required: true
+Command:
+  description: "The button to press. One of `ps` (PS button), `ps_hold` (PS button long press), `option`, `enter`, `back`, `up` (swipe up), `down` (swipe down), `left` (swipe left), or `right` (swipe right)."
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `ps4.send_command`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: ps4.send_command
+  data:
+    entity_id: media_player.ps4
+    command: ps
+{% endexample %}
+
+This presses the PS button on the selected PlayStation 4.
+
+### Options in YAML
+
+{% options_yaml %}
+entity_id:
+  description: >
+    The PlayStation 4 media player entity to send the command to.
+  required: true
+  type: string
+command:
+  description: >
+    The button to press. One of `ps` (PS button), `ps_hold` (PS button
+    long press), `option`, `enter`, `back`, `up` (swipe up), `down`
+    (swipe down), `left` (swipe left), or `right` (swipe right).
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/ps4.markdown
+++ b/source/_integrations/ps4.markdown
@@ -117,41 +117,13 @@ Backup a copy of your `.ps4-games.json` file before continuing. If there are err
 
 To edit, simply open the file in a text editor, find the game or app you would like to edit, and edit the value(s) you wish to change and then save the file. The changes will appear the next time you play the game or app on your console. 
 
-## Actions
+## Selecting a game or app
 
-### Action `select_source`
+The **Media player: Select source** action opens a new game or app and closes the one that's currently running. The game or app must be in the entity's source list. Games are added automatically when you open them normally on your console.
 
-Opens new application/game and closes currently running application/game. The game/app must be in the entity's source list. Games will be added automatically when you open them normally.
+When you select a source, you can use either the title (for example, `Some Game`) or the SKU ID (for example, `CUSA00123`). Using the SKU ID is the most reliable.
 
-| Data attribute | Optional | Example                    | Description                                                                                                 |
-| ---------------------- | -------- | -------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| `entity_id`            | No       | `media_player.ps4`         | The entity id for your PlayStation 4.                                                                       |
-| `source`               | No       | `Some Game` or `CUSA00123` | The game/app you want to open. You can use the title or SKU ID. Using the SKU ID will be the most reliable. |
-
-### Action `send_command`
-
-Emulate button press on PlayStation 4. This emulates the commands available for the PS4 Second Screen App. This is not to be confused with DualShock 4 controller buttons.
-
-| Data attribute | Optional | Example            | Description                           |
-| ---------------------- | -------- | ------------------ | ------------------------------------- |
-| `entity_id`            | No       | `media_player.ps4` | The entity id for your PlayStation 4. |
-| `command`              | No       | `ps`               | The command you want to send.         |
-
-#### Available Commands
-
-Full list of supported commands.
-
-| Command   | Button Emulated    |
-| --------- | ------------------ |
-| `ps`      | PS (PlayStation)   |
-| `ps_hold` | PS Hold/Long Press |
-| `option`  | Option             |
-| `enter`   | Enter              |
-| `back`    | Back               |
-| `up`      | Swipe Up           |
-| `down`    | Swipe Down         |
-| `left`    | Swipe Left         |
-| `right`   | Swipe Right        |
+{% include integrations/actions.md %}
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Proposed change

Migrates the inline `ps4.send_command` action into a dedicated page under `source/_actions/` and replaces the inline `## Actions` block on the integration page with the `{% include integrations/actions.md %}` include. The guidance for selecting a game or app (the generic media player select source action) is kept as a short section on the integration page. This aligns the PlayStation 4 documentation with the standardized action documentation structure used across other integrations.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
