### PR TITLE
Fully Kiosk Browser: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/fully_kiosk.load_url.markdown
+++ b/source/_actions/fully_kiosk.load_url.markdown
@@ -1,0 +1,70 @@
+---
+title: "Load URL"
+action: fully_kiosk.load_url
+domain: fully_kiosk
+description: "Loads a URL on Fully Kiosk Browser."
+related_actions:
+  - fully_kiosk.set_config
+  - fully_kiosk.start_application
+---
+
+The **Load URL** action tells Fully Kiosk Browser to open a specific web address on your device.
+
+{% include actions/ui_header.md %}
+
+To load a URL from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create** to start a new one.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Fully Kiosk Browser: Load URL**.
+6. Select the **Device ID** to load the URL on.
+7. Enter the **URL** to load.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Device ID:
+  description: The device running Fully Kiosk Browser to load the URL on.
+  required: true
+URL:
+  description: The URL to load.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `fully_kiosk.load_url`:
+
+{% example %}
+action: |
+  action: fully_kiosk.load_url
+  data:
+    device_id: a674c90eca95eca91f6020415de07713
+    url: "https://www.home-assistant.io"
+{% endexample %}
+
+This opens the Home Assistant website on the selected device.
+
+### Options in YAML
+
+{% options_yaml %}
+device_id:
+  description: The device running Fully Kiosk Browser to load the URL on.
+  required: true
+  type: string
+url:
+  description: The URL to load.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/fully_kiosk.load_url.markdown
+++ b/source/_actions/fully_kiosk.load_url.markdown
@@ -8,7 +8,7 @@ related_actions:
   - fully_kiosk.start_application
 ---
 
-The **Load URL** action tells Fully Kiosk Browser to open a specific web address on your device.
+This action tells Fully Kiosk Browser to open a specific web address on your device.
 
 {% include actions/ui_header.md %}
 
@@ -62,8 +62,6 @@ url:
 {% endoptions_yaml %}
 
 {% include actions/try_it.md %}
-
-{% include actions/more_examples.md %}
 
 {% include actions/stuck.md %}
 

--- a/source/_actions/fully_kiosk.set_config.markdown
+++ b/source/_actions/fully_kiosk.set_config.markdown
@@ -1,0 +1,80 @@
+---
+title: "Set configuration"
+action: fully_kiosk.set_config
+domain: fully_kiosk
+description: "Sets a configuration parameter on Fully Kiosk Browser."
+related_actions:
+  - fully_kiosk.load_url
+  - fully_kiosk.start_application
+---
+
+The **Set configuration** action changes one of the many configuration parameters of Fully Kiosk Browser on your device.
+
+You can find the list of available keys in the Fully Kiosk Browser remote admin panel by selecting the **Show keys** button.
+
+{% include actions/ui_header.md %}
+
+To set a configuration parameter from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create** to start a new one.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Fully Kiosk Browser: Set configuration**.
+6. Select the **Device ID** to change the parameter on.
+7. Enter the **Key** and the **Value** to set.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Device ID:
+  description: The device running Fully Kiosk Browser to change the parameter on.
+  required: true
+Key:
+  description: The configuration parameter to set.
+  required: true
+Value:
+  description: The value to set the configuration parameter to.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `fully_kiosk.set_config`:
+
+{% example %}
+action: |
+  action: fully_kiosk.set_config
+  data:
+    device_id: a674c90eca95eca91f6020415de07713
+    key: "motionSensitivity"
+    value: "90"
+{% endexample %}
+
+This sets the motion sensitivity to `90` on the selected device.
+
+### Options in YAML
+
+{% options_yaml %}
+device_id:
+  description: The device running Fully Kiosk Browser to change the parameter on.
+  required: true
+  type: string
+key:
+  description: The configuration parameter to set.
+  required: true
+  type: string
+value:
+  description: The value to set the configuration parameter to.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/fully_kiosk.set_config.markdown
+++ b/source/_actions/fully_kiosk.set_config.markdown
@@ -8,7 +8,7 @@ related_actions:
   - fully_kiosk.start_application
 ---
 
-The **Set configuration** action changes one of the many configuration parameters of Fully Kiosk Browser on your device.
+This action changes one of the many configuration parameters of Fully Kiosk Browser on your device.
 
 You can find the list of available keys in the Fully Kiosk Browser remote admin panel by selecting the **Show keys** button.
 
@@ -72,8 +72,6 @@ value:
 {% endoptions_yaml %}
 
 {% include actions/try_it.md %}
-
-{% include actions/more_examples.md %}
 
 {% include actions/stuck.md %}
 

