### PR TITLE
Velbus: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/velbus.clear_cache.markdown
+++ b/source/_actions/velbus.clear_cache.markdown
@@ -1,0 +1,72 @@
+---
+title: "Clear cache"
+action: velbus.clear_cache
+domain: velbus
+description: "Clears the Velbus cache and starts a new scan."
+related_actions:
+  - velbus.sync_clock
+  - velbus.scan
+  - velbus.set_memo_text
+---
+
+Use this action to clear the Velbus cache and start a new scan. Run it when you make changes to your configuration with the VelbusLink software. You can clear the cache for a single module or for all modules.
+
+{% include actions/ui_header.md %}
+
+To clear the cache from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Search for and select **Velbus: Clear cache**.
+6. Select the **Config entry**. Optionally, enter a module **Address** to clear only that module.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Config entry:
+  description: The Velbus connection to send the command to.
+  required: true
+Address:
+  description: The module address in decimal format. When provided, only this module is cleared. When left empty, the whole cache is cleared. The decimal addresses are shown in front of the modules listed on the integration page.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `velbus.clear_cache`:
+
+{% example %}
+action: |
+  action: velbus.clear_cache
+  data:
+    config_entry: "01JGE8XB3MNPZFA836TTZ3KZ46"
+    address: 65
+{% endexample %}
+
+This clears the cache for the module with address 65 and then starts a new scan.
+
+### Options in YAML
+
+{% options_yaml %}
+config_entry:
+  description: The Velbus connection to send the command to.
+  required: true
+  type: string
+address:
+  description: The module address in decimal format. When provided, only this module is cleared. When left empty, the whole cache is cleared. The decimal addresses are shown in front of the modules listed on the integration page.
+  required: false
+  type: integer
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/velbus.scan.markdown
+++ b/source/_actions/velbus.scan.markdown
@@ -1,0 +1,64 @@
+---
+title: "Scan"
+action: velbus.scan
+domain: velbus
+description: "Scans the Velbus modules on the bus."
+related_actions:
+  - velbus.sync_clock
+  - velbus.set_memo_text
+  - velbus.clear_cache
+---
+
+Use this action to scan the Velbus modules on the bus. Run it when you see unknown module warnings in the logs or after you add new modules. This is the same as the **Scan** button in the VelbusLink software.
+
+{% include actions/ui_header.md %}
+
+To scan the bus from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Search for and select **Velbus: Scan**.
+6. Select the **Config entry** for the Velbus connection you want to use.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Config entry:
+  description: The Velbus connection to send the command to.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `velbus.scan`:
+
+{% example %}
+action: |
+  action: velbus.scan
+  data:
+    config_entry: "01JGE8XB3MNPZFA836TTZ3KZ46"
+{% endexample %}
+
+This scans the Velbus modules on the selected connection.
+
+### Options in YAML
+
+{% options_yaml %}
+config_entry:
+  description: The Velbus connection to send the command to.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/velbus.set_memo_text.markdown
+++ b/source/_actions/velbus.set_memo_text.markdown
@@ -1,0 +1,80 @@
+---
+title: "Set memo text"
+action: velbus.set_memo_text
+domain: velbus
+description: "Shows memo text on the display of Velbus modules."
+related_actions:
+  - velbus.sync_clock
+  - velbus.scan
+  - velbus.clear_cache
+---
+
+Use this action to show memo text on the display of Velbus modules like the VMBGPO, VMBGPOD, and VMBELO. Make sure the module pages are configured to display the memo text.
+
+{% include actions/ui_header.md %}
+
+To set the memo text from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Search for and select **Velbus: Set memo text**.
+6. Select the **Config entry**, enter the module **Address**, and the **Memo text** to display.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Config entry:
+  description: The Velbus connection to send the command to.
+  required: true
+Address:
+  description: The module address in decimal format. The decimal addresses are shown in front of the modules listed on the integration page.
+  required: true
+Memo text:
+  description: The text to display, limited to 64 characters. When left empty, the memo text is cleared.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `velbus.set_memo_text`:
+
+{% example %}
+action: |
+  action: velbus.set_memo_text
+  data:
+    config_entry: "01JGE8XB3MNPZFA836TTZ3KZ46"
+    address: 65
+    memo_text: "It's trash day"
+{% endexample %}
+
+This displays the text on the module with address 65.
+
+### Options in YAML
+
+{% options_yaml %}
+config_entry:
+  description: The Velbus connection to send the command to.
+  required: true
+  type: string
+address:
+  description: The module address in decimal format. The decimal addresses are shown in front of the modules listed on the integration page.
+  required: true
+  type: integer
+memo_text:
+  description: The text to display, limited to 64 characters. When left empty, the memo text is cleared.
+  required: false
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/velbus.sync_clock.markdown
+++ b/source/_actions/velbus.sync_clock.markdown
@@ -1,0 +1,64 @@
+---
+title: "Sync clock"
+action: velbus.sync_clock
+domain: velbus
+description: "Synchronizes the clock of the Velbus modules to the Home Assistant clock."
+related_actions:
+  - velbus.scan
+  - velbus.set_memo_text
+  - velbus.clear_cache
+---
+
+Use this action to synchronize the clock of your Velbus modules to the Home Assistant clock. This is the same as the **Sync clock** button in the VelbusLink software.
+
+{% include actions/ui_header.md %}
+
+To sync the clock from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Search for and select **Velbus: Sync clock**.
+6. Select the **Config entry** for the Velbus connection you want to use.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Config entry:
+  description: The Velbus connection to send the command to.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `velbus.sync_clock`:
+
+{% example %}
+action: |
+  action: velbus.sync_clock
+  data:
+    config_entry: "01JGE8XB3MNPZFA836TTZ3KZ46"
+{% endexample %}
+
+This synchronizes the clock of the Velbus modules on the selected connection.
+
+### Options in YAML
+
+{% options_yaml %}
+config_entry:
+  description: The Velbus connection to send the command to.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/velbus.markdown
+++ b/source/_integrations/velbus.markdown
@@ -169,61 +169,7 @@ vlp:
     description: "Path to the VLP file to import during re-configuration. If not provided, no VLP file will be imported and a bus scan will be performed."
 {% endconfiguration_basic %}
 
