### PR TITLE
Total Connect: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/totalconnect.arm_away_instant.markdown
+++ b/source/_actions/totalconnect.arm_away_instant.markdown
@@ -47,7 +47,7 @@ This action has no additional YAML options beyond the target.
 ## Good to know
 
 - With zero entry delay, there is no grace period to disarm. The alarm triggers immediately if an entry or exit zone opens while armed.
-- For a normal entry delay, use the standard arm away action instead.
+- For a normal entry delay, use [Arm alarm away](/actions/alarm_control_panel.alarm_arm_away/) instead.
 
 {% include actions/try_it.md %}
 

--- a/source/_actions/totalconnect.arm_away_instant.markdown
+++ b/source/_actions/totalconnect.arm_away_instant.markdown
@@ -1,0 +1,83 @@
+---
+title: "Arm away instant"
+action: totalconnect.arm_away_instant
+domain: totalconnect
+description: "Arms the alarm panel in away mode with zero entry delay."
+related_actions:
+  - totalconnect.arm_home_instant
+---
+
+Use this action to arm your Total Connect alarm panel in away mode with no entry delay. With zero entry delay, the alarm sounds instantly if an entry or exit zone is faulted, instead of giving you time to disarm. This is equivalent to "arm away instant" on most alarm panels.
+
+{% include actions/ui_header.md %}
+
+To arm away instant from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the area, floor, device, label, or entity you want to control.
+6. From the actions shown for that target, select **Arm away instant**.
+7. Select **Save**.
+
+### Options in the UI
+
+This action has no additional options beyond the target.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `totalconnect.arm_away_instant`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: totalconnect.arm_away_instant
+  target:
+    entity_id: alarm_control_panel.home
+{% endexample %}
+
+This arms `alarm_control_panel.home` in away mode with zero entry delay.
+
+### Options in YAML
+
+This action has no additional YAML options beyond the target.
+
+{% include actions/targets.md domain="alarm_control_panel" %}
+
+## Good to know
+
+- With zero entry delay, there is no grace period to disarm. The alarm triggers immediately if an entry or exit zone opens while armed.
+- For a normal entry delay, use the standard arm away action instead.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: arm away instant when everyone leaves
+
+Use this automation to arm the panel in away mode with no entry delay once the last person leaves home.
+
+- **Trigger**: Everyone leaves the home zone
+- **Action**: Arm away instant
+  - **Target**: Home alarm panel
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  - alias: "Arm away instant when everyone leaves"
+    triggers:
+      - trigger: state
+        entity_id: zone.home
+        to: "0"
+    actions:
+      - action: totalconnect.arm_away_instant
+        target:
+          entity_id: alarm_control_panel.home
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/totalconnect.arm_away_instant.markdown
+++ b/source/_actions/totalconnect.arm_away_instant.markdown
@@ -61,11 +61,11 @@ Use this automation to arm the panel in away mode with no entry delay once the l
 - **Action**: Arm away instant
   - **Target**: Home alarm panel
 
-{% details "Show example YAML" %}
+{% details "YAML example for arming away instant when everyone leaves" %}
 
 {% example %}
 automation: |
-  - alias: "Arm away instant when everyone leaves"
+    alias: "Arm away instant when everyone leaves"
     triggers:
       - trigger: state
         entity_id: zone.home

--- a/source/_actions/totalconnect.arm_home_instant.markdown
+++ b/source/_actions/totalconnect.arm_home_instant.markdown
@@ -61,11 +61,11 @@ Use this automation to arm the panel in home mode with no entry delay every even
 - **Action**: Arm home instant
   - **Target**: Home alarm panel
 
-{% details "Show example YAML" %}
+{% details "YAML example for arming home instant at sunset" %}
 
 {% example %}
 automation: |
-  - alias: "Arm home instant at sunset"
+    alias: "Arm home instant at sunset"
     triggers:
       - trigger: sun
         event: sunset

