### PR TITLE
Iperf3: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/iperf3.speedtest.markdown
+++ b/source/_actions/iperf3.speedtest.markdown
@@ -25,7 +25,7 @@ This action does not support targets. In the UI, you are not prompted to choose 
 
 {% options_ui %}
 Host:
-  description: The host name of a configured iperf3 server to test against. If left empty, the test runs against all configured servers.
+  description: The host name or IP address of a configured iperf3 server to test against. If left empty, the test runs against all configured servers.
   required: false
 {% endoptions_ui %}
 
@@ -47,7 +47,7 @@ This runs a speed test against the `iperf.he.net` server.
 {% options_yaml %}
 host:
   description: >
-    The host name of a configured iperf3 server to test against. If omitted,
+    The host name or IP address of a configured iperf3 server to test against. If omitted,
     the test runs against all configured servers.
   required: false
   type: string

--- a/source/_actions/iperf3.speedtest.markdown
+++ b/source/_actions/iperf3.speedtest.markdown
@@ -1,0 +1,89 @@
+---
+title: "Speedtest"
+action: iperf3.speedtest
+domain: iperf3
+description: "Runs an iperf3 speed test on demand."
+---
+
+Use this action to run an iperf3 speed test right away, instead of waiting for the next scheduled test. This is handy when you want an up-to-date measurement, for example to check your connection after making a network change.
+
+{% include actions/ui_header.md %}
+
+To run a speed test from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Iperf3: Speedtest**.
+6. Optionally, set the **Host** to test against a single configured server.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Host:
+  description: The host name of a configured iperf3 server to test against. If left empty, the test runs against all configured servers.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `iperf3.speedtest`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: iperf3.speedtest
+  data:
+    host: "iperf.he.net"
+{% endexample %}
+
+This runs a speed test against the `iperf.he.net` server.
+
+### Options in YAML
+
+{% options_yaml %}
+host:
+  description: >
+    The host name of a configured iperf3 server to test against. If omitted,
+    the test runs against all configured servers.
+  required: false
+  type: string
+{% endoptions_yaml %}
+
+## Good to know
+
+- Leave the host empty to test every configured server at once.
+- This action is most useful when you've set a long scan interval and want a fresh result without waiting for the next automatic test.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: run a speed test after the router reboots
+
+When the router comes back online, run an iperf3 speed test so you have a fresh measurement of the connection.
+
+- **Trigger**: Router connectivity sensor turns on
+- **Action**: Iperf3: Speedtest
+
+{% details "YAML example for testing after a router reboot" %}
+
+{% example %}
+automation: |
+  alias: "Run iperf3 test after router reboot"
+  triggers:
+    - trigger: state
+      entity_id: binary_sensor.router_online
+      to: "on"
+  actions:
+    - action: iperf3.speedtest
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/iperf3.markdown
+++ b/source/_integrations/iperf3.markdown
@@ -114,16 +114,4 @@ Parallel streams can help in some situations. As TCP attempts to be fair and con
 
 You can use the `sensor.iperf3_update` action to trigger a manual speed test for all sensors. Iperf3 has its own action that allows performing a speed test on a particular entity.
 
-## Action
-
-Once loaded, the `iperf3` integration will expose an action (`iperf3.speedtest`) that can be called to run a speed test on demand. This can be useful if you have enabled manual mode.
-
-| Data attribute | Description |
-| --- | --- |
-| `host` | String that point at a configured `host` from `configuration.yaml`. Otherwise, tests will be run against all configured hosts. |
-
-Example action data:
-
-```json
-{"host": "192.168.0.121"}
-```
+{% include integrations/actions.md %}


### PR DESCRIPTION
## Proposed change

Migrates the inline Iperf3 action into a dedicated page under `source/_actions/` and replaces the inline block with `{% include integrations/actions.md %}`, in line with the action documentation standardization.

The `speedtest` action gets its own page, with the optional `host` field documented for both the UI and YAML.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

