### PR TITLE
Miele: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/miele.get_programs.markdown
+++ b/source/_actions/miele.get_programs.markdown
@@ -1,0 +1,89 @@
+---
+title: "Get the programs of a Miele appliance"
+action: miele.get_programs
+domain: miele
+description: "Returns the available programs of a Miele appliance."
+related_actions:
+  - miele.set_program
+  - miele.set_program_oven
+---
+
+Use this action to retrieve the available programs of a Miele appliance, along with their parameters. For example, you can use it to find the program ID to pass to the [Set program](/actions/miele.set_program/) action.
+
+The action returns an empty list if the appliance does not support programs, such as a freezer. The appliance must be in the same state required by the [Set program](/actions/miele.set_program/) action.
+
+This action returns its result as [response data](/docs/scripts/perform-actions#use-templates-to-handle-response-data) and does not change anything on the appliance.
+
+{% include actions/ui_header.md %}
+
+To get the programs from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Search for the action **Miele: Get programs** and select it.
+6. Select the appliance in the **Device** field.
+7. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Device:
+  description: The Miele appliance to get the programs from.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `miele.get_programs`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: miele.get_programs
+  data:
+    device_id: abcde1234567890abcde1234567890ab
+  response_variable: programs
+{% endexample %}
+
+This stores the available programs of the appliance in a variable named `programs`.
+
+### Options in YAML
+
+{% options_yaml %}
+device_id:
+  description: The ID of the Miele appliance to get the programs from.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+This action does not support targets. Select the appliance through the **Device** field.
+
+## Response data
+
+The action returns a `programs` list. Each entry has a `program_id`, a `program` name, and a `parameters` mapping. The parameters can include a `temperature` and a `duration` range, each with whether it is `mandatory`. Parameters that the program does not support are returned as empty.
+
+```yaml
+programs:
+  - program_id: 1
+    program: Cottons
+    parameters:
+      temperature:
+        min: 30
+        max: 90
+        step: 10
+        mandatory: false
+      duration:
+        min:
+          hours: 1
+          minutes: 0
+        max:
+          hours: 3
+          minutes: 0
+        mandatory: false
+```
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/miele.set_program.markdown
+++ b/source/_actions/miele.set_program.markdown
@@ -1,0 +1,69 @@
+---
+title: "Set a program on a Miele appliance"
+action: miele.set_program
+domain: miele
+description: "Sets and starts a program on a Miele appliance."
+related_actions:
+  - miele.set_program_oven
+  - miele.get_programs
+---
+
+Use this action to set and start a program on a Miele appliance, for example to start a washing machine at a scheduled time.
+
+The appliance must be in a state where it accepts a new program. Most washing machines must be turned on, and many appliances must be set to mobile start or remote control mode first. If the appliance does not accept the program, an error is shown.
+
+{% include actions/ui_header.md %}
+
+To set a program from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Search for the action **Miele: Set program** and select it.
+6. Select the appliance in the **Device** field and enter the **Program ID**.
+7. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Device:
+  description: The Miele appliance to set the program on.
+Program ID:
+  description: The ID of the program to set. To find the ID, use the [Get programs](/actions/miele.get_programs/) action, or fetch a diagnostics download while the program runs and read the value of `state.programId.value_raw`.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `miele.set_program`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: miele.set_program
+  data:
+    device_id: abcde1234567890abcde1234567890ab
+    program_id: 1
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+device_id:
+  description: The ID of the Miele appliance to set the program on.
+  required: true
+  type: string
+program_id:
+  description: The ID of the program to set. To find the ID, use the `miele.get_programs` action, or fetch a diagnostics download while the program runs and read the value of `state.programId.value_raw`.
+  required: true
+  type: integer
+{% endoptions_yaml %}
+
+This action does not support targets. Select the appliance through the **Device** field.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/miele.set_program_oven.markdown
+++ b/source/_actions/miele.set_program_oven.markdown
@@ -1,0 +1,85 @@
+---
+title: "Set a program on a Miele oven"
+action: miele.set_program_oven
+domain: miele
+description: "Sets and starts a program on a Miele oven."
+related_actions:
+  - miele.set_program
+  - miele.get_programs
+---
+
+Use this action to set and start a program on a Miele oven, optionally with a target temperature and a duration.
+
+The oven must be in a state where it accepts a new program. Most ovens must be turned on, and many appliances must be set to mobile start or remote control mode first. If the oven does not accept the program, an error is shown.
+
+{% include actions/ui_header.md %}
+
+To set an oven program from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Search for the action **Miele: Set program on oven** and select it.
+6. Select the oven in the **Device** field and enter the **Program ID**. Optionally, set a **Temperature** and a **Duration**.
+7. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Device:
+  description: The Miele oven to set the program on.
+Program ID:
+  description: The ID of the program to set. To find the ID, use the [Get programs](/actions/miele.get_programs/) action, or fetch a diagnostics download while the program runs and read the value of `state.programId.value_raw`.
+Temperature:
+  description: The target temperature for the oven program, in degrees Celsius.
+  required: false
+Duration:
+  description: The duration for the oven program.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `miele.set_program_oven`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: miele.set_program_oven
+  data:
+    device_id: abcde1234567890abcde1234567890ab
+    program_id: 1
+    temperature: 180
+    duration: "01:15:00"
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+device_id:
+  description: The ID of the Miele oven to set the program on.
+  required: true
+  type: string
+program_id:
+  description: The ID of the program to set. To find the ID, use the `miele.get_programs` action, or fetch a diagnostics download while the program runs and read the value of `state.programId.value_raw`.
+  required: true
+  type: integer
+temperature:
+  description: The target temperature for the oven program, in degrees Celsius. Between 30 and 300.
+  required: false
+  type: integer
+duration:
+  description: The duration for the oven program, in `HH:MM:SS` format. Between 1 minute and 12 hours.
+  required: false
+  type: string
+{% endoptions_yaml %}
+
+This action does not support targets. Select the oven through the **Device** field.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/miele.markdown
+++ b/source/_integrations/miele.markdown
@@ -193,37 +193,7 @@ Climate entities are used to control target temperatures in refrigerators, freez
 - **Robot vacuum cleaner**: Miele robot vacuum cleaners can be monitored and controlled to a limited extent. The device can be started, stopped, and paused. The fan speed can also be set.
 {% enddetails %}
 
-## Actions
-
-### Action `miele.set_program`
-
-Set and start a program for applicable appliances. Note that the device must be in a state where it will accept a new program, for example, most washing machines must be in state `on` and many appliances must be set manually to 'MobileStart' or 'MobileControl' in advance. An error message is displayed if the device did not accept the action command.
-The action can be set up by UI in Automations editor. It can also be executed in Developer tools.
-
-| Data attribute | Optional |  Description                                                                                                      |
-| -------------- | -------- | ----------------------------------------------------------------------------------------------------------------- |
-| `device_id`    | no       |  Select device in GUI mode, then switch to YAML mode to see the device_id.                                        |
-| `program_id`   | no       |  Enter the program_id number. The easiest way to find the number is to use the `get_programs` action from developer tools. It can also be found by fetching a diagnostic download while running the actual program. Use the value from the key  `state.programId.value_raw`.|
-
-### Action `miele.set_program_oven`
-
-Set and start a program for oven appliances. Note that the device must be in a state that will accept a new program. For example, most ovens must be in the state `on`, and many appliances must be set manually to 'MobileStart' or 'MobileControl' in advance. An error message is displayed if the device does not accept the action command.
-The action can be set up by UI in the **Automations** editor. It can also be executed in the **Developer tools**.
-
-| Data attribute | Optional |  Description                                                                                                      |
-| -------------- | -------- | ----------------------------------------------------------------------------------------------------------------- |
-| `device_id`    | no       |  Select device in GUI mode, then switch to YAML mode to see the device_id.                                        |
-| `program_id`   | no       |  Enter the program_id number. The easiest way to find the number is to use the `get_programs` action from developer tools. It can also be found by fetching a diagnostic download while running the actual program. Use the value from the key  `state.programId.value_raw`.|
-| `duration`     | yes      |  Set an optional duration for the oven program.|
-| `temperature`  | yes      |  Set an optional target temperature for the oven program.|
-
-### Action `miele.get_programs`
-
-Get the list of available programs and associated parameters for applicable appliances. The API will return an empty list if the device doesn't support programs (for example, freezers). Same requirements on device state as described for `set_program` action above.
-
-| Data attribute | Optional |  Description                                                                                                      |
-| -------------- | -------- | ----------------------------------------------------------------------------------------------------------------- |
-| `device_id`    | no       |  Select the device in GUI mode, then switch to YAML mode to see the device_id.                                        |
+{% include integrations/actions.md %}
 
 ## Automation examples
 


### PR DESCRIPTION
## Proposed change

Migrate the three Miele actions (`set_program`, `set_program_oven`, and `get_programs`) from the inline block on the integration page to dedicated action pages under `source/_actions`, and replace the inline block with the standard actions include. This brings Miele in line with the new per-action documentation structure.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

