### PR TITLE
Immich: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/immich.upload_file.markdown
+++ b/source/_actions/immich.upload_file.markdown
@@ -88,7 +88,7 @@ album_id:
 
 ### Script: upload a camera snapshot
 
-Take a snapshot of a camera entity with the [`camera.snapshot`](/integrations/camera/) action, store it using a [local media](/integrations/media_source/#local-media) path, then upload it to a specific album in your Immich instance.
+Take a snapshot of a camera entity with the [`camera.snapshot`](/actions/camera.snapshot) action, store it using a [local media](/integrations/media_source/#local-media) path, then upload it to a specific album in your Immich instance.
 
 {% details "YAML example for uploading a camera snapshot" %}
 

--- a/source/_actions/immich.upload_file.markdown
+++ b/source/_actions/immich.upload_file.markdown
@@ -1,0 +1,91 @@
+---
+title: "Upload file"
+action: immich.upload_file
+domain: immich
+description: "Uploads a file to your Immich instance."
+---
+
+The **Upload file** action sends a media file, such as a photo or video, to your Immich instance. Optionally, you can place the uploaded file directly into one of your albums.
+
+{% include actions/ui_header.md %}
+
+To upload a file from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create** to start a new one.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Immich: Upload file**.
+6. Select the **Immich instance** to upload to.
+7. Select the **File** to upload.
+8. Optionally, enter an **Album ID** to place the file in a specific album.
+9. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Immich instance:
+  description: The Immich instance to upload the file to.
+  required: true
+File:
+  description: The media file to upload.
+  required: true
+Album ID:
+  description: >
+    The album to place the file in after uploading. To find the album ID, open
+    the album in the Immich web interface. The ID is the last part of the URL,
+    `https://your-immich-instance/albums/<ALBUM-ID>`.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `immich.upload_file`:
+
+{% example %}
+action: |
+  action: immich.upload_file
+  data:
+    config_entry_id: 01JVJ0RA387MWA938VE8HGXBMJ
+    file:
+      media_content_id: "media-source://media_source/local/photo.jpg"
+      media_content_type: "image/jpeg"
+    album_id: f2de0ede-d7d4-4db3-afe3-7288f4e65bb1
+{% endexample %}
+
+This uploads a local photo to the selected Immich instance and places it in the given album.
+
+### Options in YAML
+
+{% options_yaml %}
+config_entry_id:
+  description: The Immich instance to upload the file to.
+  required: true
+  type: string
+file:
+  description: The media file to upload.
+  required: true
+  type: map
+  keys:
+    media_content_id:
+      description: The media source URL of the file to upload.
+      type: string
+    media_content_type:
+      description: The MIME type of the file to upload, for example `image/jpeg`.
+      type: string
+album_id:
+  description: >
+    The album to place the file in after uploading. To find the album ID, open
+    the album in the Immich web interface. The ID is the last part of the URL,
+    `https://your-immich-instance/albums/<ALBUM-ID>`.
+  required: false
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/immich.upload_file.markdown
+++ b/source/_actions/immich.upload_file.markdown
@@ -86,6 +86,33 @@ album_id:
 
 {% include actions/more_examples.md %}
 
+### Script: upload a camera snapshot
+
+Take a snapshot of a camera entity with the [`camera.snapshot`](/integrations/camera/) action, store it using a [local media](/integrations/media_source/#local-media) path, then upload it to a specific album in your Immich instance.
+
+{% details "YAML example for uploading a camera snapshot" %}
+
+{% example %}
+script: |
+  sequence:
+    - variables:
+        file_name: camera.yourcamera_{{ now().strftime("%Y%m%d-%H%M%S") }}.jpg
+    - action: camera.snapshot
+      data:
+        filename: "/media/{{ file_name }}"
+      target:
+        entity_id: camera.yourcamera
+    - action: immich.upload_file
+      data:
+        config_entry_id: 01JVJ0RA387MWA938VE8HGXBMJ
+        file:
+          media_content_id: "media-source://media_source/local/{{ file_name }}"
+          media_content_type: "image/jpeg"
+        album_id: f2de0ede-d7d4-4db3-afe3-7288f4e65bb1
+{% endexample %}
+
+{% enddetails %}
+
 {% include actions/stuck.md %}
 
 {% include actions/related.md %}

--- a/source/_actions/immich.upload_file.markdown
+++ b/source/_actions/immich.upload_file.markdown
@@ -46,11 +46,11 @@ In YAML, refer to this action as `immich.upload_file`:
 action: |
   action: immich.upload_file
   data:
-    config_entry_id: 01JVJ0RA387MWA938VE8HGXBMJ
+    config_entry_id: YOUR_CONFIG_ENTRY_ID
     file:
       media_content_id: "media-source://media_source/local/photo.jpg"
       media_content_type: "image/jpeg"
-    album_id: f2de0ede-d7d4-4db3-afe3-7288f4e65bb1
+    album_id: YOUR_ALBUM_ID
 {% endexample %}
 
 This uploads a local photo to the selected Immich instance and places it in the given album.

--- a/source/_integrations/immich.markdown
+++ b/source/_integrations/immich.markdown
@@ -86,29 +86,13 @@ The following {% term sensors %} are created. For some of those the API key need
 
 An {% term update %} entity is created to inform about a new available Immich server version (_requires Immich server v1.134.0_).
 
-## Actions
+{% include integrations/actions.md %}
 
-### Upload file
+## Examples
 
-This action allows you to upload a media file to your Immich instance. It takes the following arguments:
+### Upload a camera snapshot
 
-{% configuration_basic %}
-Immich instance:
-  description: The config entry of the Immich instance where to upload the file.
-File:
-  description: Use the [MediaSelector](/docs/blueprint/selectors/#media-selector) to define the file to be uploaded.
-  keys:
-    media_content_id:
-      description: The [media source](/integrations/media_source) URL.
-    media_content_type:
-      description: The MIME type of the file to be uploaded.
-Album ID:
-  description: The album in which the file should be placed after uploading. To get the album ID, open the Immich instance web UI in a browser and navigate to the corresponding album, the album ID can now be found in the URL `https://your-immich-instance/albums/<ALBUM-ID>`
-{% endconfiguration_basic %}
-
-#### Example script
-
-Take a snapshot of a camera entity via the [`camera.snapshot`](/integrations/camera/#action-snapshot) action, use the [local media](/integrations/media_source/#local-media) path to store the snapshot and upload it to the Immich instance in a specific album.
+Take a snapshot of a camera entity with the [`camera.snapshot`](/integrations/camera/) action, store it using a [local media](/integrations/media_source/#local-media) path, then upload it to a specific album in your Immich instance.
 
 ```yaml
 sequence:

--- a/source/_integrations/immich.markdown
+++ b/source/_integrations/immich.markdown
@@ -88,30 +88,6 @@ An {% term update %} entity is created to inform about a new available Immich se
 
 {% include integrations/actions.md %}
 
-## Examples
-
-### Upload a camera snapshot
-
-Take a snapshot of a camera entity with the [`camera.snapshot`](/integrations/camera/) action, store it using a [local media](/integrations/media_source/#local-media) path, then upload it to a specific album in your Immich instance.
-
-```yaml
-sequence:
-  - variables:
-      file_name: camera.yourcamera_{{ now().strftime("%Y%m%d-%H%M%S") }}.jpg
-  - action: camera.snapshot
-    data:
-      filename: "/media/{{ file_name }}"
-    target:
-      entity_id: camera.yourcamera
-  - action: immich.upload_file
-    data:
-      config_entry_id: 01JVJ0RA387MWA938VE8HGXBMJ
-      file:
-        media_content_id: "media-source://media_source/local/{{ file_name }}"
-        media_content_type: "image/jpeg"
-      album_id: f2de0ede-d7d4-4db3-afe3-7288f4e65bb1
-```
-
 ## Troubleshooting
 
 In any case, when reporting an issue, please enable [debug logging](/docs/configuration/troubleshooting/#debug-logs-and-diagnostics), restart the integration, and as soon as the issue re-occurs, stop the debug logging again (_download of debug log file will start automatically_). Further, if still possible, please also download the [diagnostics](/integrations/diagnostics/) data. If you have collected the debug log and the diagnostics data, provide them with the issue report.


### PR DESCRIPTION
## Proposed change

Migrate the Immich `upload_file` action from the inline block on the integration page to a dedicated action page under `source/_actions`, and replace the inline block with the standard actions include. The camera snapshot example is kept on the integration page under an Examples section.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

