### PR TITLE
Envisalink: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/envisalink.alarm_keypress.markdown
+++ b/source/_actions/envisalink.alarm_keypress.markdown
@@ -69,6 +69,32 @@ keypress:
 
 {% include actions/more_examples.md %}
 
+### Automation: send a command sequence at bedtime
+
+Send a custom keypress sequence to the panel every night, for example to activate a special arming mode that is not available as a standard action.
+
+- **Trigger**: Time: 23:00:00
+- **Action**: Envisalink: Alarm keypress
+  - **Entity**: Your alarm control panel
+  - **Keypress**: `*71`
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  - alias: "Send the night command sequence"
+    triggers:
+      - trigger: time
+        at: "23:00:00"
+    actions:
+      - action: envisalink.alarm_keypress
+        data:
+          entity_id: alarm_control_panel.home_alarm
+          keypress: "*71"
+{% endexample %}
+
+{% enddetails %}
+
 {% include actions/stuck.md %}
 
 {% include actions/related.md %}

--- a/source/_actions/envisalink.alarm_keypress.markdown
+++ b/source/_actions/envisalink.alarm_keypress.markdown
@@ -82,7 +82,7 @@ Send a custom keypress sequence to the panel every night, for example to activat
 
 {% example %}
 automation: |
-  - alias: "Send the night command sequence"
+    alias: "Send the night command sequence"
     triggers:
       - trigger: time
         at: "23:00:00"

--- a/source/_actions/envisalink.alarm_keypress.markdown
+++ b/source/_actions/envisalink.alarm_keypress.markdown
@@ -21,7 +21,7 @@ To send keypresses from an automation or a script:
 6. Select the alarm control panel **Entity** and enter the **Keypress** string to send.
 7. Select **Save**.
 
-This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+This action does not support targets. In the UI, you choose the alarm control panel in the **Entity** field.
 
 ### Options in the UI
 

--- a/source/_actions/envisalink.alarm_keypress.markdown
+++ b/source/_actions/envisalink.alarm_keypress.markdown
@@ -1,0 +1,74 @@
+---
+title: "Alarm keypress"
+action: envisalink.alarm_keypress
+domain: envisalink
+description: "Sends custom keypresses to an Envisalink alarm panel."
+related_actions:
+  - envisalink.invoke_custom_function
+---
+
+Use this action to send a string of keypresses to your Envisalink alarm panel, for example to enter a special command sequence that is not available as a standard action.
+
+{% include actions/ui_header.md %}
+
+To send keypresses from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Search for and select **Envisalink: Alarm keypress**.
+6. Select the alarm control panel **Entity** and enter the **Keypress** string to send.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Entity:
+  description: The alarm control panel to send the keypresses to.
+  required: true
+Keypress:
+  description: The string to send to the alarm panel (1-6 characters).
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `envisalink.alarm_keypress`:
+
+{% example %}
+action: |
+  action: envisalink.alarm_keypress
+  data:
+    entity_id: alarm_control_panel.home_alarm
+    keypress: "*71"
+{% endexample %}
+
+This sends the keypress sequence `*71` to the alarm panel.
+
+### Options in YAML
+
+{% options_yaml %}
+entity_id:
+  description: The alarm control panel to send the keypresses to.
+  required: true
+  type: string
+keypress:
+  description: The string to send to the alarm panel (1-6 characters).
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+## Good to know
+
+- This action works with DSC panels and is confirmed to work with the Honeywell Vista-20P (also known as the First Alert FA-168).
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/envisalink.invoke_custom_function.markdown
+++ b/source/_actions/envisalink.invoke_custom_function.markdown
@@ -7,7 +7,7 @@ related_actions:
   - envisalink.alarm_keypress
 ---
 
-Use this action to trigger a PGM output on a DSC alarm panel, for example to activate a relay or an auxiliary output wired to your panel.
+Use this action to trigger a PGM (Programmable) output on a DSC alarm panel, for example to activate a relay or an auxiliary output wired to your panel.
 
 {% include actions/ui_header.md %}
 
@@ -83,7 +83,7 @@ Trigger a PGM output to activate an auxiliary output wired to your panel, for ex
 
 {% example %}
 automation: |
-  - alias: "Open the gate with a PGM output"
+    alias: "Open the gate with a PGM output"
     triggers:
       - trigger: state
         entity_id: input_boolean.gate_button

--- a/source/_actions/envisalink.invoke_custom_function.markdown
+++ b/source/_actions/envisalink.invoke_custom_function.markdown
@@ -70,6 +70,33 @@ pgm:
 
 {% include actions/more_examples.md %}
 