-## Actions
-- `velbus.sync clock`: Synchronize Velbus time to local clock.
-- `velbus.scan`: Scan the bus for new devices.
-- `velbus.set_memo_text`: Show memo text on Velbus display modules.
-- `velbus.clear_cache`: Clear the full velbuscache or the cache for one module only.
-
-### Action: Sync clock
-
-The `velbus.sync_clock` action synchronizes the clock of the Velbus modules to the clock of the machine running Home Assistant. This is the same as the 'sync clock' button at the VelbusLink software.
-
-| Data attribute | Optional | Description                              |
-| ---------------------- | -------- | ---------------------------------------- |
-| `config_entry`         | no       | The config_entry to send the command to. |
-
-### Action: Scan
-
-The `velbus.scan` action synchronizes the modules between the bus and Home Assistant. This is the same as the 'scan' button at the VelbusLink software.
-
-| Data attribute | Optional | Description                              |
-| ---------------------- | -------- | ---------------------------------------- |
-| `config_entry`         | no       | The config_entry to send the command to. |
-
-
-### Action: Set memo text
-
-The `velbus.set_memo_text` action provides the memo text to be displayed at Velbus modules like VMBGPO(D) and VMBELO.
-
-| Data attribute | Optional | Description                              |
-| ---------------------- | -------- | ---------------------------------------- |
-| `config_entry`         | no       | The config_entry to send the command to. |
-| `address`              | no       | The module address in decimal format, which is displayed at the device list at the integration page. |
-| `memo_text`            | yes      | Text to be displayed on module. When no memo text is supplied the memo text will be cleared. |
-
-Example:
-
-```yaml
-script:
-  trash_memo:
-    alias: "Trash memo text"
-    sequence:
-    - action: velbus.set_memo_text
-      data:
-        address: 65
-        memo_text: "It's trash day"
-        config_entry: "01JGE8XB3MNPZFA836TTZ3KZ46"
-```
-
-### Action: Clear cache
-
-The `velbus.clear_cache` action clears the cache of one module or the full cache. Once the clear happens, the integration will start a new scan. Use this action when you make changes to your configuration via velbuslink.
-
-| Data attribute | Optional | Description                              |
-| ---------------------- | -------- | ---------------------------------------- |
-| `config_entry`         | no       | The config_entry to send the command to. |
-| `address`              | no       | The module address in decimal format, which is displayed on the device list on the integration page, if provided the service will only clear the cache for this model, without an address, the full velbuscache will be cleared. |
+{% include integrations/actions.md %}
 
 ## Examples
 


### PR DESCRIPTION
## Proposed change

Migrates the inline Velbus action documentation (`velbus.sync_clock`, `velbus.scan`, `velbus.set_memo_text`, and `velbus.clear_cache`) on the Velbus integration page to dedicated pages under `source/_actions/`, replacing the inline block with `{% include integrations/actions.md %}`. This aligns the Velbus integration with the standardized action documentation structure.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