--- a/source/_actions/fully_kiosk.start_application.markdown
+++ b/source/_actions/fully_kiosk.start_application.markdown
@@ -8,7 +8,7 @@ related_actions:
   - fully_kiosk.set_config
 ---
 
-The **Start application** action launches an Android app on the device running Fully Kiosk Browser.
+This action launches an Android app on the device running Fully Kiosk Browser.
 
 You refer to the app by its package name, for example `de.ozerov.fully` for Fully Kiosk Browser itself.
 
@@ -64,8 +64,6 @@ application:
 {% endoptions_yaml %}
 
 {% include actions/try_it.md %}
-
-{% include actions/more_examples.md %}
 
 {% include actions/stuck.md %}
 

--- a/source/_actions/fully_kiosk.start_application.markdown
+++ b/source/_actions/fully_kiosk.start_application.markdown
@@ -1,0 +1,72 @@
+---
+title: "Start application"
+action: fully_kiosk.start_application
+domain: fully_kiosk
+description: "Starts an application on the device running Fully Kiosk Browser."
+related_actions:
+  - fully_kiosk.load_url
+  - fully_kiosk.set_config
+---
+
+The **Start application** action launches an Android app on the device running Fully Kiosk Browser.
+
+You refer to the app by its package name, for example `de.ozerov.fully` for Fully Kiosk Browser itself.
+
+{% include actions/ui_header.md %}
+
+To start an application from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create** to start a new one.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Fully Kiosk Browser: Start application**.
+6. Select the **Device ID** to start the application on.
+7. Enter the **Application** package name to start.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Device ID:
+  description: The device running Fully Kiosk Browser to start the application on.
+  required: true
+Application:
+  description: The package name of the application to start.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `fully_kiosk.start_application`:
+
+{% example %}
+action: |
+  action: fully_kiosk.start_application
+  data:
+    device_id: a674c90eca95eca91f6020415de07713
+    application: "de.ozerov.fully"
+{% endexample %}
+
+This launches the Fully Kiosk Browser app on the selected device.
+
+### Options in YAML
+
+{% options_yaml %}
+device_id:
+  description: The device running Fully Kiosk Browser to start the application on.
+  required: true
+  type: string
+application:
+  description: The package name of the application to start.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/fully_kiosk.markdown
+++ b/source/_integrations/fully_kiosk.markdown
@@ -99,66 +99,7 @@ The following notify entities that can be passed to `notify.send_message` action
 The Fully Kiosk Browser app does not provide feedback on the device volume or media playback status, so we are unable to display the current volume level or playback status.
 {% endnote %}
 
-## Actions
-
-**Action `load_url`**
-
-You can use the `fully_kiosk.load_url` action to have the tablet open the specified URL.
-
-| Data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `device_id` | yes | Device ID (or list of device IDs) to load the URL on.
-| `url` | yes | The URL to load.
-
-Example:
-
-```yaml
-action: fully_kiosk.load_url
-data:
-  url: "https://home-assistant.io"
-target:
-  device_id: a674c90eca95eca91f6020415de07713
-```
-
-**Action `set_config`**
-
-You can use the `fully_kiosk.set_config` action to change the many configuration parameters of Fully Kiosk Browser.
-
-| Data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `device_id` | no | Device ID (or list of device IDs) to load the URL on.
-| `key` | no | The configuration parameter key. The list of available keys can be found in the Fully Kiosk Browser remote admin panel by clicking the **Show keys** button.
-| `value` | no | The value to set the configuration parameter to.
-
-Example:
-
-```yaml
-action: fully_kiosk.set_config
-data:
-  key: "startURL"
-  value: "https://home-assistant.io"
-target:
-  device_id: a674c90eca95eca91f6020415de07713
-```
-
-**Action `start_application`**
-
-You can use the `fully_kiosk.start_application` action to have the tablet launch the specified app.
-
-| Data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `device_id` | yes | Device ID (or list of device IDs) to load the URL on.
-| `application` | yes | The package name of the app to load.
-
-Example:
-
-```yaml
-action: fully_kiosk.start_application
-data:
-  application: "de.ozerov.fully"
-target:
-  device_id: a674c90eca95eca91f6020415de07713
-```
+{% include integrations/actions.md %}
 
 ## Removing the integration
 


### PR DESCRIPTION
## Proposed change

Migrate the three Fully Kiosk Browser actions (`load_url`, `set_config`, and `start_application`) from the inline blocks on the integration page to dedicated action pages under `source/_actions`, and replace the inline blocks with the standard actions include.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

