### PR TITLE
Nuki Bridge: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/nuki.lock_n_go.markdown
+++ b/source/_actions/nuki.lock_n_go.markdown
@@ -1,0 +1,92 @@
+---
+title: "Lock 'n' Go"
+action: nuki.lock_n_go
+domain: nuki
+description: "Unlocks a Nuki lock, waits a few seconds, then locks it again."
+related_actions:
+  - nuki.set_continuous_mode
+---
+
+Use this action to unlock a Nuki Smart Lock, let it stay open for a short moment, then automatically lock it again. This is handy for letting someone in without leaving the door unlocked. The wait period (20 seconds by default) is set in the Nuki app.
+
+{% include actions/ui_header.md %}
+
+To run Lock 'n' Go from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the area, floor, device, label, or entity you want to control.
+6. From the actions shown for that target, select **Lock 'n' Go**.
+7. To also pull the latch open when unlocking, turn on **Unlatch**.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Unlatch:
+  description: "Whether to also unlatch the door when unlocking it. The default is off."
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `nuki.lock_n_go`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: nuki.lock_n_go
+  target:
+    entity_id: lock.front_door
+{% endexample %}
+
+This runs Lock 'n' Go on `lock.front_door`.
+
+### Options in YAML
+
+{% options_yaml %}
+unlatch:
+  description: "Whether to also unlatch the door when unlocking it."
+  required: false
+  type: boolean
+  default: false
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="lock" %}
+
+## Good to know
+
+- Adjust the wait time between unlocking and re-locking in the Nuki app.
+- Unlatching pulls the door latch open. Only enable it if your installation supports it and you want the door to swing free.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: let a guest in with a single button
+
+Use this automation to run Lock 'n' Go when you press a dashboard button, so a visitor can come in without the door staying unlocked.
+
+- **Trigger**: Guest entry button pressed
+- **Action**: Lock 'n' Go
+  - **Target**: Front door lock
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  - alias: "Let a guest in with Lock 'n' Go"
+    triggers:
+      - trigger: state
+        entity_id: input_button.guest_entry
+    actions:
+      - action: nuki.lock_n_go
+        target:
+          entity_id: lock.front_door
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/nuki.set_continuous_mode.markdown
+++ b/source/_actions/nuki.set_continuous_mode.markdown
@@ -1,0 +1,97 @@
+---
+title: "Set continuous mode"
+action: nuki.set_continuous_mode
+domain: nuki
+description: "Enables or disables continuous mode on a Nuki Opener."
+related_actions:
+  - nuki.lock_n_go
+---
+
+Use this action to turn continuous mode on or off for a Nuki Opener. Continuous mode is similar to the Ring-to-Open feature, but without a time limit. While it is enabled, the door opens whenever the buzzer button is pressed, like at a doctor's office or a business during opening hours. On other Nuki products, this action does nothing.
+
+{% include actions/ui_header.md %}
+
+To set continuous mode from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the area, floor, device, label, or entity you want to control.
+6. From the actions shown for that target, select **Set continuous mode**.
+7. Turn **Enable** on to enable continuous mode, or leave it off to disable it.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Enable:
+  description: "Turn on to enable continuous mode, or leave off to disable it."
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `nuki.set_continuous_mode`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: nuki.set_continuous_mode
+  target:
+    entity_id: lock.front_door_opener
+  data:
+    enable: true
+{% endexample %}
+
+This enables continuous mode on `lock.front_door_opener`.
+
+### Options in YAML
+
+{% options_yaml %}
+enable:
+  description: "Whether to enable or disable continuous mode."
+  required: true
+  type: boolean
+  default: false
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="lock" %}
+
+## Good to know
+
+- Continuous mode only applies to the Nuki Opener. Running this action on other Nuki devices has no effect.
+- Unlike Ring-to-Open, continuous mode stays active until you disable it, so remember to turn it off when you no longer want the door to open on the buzzer.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: enable continuous mode during office hours
+
+Use this automation to enable continuous mode every morning and disable it again in the evening, so visitors can come in while you're open.
+
+- **Trigger**: Time: 09:00
+- **Action**: Set continuous mode
+  - **Target**: Front door opener
+  - **Enable**: On
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  - alias: "Enable continuous mode during office hours"
+    triggers:
+      - trigger: time
+        at: "09:00:00"
+    actions:
+      - action: nuki.set_continuous_mode
+        target:
+          entity_id: lock.front_door_opener
+        data:
+          enable: true
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/nuki.set_continuous_mode.markdown
+++ b/source/_actions/nuki.set_continuous_mode.markdown
@@ -49,7 +49,7 @@ This enables continuous mode on `lock.front_door_opener`.
 {% options_yaml %}
 enable:
   description: "Whether to enable or disable continuous mode."
-  required: true
+  required: false
   type: boolean
   default: false
 {% endoptions_yaml %}

--- a/source/_integrations/nuki.markdown
+++ b/source/_integrations/nuki.markdown
@@ -40,26 +40,7 @@ Use an encrypted token for authentication:
   description: Use an encrypted token for API calls to the bridge. This should only be deactivated if you experience issues with the API (authentication, etc). The default is `True`.
 {% endconfiguration_basic %}
 
-## Actions
-
-### Action `nuki.lock_n_go`
-
-This will first unlock, wait a few seconds (20 by default) then re-lock. The wait period can be customized through the app.
-See the [Nuki Website](https://nuki.io/en/support/smart-lock/sl-features/locking-with-the-smart-lock/) for more details about this feature.
-
-| Data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `entity_id` | yes | String or list of strings that point at `entity_id`s Nuki Locks.
-| `unlatch` | yes | Boolean - Whether to unlatch the door when first opening it.
-
-### Action `nuki.set_continuous_mode`
-
-This action allows you to enable or disable the "Continuous Mode" feature of Nuki Openers. This is similar to the Ring-to-Open feature that is mapped to "lock/unlock", except that it doesn't have a time limit - as long as this mode is enabled, the door will open when the buzzer button is pressed, similar to how it works at e.g. a doctor's office or other business during the day. On other Nuki products, this action is a no-op.
-
-| Data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `entity_id` | yes | String or list of strings that point at `entity_id`s Nuki Locks.
-| `enabled` | yes | Boolean - Set to `true` to enable Continuous Mode, or `false` to disable.
+{% include integrations/actions.md %}
 
 ## Events
 


### PR DESCRIPTION
## Proposed change

Migrate the two Nuki actions (`lock_n_go` and `set_continuous_mode`) from the inline block on the integration page to dedicated action pages under `source/_actions`, and replace the inline block with the standard actions include.

This also corrects the `set_continuous_mode` field name, which was documented as `enabled` but is actually `enable`.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

