### PR TITLE
Linn / OpenHome: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/openhome.invoke_pin.markdown
+++ b/source/_actions/openhome.invoke_pin.markdown
@@ -1,0 +1,93 @@
+---
+title: "Play pin"
+action: openhome.invoke_pin
+domain: openhome
+description: "Starts playing content pinned on a Linn or OpenHome device."
+---
+
+Use this action to start playing a pin on a Linn or OpenHome device. Pins are the presets you've saved on the device, such as a radio station or a playlist, so this is a quick way to start your favorite content from an automation or a script.
+
+{% include actions/ui_header.md %}
+
+To play a pin from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the device you want to play the pin on.
+6. From the actions shown for that target, select **Play pin**.
+7. Set the **Pin ID** of the content you want to play.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Pin ID:
+  description: The ID of the pinned content to play.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `openhome.invoke_pin`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: openhome.invoke_pin
+  target:
+    entity_id: media_player.linn_bedroom
+  data:
+    pin: 1
+{% endexample %}
+
+This starts playing pin 1 on the bedroom Linn device.
+
+### Options in YAML
+
+{% options_yaml %}
+pin:
+  description: >
+    The ID of the pinned content to play, between 0 and 1000.
+  required: true
+  type: integer
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="media_player" %}
+
+## Good to know
+
+- Pins are the presets stored on the device itself. Set them up in the Linn or OpenHome app, then refer to them here by their ID.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: play a morning radio pin on a button press
+
+When you press a physical button, start your favorite radio pin on the kitchen device to ease into the morning.
+
+- **Trigger**: Button pressed
+- **Action**: Linn / OpenHome: Play pin on the kitchen device
+
+{% details "YAML example for a morning radio pin" %}
+
+{% example %}
+automation: |
+  alias: "Play morning radio pin"
+  triggers:
+    - trigger: state
+      entity_id: binary_sensor.kitchen_button
+      to: "on"
+  actions:
+    - action: openhome.invoke_pin
+      target:
+        entity_id: media_player.linn_kitchen
+      data:
+        pin: 1
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/openhome.markdown
+++ b/source/_integrations/openhome.markdown
@@ -44,13 +44,4 @@ actions:
       media_content_type: music
 ```
 
-## Actions
-
-### Media control actions
-
-Available actions: `invoke_pin`
-
-| Data attribute | Optional | Description                                      |
-| ---------------------- | -------- | ------------------------------------------------ |
-| `entity_id`            |     yes | The name of the openhome device to invoke the pin on.|
-| `pin`                  |      no | Which pin to invoke.                              |
+{% include integrations/actions.md %}


### PR DESCRIPTION
## Proposed change

Migrates the inline Linn / OpenHome action into a dedicated page under `source/_actions/` and replaces the inline block with `{% include integrations/actions.md %}`, in line with the action documentation standardization.

The `invoke_pin` action gets its own page, documented as an entity-targeted media player action.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

