### PR TITLE
File: migrate actions to dedicated action page

### DIFF
--- a/source/_actions/file.read_file.markdown
+++ b/source/_actions/file.read_file.markdown
@@ -1,0 +1,95 @@
+---
+title: "Read file"
+action: file.read_file
+domain: file
+description: "Reads a file and returns its contents in a response."
+---
+
+Use this action to read a JSON or YAML file and return its parsed contents in a response variable, for example to load data saved by another automation or an external program.
+
+This action returns its result in a response variable, which you can use in later steps of the same automation or script.
+
+{% include actions/ui_header.md %}
+
+To read a file from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Search for and select **File: Read file**.
+6. Enter the **File name** and select the **File encoding** that matches your file.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+File name:
+  description: Name of the file to read. The path must be in your list of allowed external directories.
+  required: true
+File encoding:
+  description: Encoding of the file. Choose JSON or YAML.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `file.read_file`. Store the result in a response variable so you can use it in later steps:
+
+{% example %}
+action: |
+  action: file.read_file
+  data:
+    file_name: "/config/www/myfile.json"
+    file_encoding: JSON
+  response_variable: file_content
+{% endexample %}
+
+This reads `myfile.json` and stores its parsed contents in the `file_content` variable.
+
+### Options in YAML
+
+{% options_yaml %}
+file_name:
+  description: Name of the file to read. The path must be in your list of allowed external directories.
+  required: true
+  type: string
+file_encoding:
+  description: Encoding of the file. Choose JSON or YAML.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+## Response data
+
+The action returns a `data` field that holds the parsed contents of the file. For example, reading a file with this JSON content:
+
+```json
+{
+  "latitude": 32.87336,
+  "longitude": -117.22743,
+  "gps_accuracy": 1.2
+}
+```
+
+returns the following response:
+
+```yaml
+data:
+  latitude: 32.87336
+  longitude: -117.22743
+  gps_accuracy: 1.2
+```
+
+## Good to know
+
+- The file path must be added to your [`allowlist_external_dirs`](/integrations/homeassistant/#allowlist_external_dirs) in {% term "`configuration.yaml`" %}. Otherwise, the action cannot access the file.
+- Only an administrator can run this action.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/file.read_file.markdown
+++ b/source/_actions/file.read_file.markdown
@@ -51,7 +51,9 @@ action: |
     file_encoding: JSON
   response_variable: file_content
 {% endexample %}
+
 This reads `myfile.json` and stores the response in the `file_content` variable. The parsed file contents are in `file_content.data`.
+
 ### Options in YAML
 
 {% options_yaml %}

--- a/source/_actions/file.read_file.markdown
+++ b/source/_actions/file.read_file.markdown
@@ -46,9 +46,7 @@ action: |
     file_encoding: JSON
   response_variable: file_content
 {% endexample %}
-
-This reads `myfile.json` and stores its parsed contents in the `file_content` variable.
-
+This reads `myfile.json` and stores the response in the `file_content` variable. The parsed file contents are in `file_content.data`.
 ### Options in YAML
 
 {% options_yaml %}
@@ -83,10 +81,6 @@ data:
   gps_accuracy: 1.2
 ```
 
-## Good to know
-
-- The file path must be added to your [`allowlist_external_dirs`](/integrations/homeassistant/#allowlist_external_dirs) in {% term "`configuration.yaml`" %}. Otherwise, the action cannot access the file.
-- Only an administrator can run this action.
 
 {% include actions/try_it.md %}
 

--- a/source/_actions/file.read_file.markdown
+++ b/source/_actions/file.read_file.markdown
@@ -11,6 +11,11 @@ This action returns its result in a response variable, which you can use in late
 
 {% include actions/ui_header.md %}
 
+### Prerequisites
+
+- You need administrator rights to run this action.
+- The file path must be added to [`allowlist_external_dirs`](/integrations/homeassistant/#allowlist_external_dirs) in {% term "`configuration.yaml`" %}.
+
 To read a file from an automation or a script:
 
 1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.

--- a/source/_integrations/file.markdown
+++ b/source/_integrations/file.markdown
@@ -31,46 +31,7 @@ file:
   
 {% include integrations/config_flow.md %}
 
-## Action: Read file
-
-The `file.read_file` action reads a file and returns the data in a response.
-
-| Data attribute | Optional | Description |
-| -------------- | -------- | ----------- |
-| `file_name`    | No       | The path of the file and name to read. Files should be UTF-8 encoded. Example: `config/www/myfile.yaml` |
-| `file_encoding`| No       | The content type of the file (`JSON` or `YAML`). Example: `YAML` |
-
-> **Note:** The file paths should be relative to the Home Assistant configuration directory.
-
-> **Note:** File paths must be added to [allowlist_external_dirs](/integrations/homeassistant/#allowlist_external_dirs) in your {% term "`configuration.yaml`" %}.
-
-The action returns a dictionary with a data element containing the parsed content from the file.
-
-Example, read a JSON file out of the `www` directory.
-```yaml
-  - action: file.read_file
-    data:
-      file_name: config/www/myfile.json
-      file_encoding: JSON
-    response_variable: file_content
-```
-<!-- textlint-disable -->
-Contents of myfile.json
-<!-- textlint-enable -->
-```json
-{
-  "latitude": 32.87336,
-  "longitude": -117.22743,
-  "gps_accuracy": 1.2
-}
-```
-Response:
-```yaml
-data:
-  latitude: 32.87336
-  longitude: -117.22743
-  gps_accuracy: 1.2
-```
+{% include integrations/actions.md %}
 
 ## Notifications
 


### PR DESCRIPTION
## Proposed change

Migrates the inline `file.read_file` action documentation on the File integration page to a dedicated page under `source/_actions/`, replacing the inline block with `{% include integrations/actions.md %}`. This aligns the File integration with the standardized action documentation structure.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

