### PR TITLE
iZone: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/izone.airflow_max.markdown
+++ b/source/_actions/izone.airflow_max.markdown
@@ -1,0 +1,95 @@
+---
+title: "Set maximum airflow"
+action: izone.airflow_max
+domain: izone
+description: "Sets the maximum airflow percentage for an iZone zone."
+related_actions:
+  - izone.airflow_min
+---
+
+Use this action to set the maximum airflow for an iZone zone, so the zone never draws more than that much airflow. This is useful to balance your system, for example to stop one room taking all the air from the rest of the house.
+
+{% include actions/ui_header.md %}
+
+To set the maximum airflow from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the zone you want to adjust.
+6. From the actions shown for that target, select **Set maximum airflow**.
+7. Set the **Percent** for the maximum airflow.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Percent:
+  description: The maximum airflow percentage, set in steps of 5%.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `izone.airflow_max`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: izone.airflow_max
+  target:
+    entity_id: climate.bed_2
+  data:
+    airflow: 80
+{% endexample %}
+
+This limits the `climate.bed_2` zone to at most 80% airflow.
+
+### Options in YAML
+
+{% options_yaml %}
+airflow:
+  description: >
+    The maximum airflow percentage, between 0 and 100, set in steps of 5%.
+  required: true
+  type: integer
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="climate" %}
+
+## Good to know
+
+- The maximum can't be lower than the zone's minimum airflow. Use [Set minimum airflow](/actions/izone.airflow_min/) to lower the minimum first if you need a lower maximum.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: limit the living room during peak cooling
+
+On hot afternoons, cap the living room airflow so the rest of the house keeps cooling evenly.
+
+- **Trigger**: Outdoor temperature rises above 30 °C
+- **Action**: iZone: Set maximum airflow on the living room
+
+{% details "YAML example for limiting airflow on hot days" %}
+
+{% example %}
+automation: |
+  alias: "Limit living room airflow on hot afternoons"
+  triggers:
+    - trigger: numeric_state
+      entity_id: sensor.outdoor_temperature
+      above: 30
+  actions:
+    - action: izone.airflow_max
+      target:
+        entity_id: climate.living_room
+      data:
+        airflow: 70
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/izone.airflow_min.markdown
+++ b/source/_actions/izone.airflow_min.markdown
@@ -1,0 +1,94 @@
+---
+title: "Set minimum airflow"
+action: izone.airflow_min
+domain: izone
+description: "Sets the minimum airflow percentage for an iZone zone."
+related_actions:
+  - izone.airflow_max
+---
+
+Use this action to set the minimum airflow for an iZone zone, so the zone always keeps at least that much airflow when it's open. This is useful to make sure a room never gets starved of air, for example a bedroom you want to stay gently ventilated.
+
+{% include actions/ui_header.md %}
+
+To set the minimum airflow from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the zone you want to adjust.
+6. From the actions shown for that target, select **Set minimum airflow**.
+7. Set the **Percent** for the minimum airflow.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Percent:
+  description: The minimum airflow percentage, set in steps of 5%.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `izone.airflow_min`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: izone.airflow_min
+  target:
+    entity_id: climate.bed_2
+  data:
+    airflow: 20
+{% endexample %}
+
+This keeps at least 20% airflow to the `climate.bed_2` zone.
+
+### Options in YAML
+
+{% options_yaml %}
+airflow:
+  description: >
+    The minimum airflow percentage, between 0 and 100, set in steps of 5%.
+  required: true
+  type: integer
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="climate" %}
+
+## Good to know
+
+- The minimum can't be higher than the zone's maximum airflow. Use [Set maximum airflow](/actions/izone.airflow_max/) to raise the maximum first if you need a higher minimum.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: ventilate the nursery overnight
+
+At night, keep a minimum airflow to the nursery so the room stays gently ventilated while everyone sleeps.
+
+- **Trigger**: Time, 21:00
+- **Action**: iZone: Set minimum airflow on the nursery
+
+{% details "YAML example for overnight ventilation" %}
+
+{% example %}
+automation: |
+  alias: "Ventilate the nursery overnight"
+  triggers:
+    - trigger: time
+      at: "21:00:00"
+  actions:
+    - action: izone.airflow_min
+      target:
+        entity_id: climate.nursery
+      data:
+        airflow: 25
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/izone.markdown
+++ b/source/_integrations/izone.markdown
@@ -134,22 +134,4 @@ logger:
 
 This will help you to find network connection issues.
 
-## Actions
-
-### Action: Set minimum airflow
-
-The `izone.airflow_min` action sets the minimum airflow for a particular zone.
-
-| Data attribute | Optional | Description                                    |
-| -------------- | -------- | ---------------------------------------------- |
-| `entity_id`    | yes      | izone Zone entity. For example `climate.bed_2` |
-| `airflow`      | no       | Airflow percent in 5% increments               |
-
-### Action: Set maximum airflow
-
-The `izone.airflow_max` action sets the maximum airflow for a particular zone.
-
-| Data attribute | Optional | Description                                    |
-| -------------- | -------- | ---------------------------------------------- |
-| `entity_id`    | yes      | izone Zone entity. For example `climate.bed_2` |
-| `airflow`      | no       | Airflow percent in 5% increments               |
+{% include integrations/actions.md %}


### PR DESCRIPTION
## Proposed change

Migrates the inline iZone actions into dedicated pages under `source/_actions/` and replaces the inline block with `{% include integrations/actions.md %}`, in line with the action documentation standardization.

The `airflow_min` and `airflow_max` actions each get their own page, documented as entity-targeted climate zone actions.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

