### PR TITLE
Risco: migrate actions to dedicated action page

### DIFF
--- a/source/_actions/risco.set_time.markdown
+++ b/source/_actions/risco.set_time.markdown
@@ -66,6 +66,30 @@ time:
 
 {% include actions/more_examples.md %}
 
+### Automation: keep the alarm panel clock in sync
+
+Re-sync the alarm panel clock with the Home Assistant system time every night, so it stays accurate after a power loss or a daylight saving time change.
+
+- **Trigger**: Time: 03:00:00
+- **Action**: Risco: Set the alarm panel time
+  - **Config entry**: Your Risco alarm panel
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  - alias: "Sync the Risco alarm panel clock"
+    triggers:
+      - trigger: time
+        at: "03:00:00"
+    actions:
+      - action: risco.set_time
+        data:
+          config_entry_id: 1b9a8a9d2c3e4f5061728394a5b6c7d8
+{% endexample %}
+
+{% enddetails %}
+
 {% include actions/stuck.md %}
 
 {% include actions/related.md %}

--- a/source/_actions/risco.set_time.markdown
+++ b/source/_actions/risco.set_time.markdown
@@ -1,0 +1,71 @@
+---
+title: "Set the alarm panel time"
+action: risco.set_time
+domain: risco
+description: "Sets the time of a Risco alarm panel."
+---
+
+Use this action to set the clock on your Risco alarm panel, for example to keep it in sync with Home Assistant after a power loss or a time change.
+
+{% include actions/ui_header.md %}
+
+To set the alarm panel time from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Search for and select **Risco: Set the alarm panel time**.
+6. Select the **Config entry** for the alarm panel you want to set, and optionally a **Time**.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Config entry:
+  description: The Risco alarm panel to set the time for.
+  required: true
+Time:
+  description: The time to send to the alarm panel. Leave it empty to use the Home Assistant system time.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `risco.set_time`:
+
+{% example %}
+action: |
+  action: risco.set_time
+  data:
+    config_entry_id: 1b9a8a9d2c3e4f5061728394a5b6c7d8
+{% endexample %}
+
+This sets the alarm panel clock to the current Home Assistant system time.
+
+### Options in YAML
+
+{% options_yaml %}
+config_entry_id:
+  description: The Risco alarm panel to set the time for.
+  required: true
+  type: string
+time:
+  description: The time to send to the alarm panel. Leave it empty to use the Home Assistant system time.
+  required: false
+  type: datetime
+{% endoptions_yaml %}
+
+## Good to know
+
+- Setting the panel time is only available on a local connection, not over Risco Cloud.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/risco.markdown
+++ b/source/_integrations/risco.markdown
@@ -97,13 +97,4 @@ And in the reverse direction:
 - [Sensor](/integrations/sensor/)
 - [Switch](/integrations/switch/)
 
-## Actions
-
-### Set time
-
-The `risco.set_time` action enables you to set the time of a panel on a local connection.
-
-| Data attribute    | Required | Description                                                                                |
-| ----------------- | -------- | ------------------------------------------------------------------------------------------ |
-| `config_entry_id` | yes      | The config entry ID of the alarm panel.                                                    |
-| `time`            | no       | The time to send to the alarm panel. Leave it empty to use the Home Assistant system time. |
+{% include integrations/actions.md %}


### PR DESCRIPTION
## Proposed change

Migrates the inline `risco.set_time` action documentation on the Risco integration page to a dedicated page under `source/_actions/`, replacing the inline block with `{% include integrations/actions.md %}`. This aligns the Risco integration with the standardized action documentation structure.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

