### PR TITLE
RFXCOM RFXtrx: migrate actions to dedicated action page

### DIFF
--- a/source/_actions/rfxtrx.send.markdown
+++ b/source/_actions/rfxtrx.send.markdown
@@ -2,10 +2,10 @@
 title: "Send"
 action: rfxtrx.send
 domain: rfxtrx
-description: "Sends a raw event over radio with the RFXtrx device."
+description: "Sends a raw event over the radio with the RFXtrx device."
 ---
 
-Use this action to send a raw event over radio, for example to simulate a button press or control a device that is not automatically added in Home Assistant.
+Use this action to send a raw event over the radio, for example to simulate a button press or control a device that is not automatically added in Home Assistant.
 
 {% include actions/ui_header.md %}
 
@@ -40,7 +40,7 @@ action: |
     event: "0b1111e003af16aa10000060"
 {% endexample %}
 
-This simulates a button being pressed by sending the raw event over radio.
+This simulates a button being pressed by sending the raw event over the radio.
 
 ### Options in YAML
 
@@ -58,6 +58,30 @@ event:
 {% include actions/try_it.md %}
 
 {% include actions/more_examples.md %}
+
+### Automation: control a device that is not added to Home Assistant
+
+Send a raw event to switch on a device that Home Assistant does not control directly, for example an older remote-controlled outlet, when the sun goes down.
+
+- **Trigger**: Sun: Sunset
+- **Action**: RFXCOM RFXtrx: Send
+  - **Event**: `0b1111e003af16aa10000060`
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  - alias: "Switch on the porch light at sunset"
+    triggers:
+      - trigger: sun
+        event: sunset
+    actions:
+      - action: rfxtrx.send
+        data:
+          event: "0b1111e003af16aa10000060"
+{% endexample %}
+
+{% enddetails %}
 
 {% include actions/stuck.md %}
 

--- a/source/_actions/rfxtrx.send.markdown
+++ b/source/_actions/rfxtrx.send.markdown
@@ -1,0 +1,64 @@
+---
+title: "Send"
+action: rfxtrx.send
+domain: rfxtrx
+description: "Sends a raw event over radio with the RFXtrx device."
+---
+
+Use this action to send a raw event over radio, for example to simulate a button press or control a device that is not automatically added in Home Assistant.
+
+{% include actions/ui_header.md %}
+
+To send a raw event from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Search for and select **RFXCOM RFXtrx: Send**.
+6. Enter the **Event** as a hexadecimal string.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Event:
+  description: A hexadecimal string to send, for example 0b1111e003af16aa10000060.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `rfxtrx.send`:
+
+{% example %}
+action: |
+  action: rfxtrx.send
+  data:
+    event: "0b1111e003af16aa10000060"
+{% endexample %}
+
+This simulates a button being pressed by sending the raw event over radio.
+
+### Options in YAML
+
+{% options_yaml %}
+event:
+  description: A hexadecimal string to send, for example 0b1111e003af16aa10000060.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+## Good to know
+
+- To generate event codes for switches and lights, see [Generate codes](/integrations/rfxtrx/#generate-codes) on the RFXCOM RFXtrx integration page.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/rfxtrx.markdown
+++ b/source/_integrations/rfxtrx.markdown
@@ -335,34 +335,7 @@ automation:
           entity_id: scene.welcomescene
 ```
 
-## Actions
-
-- `rfxtrx.send`: Send a custom event using the RFXtrx device.
-
-### Action: Send
-
-The `rfxtrx.send` action sends a custom event using the RFXtrx device.
-
-Simulate a button being pressed:
-
-```yaml
-...
-actions:
-  - action: rfxtrx.send
-    data:
-      event: 0b1111e003af16aa10000060
-```
-
-Alternatively:
-
-- Go to: {% my developer_call_service title="**Settings** > **Developer tools** > **Actions**" service="rfxtrx.send" %}
-- Select: `RFXCOM RFXtrx: Send` from the **Action** drop-down menu.
-
-```yaml
-action: rfxtrx.send
-data:
-  event: "0b1111e003af16aa10000060"
-```
+{% include integrations/actions.md %}
 
 ## Generate codes
 


### PR DESCRIPTION
## Proposed change

Migrates the inline `rfxtrx.send` action documentation on the RFXCOM RFXtrx integration page to a dedicated page under `source/_actions/`, replacing the inline block with `{% include integrations/actions.md %}`. This aligns the integration with the standardized action documentation structure.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

