### PR TITLE
EZVIZ: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/ezviz.wake_device.markdown
+++ b/source/_actions/ezviz.wake_device.markdown
@@ -1,0 +1,81 @@
+---
+title: "Wake camera"
+action: ezviz.wake_device
+domain: ezviz
+description: "Wakes an EZVIZ camera from sleep mode."
+---
+
+Use this action to wake an EZVIZ camera that is in sleep mode. This is especially useful for battery-powered cameras, which go to sleep to save power and need to be woken before they can stream or respond.
+
+{% include actions/ui_header.md %}
+
+To wake a camera from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the area, floor, device, label, or entity you want to control.
+6. From the actions shown for that target, select **Wake camera**.
+7. Select **Save**.
+
+### Options in the UI
+
+This action has no additional options beyond the target.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `ezviz.wake_device`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: ezviz.wake_device
+  target:
+    entity_id: camera.front_door
+{% endexample %}
+
+This wakes `camera.front_door`.
+
+### Options in YAML
+
+This action has no additional YAML options beyond the target.
+
+{% include actions/targets.md domain="camera" %}
+
+## Good to know
+
+- A battery-powered camera will not report fresh data while it is asleep. Wake it first if you need an up-to-date snapshot or stream.
+- The camera returns to sleep mode on its own after a period of inactivity to preserve battery life.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: wake the camera before a snapshot
+
+Use this automation to wake a battery camera right before taking a snapshot, so the image is current.
+
+- **Trigger**: Doorbell button pressed
+- **Action**: Wake camera
+  - **Target**: Front door camera
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  - alias: "Wake the front door camera when the doorbell is pressed"
+    triggers:
+      - trigger: state
+        entity_id: binary_sensor.doorbell
+        to: "on"
+    actions:
+      - action: ezviz.wake_device
+        target:
+          entity_id: camera.front_door
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/ezviz.markdown
+++ b/source/_integrations/ezviz.markdown
@@ -72,65 +72,7 @@ You can also change the camera options should you need to access a high or low r
 
 - This only works on the camera entities.
 
-### Action `ezviz.alarm_sound`
-
-If your EZVIZ camera supports warning sounds, you can use this action to set the intensity.
-
-| Data attribute | Description                                                                                          |
-| ---------------------- | ---------------------------------------------------------------------------------------------------- |
-| `entity_id`            | String or list of strings that point at `entity_id`s of cameras. Use `entity_id: all` to target all. |
-| `level`                | Set the sound level to 0 for Soft, 1 for Intensive or 2 to disable                                   |
-
-### Action `ezviz.ptz`
-
-If your EZVIZ camera supports <abbr title="pan, tilt, and zoom">PTZ</abbr>, you will be able to pan or tilt your camera.
-
-| Data attribute | Description                                                                                          |
-| ---------------------- | ---------------------------------------------------------------------------------------------------- |
-| `entity_id`            | String or list of strings that point at `entity_id`s of cameras. Use `entity_id: all` to target all. |
-| `direction`            | Direction of the movement. Allowed values: `up`, `down`, `left`, `right`                             |
-| `speed`                | (Optional) Speed to in which to move the camera. Allowed values: int from 1 to 9. Default: 5         |
-
-### Action `ezviz.set_alarm_detection_sensibility`
-
-If your EZVIZ camera supports motion detection, you will be able to set the sensitivity level using this action.
-
-| Data attribute | Description                                                                                          |
-| ---------------------- | ---------------------------------------------------------------------------------------------------- |
-| `entity_id`            | String or list of strings that point at `entity_id`s of cameras. Use `entity_id: all` to target all. |
-| `level`                | Sensibility level (1-6) for type 0 (Normal camera) or (1-100) for type 3 (PIR sensor camera).        |
-| `type_value`           | Type of detection. Options : 0 - Camera or 3 - PIR Sensor Camera.                                    |
-
-### Action `ezviz.sound_alarm`
-
-If your EZVIZ camera has a built-in siren, you can use this action to make a noise.
-
-| Data attribute | Description                                                                                          |
-| ---------------------- | ---------------------------------------------------------------------------------------------------- |
-| `entity_id`            | String or list of strings that point at `entity_id`s of cameras. Use `entity_id: all` to target all. |
-| `enable`               | Sound the alarm by setting this to 1 or stop the siren by setting this to 0.                         |
-
-### Action `ezviz.wake_device`
-
-If you have "sleep" mode enabled on your camera, you can use this action to wake it. Especially useful for battery cameras.
-
-| Data attribute | Description                                                                                          |
-| ---------------------- | ---------------------------------------------------------------------------------------------------- |
-| `entity_id`            | String or list of strings that point at `entity_id`s of cameras. Use `entity_id: all` to target all. |
-
-To enable/disable motion detection, use the Home Assistant built in actions. 
-
-### Action `camera.enable_motion_detection`
-
-| Data attribute | Description                                                                                          |
-| ---------------------- | ---------------------------------------------------------------------------------------------------- |
-| `entity_id`            | String or list of strings that point at `entity_id`s of cameras. Use `entity_id: all` to target all. |
-
-### Action `camera.disable_motion_detection`
-
-| Data attribute | Description                                                                                          |
-| ---------------------- | ---------------------------------------------------------------------------------------------------- |
-| `entity_id`            | String or list of strings that point at `entity_id`s of cameras. Use `entity_id: all` to target all. |
+{% include integrations/actions.md %}
 
 ### Alarm control panel entity
 

--- a/source/_integrations/ezviz.markdown
+++ b/source/_integrations/ezviz.markdown
@@ -72,8 +72,6 @@ You can also change the camera options should you need to access a high or low r
 
 - This only works on the camera entities.
 
-{% include integrations/actions.md %}
-
 ### Alarm control panel entity
 
 The Alarm control panel entity in the EZVIZ platform allows users to manage and control the armed status of all their EZVIZ devices. With this entity, users can choose between three options: **Arm Away**, **Arm Sleep**, and **Disarm**.
@@ -118,6 +116,8 @@ A light entity will be added to cameras + light combos. You can turn it on/off a
 ### Image entity
 
 The image entity represents the last detected event from a camera and visually represents the event within Home Assistant.
+
+{% include integrations/actions.md %}
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Proposed change

Migrate the EZVIZ `wake_device` action from the inline block on the integration page to a dedicated action page under `source/_actions`, and replace the inline block with the standard actions include.

This also removes the documentation for the `alarm_sound`, `ptz`, `sound_alarm`, and `set_alarm_detection_sensibility` actions, which no longer exist in the integration. The first three were replaced by dedicated entities (a select, a siren, and PTZ buttons), and `set_alarm_detection_sensibility` was removed from core in favor of the detection sensitivity number entity. The generic `camera.enable_motion_detection` and `camera.disable_motion_detection` references are dropped as well, since those belong to the camera platform rather than EZVIZ.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