+### Automation: trigger an auxiliary output
+
+Trigger a PGM output to activate an auxiliary output wired to your panel, for example a relay that opens a gate, when an input boolean is turned on.
+
+- **Trigger**: State: Gate button turns on
+- **Action**: Envisalink: Invoke custom function
+  - **Partition**: `1`
+  - **PGM**: `2`
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  - alias: "Open the gate with a PGM output"
+    triggers:
+      - trigger: state
+        entity_id: input_boolean.gate_button
+        to: "on"
+    actions:
+      - action: envisalink.invoke_custom_function
+        data:
+          partition: "1"
+          pgm: 2
+{% endexample %}
+
+{% enddetails %}
+
 {% include actions/stuck.md %}
 
 {% include actions/related.md %}

--- a/source/_actions/envisalink.invoke_custom_function.markdown
+++ b/source/_actions/envisalink.invoke_custom_function.markdown
@@ -1,0 +1,75 @@
+---
+title: "Invoke custom function"
+action: envisalink.invoke_custom_function
+domain: envisalink
+description: "Triggers a PGM output on a DSC alarm panel."
+related_actions:
+  - envisalink.alarm_keypress
+---
+
+Use this action to trigger a PGM output on a DSC alarm panel, for example to activate a relay or an auxiliary output wired to your panel.
+
+{% include actions/ui_header.md %}
+
+To trigger a PGM output from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Search for and select **Envisalink: Invoke custom function**.
+6. Enter the **Partition** and the **PGM** output number to trigger.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Partition:
+  description: The alarm panel partition to trigger the PGM output on. This is typically 1.
+  required: true
+PGM:
+  description: The PGM output number to trigger on the alarm panel (1-4).
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `envisalink.invoke_custom_function`:
+
+{% example %}
+action: |
+  action: envisalink.invoke_custom_function
+  data:
+    partition: "1"
+    pgm: 2
+{% endexample %}
+
+This triggers PGM output 2 on partition 1.
+
+### Options in YAML
+
+{% options_yaml %}
+partition:
+  description: The alarm panel partition to trigger the PGM output on. This is typically 1.
+  required: true
+  type: string
+pgm:
+  description: The PGM output number to trigger on the alarm panel (1-4).
+  required: true
+  type: integer
+{% endoptions_yaml %}
+
+## Good to know
+
+- This action only works with DSC panels.
+- You must set the alarm panel's `code` parameter in the integration configuration for this action to work.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/envisalink.markdown
+++ b/source/_integrations/envisalink.markdown
@@ -141,15 +141,11 @@ partitions:
 
 ## Actions
 
-The following actions are supported by Envisalink and can be used to script or automate the alarm.
+Envisalink alarm control panel entities support the standard [alarm control panel actions](/integrations/alarm_control_panel/), such as arming, disarming, and triggering the alarm. For example, you can use the alarm trigger action to integrate a newer Z-Wave or Zigbee sensor into a legacy alarm system through a Home Assistant automation.
 
-- **alarm_disarm**: Disarms the alarm with the user code provided, or the code specified in the configuration.
-- **alarm_arm_home**: Arms the alarm in home mode.
-- **alarm_arm_away**: Arms the alarm in standard away mode.
-- **alarm_arm_night**: Arms the alarm in night mode.
-- **alarm_trigger**: Trigger an alarm on the Envisalink connected alarm system. For example, a newer Z-Wave / Zigbee sensor can now be integrated into a legacy alarm system using a Home Assistant automation.
-- **alarm_keypress**: Sends a string of up to 6 characters to the alarm. *Works with DSC panels, and confirmed to work with Honeywell Vista-20P (aka First Alert FA-168)*
-- **invoke_custom_function**: Invokes a custom PGM function. *DSC alarms only*
+In addition, Envisalink provides the following actions:
+
+{% include integrations/actions.md %}
 
 ## Attributes
 

--- a/source/_integrations/envisalink.markdown
+++ b/source/_integrations/envisalink.markdown
@@ -139,13 +139,9 @@ partitions:
       type: string
 {% endconfiguration %}
 
-## Actions
-
-Envisalink alarm control panel entities support the standard [alarm control panel actions](/integrations/alarm_control_panel/), such as arming, disarming, and triggering the alarm. For example, you can use the alarm trigger action to integrate a newer Z-Wave or Zigbee sensor into a legacy alarm system through a Home Assistant automation.
-
-In addition, Envisalink provides the following actions:
-
 {% include integrations/actions.md %}
+
+Envisalink alarm control panel entities also support the standard [alarm control panel actions](/integrations/alarm_control_panel/), such as arming, disarming, and triggering the alarm. For example, you can use the alarm trigger action to integrate a newer Z-Wave or Zigbee sensor into a legacy alarm system through a Home Assistant automation.
 
 ## Attributes
 


### PR DESCRIPTION
## Proposed change

Migrates the inline Envisalink-specific action documentation (`envisalink.alarm_keypress` and `envisalink.invoke_custom_function`) on the Envisalink integration page to dedicated pages under `source/_actions/`, replacing the inline block with `{% include integrations/actions.md %}`. A short note keeps pointing to the standard alarm control panel actions. This aligns the Envisalink integration with the standardized action documentation structure.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