--- a/source/_actions/totalconnect.arm_home_instant.markdown
+++ b/source/_actions/totalconnect.arm_home_instant.markdown
@@ -1,0 +1,82 @@
+---
+title: "Arm home instant"
+action: totalconnect.arm_home_instant
+domain: totalconnect
+description: "Arms the alarm panel in home mode with zero entry delay."
+related_actions:
+  - totalconnect.arm_away_instant
+---
+
+Use this action to arm your Total Connect alarm panel in home mode with no entry delay. With zero entry delay, the alarm sounds instantly if an entry or exit zone is faulted, instead of giving you time to disarm. This is equivalent to "arm stay instant" on most alarm panels.
+
+{% include actions/ui_header.md %}
+
+To arm home instant from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the area, floor, device, label, or entity you want to control.
+6. From the actions shown for that target, select **Arm home instant**.
+7. Select **Save**.
+
+### Options in the UI
+
+This action has no additional options beyond the target.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `totalconnect.arm_home_instant`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: totalconnect.arm_home_instant
+  target:
+    entity_id: alarm_control_panel.home
+{% endexample %}
+
+This arms `alarm_control_panel.home` in home mode with zero entry delay.
+
+### Options in YAML
+
+This action has no additional YAML options beyond the target.
+
+{% include actions/targets.md domain="alarm_control_panel" %}
+
+## Good to know
+
+- With zero entry delay, there is no grace period to disarm. The alarm triggers immediately if an entry or exit zone opens while armed.
+- For a normal entry delay, use the standard arm home action instead.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: arm home instant at sunset
+
+Use this automation to arm the panel in home mode with no entry delay every evening at sunset.
+
+- **Trigger**: Sun: sunset
+- **Action**: Arm home instant
+  - **Target**: Home alarm panel
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  - alias: "Arm home instant at sunset"
+    triggers:
+      - trigger: sun
+        event: sunset
+    actions:
+      - action: totalconnect.arm_home_instant
+        target:
+          entity_id: alarm_control_panel.home
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/totalconnect.arm_home_instant.markdown
+++ b/source/_actions/totalconnect.arm_home_instant.markdown
@@ -47,7 +47,7 @@ This action has no additional YAML options beyond the target.
 ## Good to know
 
 - With zero entry delay, there is no grace period to disarm. The alarm triggers immediately if an entry or exit zone opens while armed.
-- For a normal entry delay, use the standard arm home action instead.
+- For a normal entry delay, use [Arm alarm home](/actions/alarm_control_panel.alarm_arm_home/) instead.
 
 {% include actions/try_it.md %}
 

--- a/source/_integrations/totalconnect.markdown
+++ b/source/_integrations/totalconnect.markdown
@@ -72,25 +72,9 @@ Home Assistant device class `door` is assigned to Total Connect entry/exit, peri
 
 The integration provides a bypass button for each zone that can be bypassed. The **Bypass All** button for the alarm panel will bypass all faulted or troubled zones. The **Clear Bypass** button for the alarm panel will clear all bypassed zones.
 
-## Actions
+The alarm control panel supports the standard alarm actions, such as arm away, arm home, arm night, and disarm. In addition, Total Connect provides the following actions.
 
-The alarm control panel supports the following basic actions: `alarm_arm_away`, `alarm_arm_home`, `alarm_arm_night`, and `alarm_disarm`.
-
-### Action: Arm home instant
-
-The `totalconnect.arm_home_instant` action puts the alarm panel in "arm home" with zero entry delay, triggering the alarm instantly if an entry/exit zone is faulted. This is equivalent to "arm stay instant" in most alarm panels.
-
-| Data attribute         | Optional | Description                                          |
-|------------------------|----------|------------------------------------------------------|
-| `entity_id`            | No       | The ID of the alarm panel to arm.                    |
-
-### Action: Arm away instant
-
-The `totalconnect.arm_away_instant` action puts the alarm panel in "arm away" with zero entry delay, triggering the alarm instantly if an entry/exit zone is faulted. This is equivalent to "arm away instant" in most alarm panels.
-
-| Data attribute         | Optional | Description                                          |
-|------------------------|----------|------------------------------------------------------|
-| `entity_id`            | No       | The ID of the alarm panel to arm.                    |
+{% include integrations/actions.md %}
 
 ## Diagnostic Sensors
 

--- a/source/_integrations/totalconnect.markdown
+++ b/source/_integrations/totalconnect.markdown
@@ -72,7 +72,6 @@ Home Assistant device class `door` is assigned to Total Connect entry/exit, peri
 
 The integration provides a bypass button for each zone that can be bypassed. The **Bypass All** button for the alarm panel will bypass all faulted or troubled zones. The **Clear Bypass** button for the alarm panel will clear all bypassed zones.
 
-The alarm control panel supports the standard alarm actions, such as arm away, arm home, arm night, and disarm. In addition, Total Connect provides the following actions.
 
 {% include integrations/actions.md %}
 


### PR DESCRIPTION
## Proposed change

Migrate the two Total Connect actions (`arm_home_instant` and `arm_away_instant`) from the inline block on the integration page to dedicated action pages under `source/_actions`, and replace the inline block with the standard actions include.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

