### PR TITLE
Kodi: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/kodi.add_to_playlist.markdown
+++ b/source/_actions/kodi.add_to_playlist.markdown
@@ -78,8 +78,6 @@ artist_name:
 
 {% include actions/try_it.md %}
 
-{% include actions/more_examples.md %}
-
 {% include actions/stuck.md %}
 
 {% include actions/related.md %}

--- a/source/_actions/kodi.add_to_playlist.markdown
+++ b/source/_actions/kodi.add_to_playlist.markdown
@@ -1,0 +1,85 @@
+---
+title: "Add music to the Kodi playlist"
+action: kodi.add_to_playlist
+domain: kodi
+description: "Adds music to the default Kodi playlist."
+related_actions:
+  - kodi.call_method
+---
+
+Use this action to add music to the default Kodi playlist, for example to queue an album or all songs by an artist. You can add a specific entry by its ID, or let Kodi search its music library by name.
+
+{% include actions/ui_header.md %}
+
+To add music to the playlist from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Kodi media player.
+6. From the actions shown for that target, select **Kodi: Add to playlist**.
+7. Enter the **Media type** and the details of the music to add.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Media type:
+  description: The type of media to add. Must be `SONG` or `ALBUM`.
+Media ID:
+  description: The unique ID of the media entry to add (`songid` or `albumid`). If you leave it out, the media name and artist name are used to search the Kodi music library.
+  required: false
+Media name:
+  description: The media name to filter on. Can be `ALL` when the media type is `ALBUM` and an artist name is given, to add all songs from one artist.
+  required: false
+Artist name:
+  description: The artist name to filter on.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `kodi.add_to_playlist`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: kodi.add_to_playlist
+  target:
+    entity_id: media_player.kodi
+  data:
+    media_type: ALBUM
+    media_name: "Highway to Hell"
+    artist_name: "AC/DC"
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+media_type:
+  description: The type of media to add. Must be `SONG` or `ALBUM`.
+  required: true
+  type: string
+media_id:
+  description: The unique ID of the media entry to add (`songid` or `albumid`). If you leave it out, the media name and artist name are used to search the Kodi music library.
+  required: false
+  type: string
+media_name:
+  description: The media name to filter on. Can be `ALL` when the media type is `ALBUM` and an artist name is given, to add all songs from one artist.
+  required: false
+  type: string
+artist_name:
+  description: The artist name to filter on.
+  required: false
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="media_player" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/kodi.call_method.markdown
+++ b/source/_actions/kodi.call_method.markdown
@@ -1,0 +1,75 @@
+---
+title: "Call a Kodi JSON-RPC API method"
+action: kodi.call_method
+domain: kodi
+description: "Calls a Kodi JSON-RPC API method with optional parameters."
+related_actions:
+  - kodi.add_to_playlist
+---
+
+Use this action to call a [Kodi JSON-RPC API](https://kodi.wiki/view/JSON-RPC_API) method, for example to trigger a library scan or run an add-on. You can pass any parameters the method accepts.
+
+{% include actions/ui_header.md %}
+
+To call a method from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Kodi media player.
+6. From the actions shown for that target, select **Kodi: Call method**.
+7. Enter the **Method** and any parameters it needs.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Method:
+  description: The name of the Kodi JSON-RPC API method to call.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `kodi.call_method`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: kodi.call_method
+  target:
+    entity_id: media_player.kodi
+  data:
+    method: VideoLibrary.Scan
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+method:
+  description: The name of the Kodi JSON-RPC API method to call.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+In addition to the `method`, you can pass any parameters that the API method accepts.
+
+{% include actions/targets.md domain="media_player" %}
+
+## Good to know
+
+When the Kodi JSON-RPC API returns data, Home Assistant fires a `kodi_call_method_result` event on the event bus, which you can use as an automation trigger. The event data looks like this:
+
+```yaml
+entity_id: media_player.kodi
+result_ok: true
+input: <the input parameters of the action>
+result: <the data received from the Kodi API>
+```
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/kodi.call_method.markdown
+++ b/source/_actions/kodi.call_method.markdown
@@ -68,8 +68,6 @@ result: <the data received from the Kodi API>
 
 {% include actions/try_it.md %}
 
-{% include actions/more_examples.md %}
-
 {% include actions/stuck.md %}
 
 {% include actions/related.md %}

--- a/source/_integrations/kodi.markdown
+++ b/source/_integrations/kodi.markdown
@@ -64,40 +64,7 @@ automation:
       - action: script.kodi_turn_off
 ```
 
-### Actions
-
-#### Action `kodi.add_to_playlist`
-
-Add music to the default playlist (that is, playlistid=0).
-
-| Data attribute | Optional | Description                                                                                                                                              |
-| -------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `entity_id`    | no       | Name(s) of the Kodi entities where to add the media.                                                                                                     |
-| `media_type`   | yes      | Media type identifier. It must be one of SONG or ALBUM.                                                                                                  |
-| `media_id`     | no       | Unique Id of the media entry to add (`songid` or `albumid`). If not defined, `media_name` and `artist_name` are needed to search the Kodi music library. |
-| `media_name`   | no       | Optional media name for filtering media. Can be 'ALL' when `media_type` is 'ALBUM' and `artist_name` is specified, to add all songs from one artist.     |
-| `artist_name`  | no       | Optional artist name for filtering media.                                                                                                                |
-
-#### Action `kodi.call_method`
-
-Call a [Kodi JSON-RPC API](https://kodi.wiki/?title=JSON-RPC_API) method with optional parameters. Results of the Kodi API call will be redirected in a Home Assistant event: `kodi_call_method_result`.
-
-| Data attribute      | Optional | Description                                               |
-| ------------------- | -------- | --------------------------------------------------------- |
-| `entity_id`         | no       | Name(s) of the Kodi entities where to run the API method. |
-| `method`            | yes      | Name of the Kodi JSON-RPC API method to be called.        |
-| any other parameter | no       | Optional parameters for the Kodi API call.                |
-
-### Event triggering
-
-When calling the `kodi.call_method` action, if the Kodi JSON-RPC API returns data, when received by Home Assistant it will fire a `kodi_call_method_result` event on the event bus with the following `event_data`:
-
-```yaml
-entity_id: "<Kodi media_player entity_id>"
-result_ok: <boolean>
-input: <input parameters of the action>
-result: <data received from the Kodi API>
-```
+{% include integrations/actions.md %}
 
 ### Kodi turn on/off samples
 

--- a/source/_integrations/kodi.markdown
+++ b/source/_integrations/kodi.markdown
@@ -36,8 +36,9 @@ If you do not remove it, your configuration will be imported with the following 
 - Kodi must be on when Home Assistant is loading for the first time for the configuration to be imported.
 
 {% include integrations/actions.md %}
+## Automation examples
 
-## Turning Kodi on/off (media player action)
+### Turning Kodi on/off (media player action)
 
 You can customize your turn on and off actions through automations. Simply use the relevant Kodi device triggers and your automation will be called to perform the `turn_on` or `turn_off` sequence; see the [Kodi turn on/off samples](#kodi-turn-onoff-samples) section for scripts that can be used.
 
@@ -71,7 +72,7 @@ automation:
 
 The following scripts can be used in automations for turning on/off your Kodi instance; see [Turning on/off](#turning-onoff).  You could also simply use these sequences directly in the automations without creating scripts.
 
-### Turning on Kodi with Wake on LAN
+#### Turning on Kodi with Wake on LAN
 
 With this configuration, when calling `media_player/turn_on` on the Kodi device, a _magic packet_ will be sent to the specified MAC address. To use this action, first you need to configure the [`wake_on_lan`](/integrations/wake_on_lan) integration in Home Assistant, which is achieved simply by adding `wake_on_lan:` to your {% term "`configuration.yaml`" %}.
 

--- a/source/_integrations/kodi.markdown
+++ b/source/_integrations/kodi.markdown
@@ -40,7 +40,7 @@ If you do not remove it, your configuration will be imported with the following 
 
 ### Turning Kodi on/off (media player action)
 
-You can customize your turn on and off actions through automations. Simply use the relevant Kodi device triggers and your automation will be called to perform the `turn_on` or `turn_off` sequence; see the [Kodi turn on/off samples](#kodi-turn-onoff-samples) section for scripts that can be used.
+You can customize your turn on and off actions through automations. Simply use the relevant Kodi device triggers and your automation will be called to perform the `turn_on` or `turn_off` sequence; see the [Kodi turn on/off samples](#turning-kodi-onoff-examples) section for scripts that can be used.
 
 These automations can be configured through the UI (see [device triggers](/docs/automation/trigger/#device-triggers) for automations).  If you prefer YAML, you'll need to get the device ID from the UI automation editor. Automations would be of the form:
 

--- a/source/_integrations/kodi.markdown
+++ b/source/_integrations/kodi.markdown
@@ -35,7 +35,9 @@ If you do not remove it, your configuration will be imported with the following 
 - You may have duplicate entities.
 - Kodi must be on when Home Assistant is loading for the first time for the configuration to be imported.
 
-### Turning On/Off
+{% include integrations/actions.md %}
+
+## Turning Kodi on/off (media player action)
 
 You can customize your turn on and off actions through automations. Simply use the relevant Kodi device triggers and your automation will be called to perform the `turn_on` or `turn_off` sequence; see the [Kodi turn on/off samples](#kodi-turn-onoff-samples) section for scripts that can be used.
 
@@ -64,13 +66,12 @@ automation:
       - action: script.kodi_turn_off
 ```
 
-{% include integrations/actions.md %}
 
-### Kodi turn on/off samples
+### Turning Kodi on/off examples
 
 The following scripts can be used in automations for turning on/off your Kodi instance; see [Turning on/off](#turning-onoff).  You could also simply use these sequences directly in the automations without creating scripts.
 
-#### Turn on Kodi with Wake on LAN
+### Turning on Kodi with Wake on LAN
 
 With this configuration, when calling `media_player/turn_on` on the Kodi device, a _magic packet_ will be sent to the specified MAC address. To use this action, first you need to configure the [`wake_on_lan`](/integrations/wake_on_lan) integration in Home Assistant, which is achieved simply by adding `wake_on_lan:` to your {% term "`configuration.yaml`" %}.
 
@@ -189,7 +190,7 @@ script:
 This example and the following requires to have the [script.json-cec](https://github.com/joshjowen/script.json-cec) plugin installed on your Kodi player. It'll also expose the endpoints standby, toggle and activate without authentication on your Kodi player. Use this with caution.
 {% endimportant %}
 
-### Kodi action samples
+### Kodi action samples (media player actions)
 
 #### Simple script to turn on the PVR in some channel as a time function
 
@@ -243,7 +244,7 @@ script:
           media_content_id: special://profile/playlists/video/feuerwehrmann_sam.xsp
 ```
 
-#### Trigger a Kodi video library update
+### Triggering a Kodi video library update (Kodi action)
 
 ```yaml
 script:


### PR DESCRIPTION
## Proposed change

Migrate the two Kodi actions (`add_to_playlist` and `call_method`) from the inline block on the integration page to dedicated action pages under `source/_actions`, and replace the inline block with the standard actions include. This also corrects the `media_type` option for `add_to_playlist`, which is required by the action but was previously documented as optional. This brings Kodi in line with the new per-action documentation structure.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

