### PR TITLE
Volvo: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/volvo.get_image_url.markdown
+++ b/source/_actions/volvo.get_image_url.markdown
@@ -48,7 +48,7 @@ action: |
   response_variable: vehicle_images
 {% endexample %}
 
-This retrieves the front exterior and interior image URLs and stores them in the `vehicle_images` variable.
+This retrieves the front exterior and interior image URLs and stores the response in the `vehicle_images` variable.
 
 ### Options in YAML
 
@@ -69,10 +69,10 @@ images:
 
 ## Response data
 
-The action returns an `images` list. Each item describes one image that is available for your vehicle:
+The action returns a response containing an `images` list. Each item describes one image that is available for your vehicle:
 
-- **type**: The angle of the image, for example `exterior_front`.
-- **url**: The URL where the image can be retrieved.
+- `type`: The angle of the image, for example `exterior_front`.
+- `url`: The URL where the image can be retrieved.
 
 Only images that actually exist for your vehicle are returned, so the list may be shorter than the angles you requested.
 

--- a/source/_actions/volvo.get_image_url.markdown
+++ b/source/_actions/volvo.get_image_url.markdown
@@ -19,7 +19,7 @@ To get image URLs from an automation or a script:
 4. In the **Then do** section, select **Add action**.
 5. From the search box, search for and select **Volvo: Get image URL**.
 6. Select the **Entry** for the vehicle you want the images for.
-7. Optionally, select one or more **Images** angles. Leave this empty to get all images.
+7. Optionally, select one or more image angles in **Images**. Leave this empty to get all images.
 8. Select **Save**.
 
 ### Options in the UI

--- a/source/_actions/volvo.get_image_url.markdown
+++ b/source/_actions/volvo.get_image_url.markdown
@@ -1,0 +1,91 @@
+---
+title: "Get image URL"
+action: volvo.get_image_url
+domain: volvo
+description: "Retrieves the URL for one or more vehicle-specific images."
+---
+
+The **Get image URL** action retrieves the URLs of images of your vehicle from a specific angle. You can request all available images at once, or pick one or more specific angles.
+
+This action returns [response data](#response-data) and does not change anything on your vehicle.
+
+{% include actions/ui_header.md %}
+
+To get image URLs from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create** to start a new one.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Volvo: Get image URL**.
+6. Select the **Entry** for the vehicle you want the images for.
+7. Optionally, select one or more **Images** angles. Leave this empty to get all images.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Entry:
+  description: The vehicle to retrieve the images for.
+  required: true
+Images:
+  description: The image angles to retrieve. Leave empty to get all images.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `volvo.get_image_url`:
+
+{% example %}
+action: |
+  action: volvo.get_image_url
+  data:
+    entry: 01JVJ0RA387MWA938VE8HGXBMJ
+    images:
+      - exterior_front
+      - interior
+  response_variable: vehicle_images
+{% endexample %}
+
+This retrieves the front exterior and interior image URLs and stores them in the `vehicle_images` variable.
+
+### Options in YAML
+
+{% options_yaml %}
+entry:
+  description: The vehicle to retrieve the images for.
+  required: true
+  type: string
+images:
+  description: >
+    The image angles to retrieve. Leave empty to get all images. One or more of
+    `exterior_back`, `exterior_back_left`, `exterior_back_right`,
+    `exterior_front`, `exterior_front_left`, `exterior_front_right`,
+    `exterior_side_left`, `exterior_side_right`, or `interior`.
+  required: false
+  type: list
+{% endoptions_yaml %}
+
+## Response data
+
+The action returns an `images` list. Each item describes one image that is available for your vehicle:
+
+- **type**: The angle of the image, for example `exterior_front`.
+- **url**: The URL where the image can be retrieved.
+
+Only images that actually exist for your vehicle are returned, so the list may be shorter than the angles you requested.
+
+```yaml
+images:
+  - type: "exterior_front"
+    url: "https://www.example.com/vehicle/exterior_front.png"
+  - type: "interior"
+    url: "https://www.example.com/vehicle/interior.png"
+```
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/volvo.markdown
+++ b/source/_integrations/volvo.markdown
@@ -228,19 +228,7 @@ Go to Volvo's developer portal to view [the list of supported models](https://de
 - **Trip automatic average fuel consumption**: Average fuel consumption on the automatic trip meter.
 - **Trip manual average fuel consumption**: Average fuel consumption on the manual trip meter.
 
-## Actions
-
-### Get image URL
-
-The action `get_image_url` retrieves the URL of your vehicle-specific images.
-Get all URLs at once, or select one or more angles.
-
-{% configuration_basic %}
-Entry:
-  description: "The entry ID to retrieve the vehicle images for."
-Images:
-  description: "The image angles to retrieve. Leave empty to get all images."
-{% endconfiguration_basic %}
+{% include integrations/actions.md %}
 
 ## Examples
 


### PR DESCRIPTION
## Proposed change

Migrate the Volvo `get_image_url` action from the inline block on the integration page to a dedicated action page under `source/_actions`, and replace the inline block with the standard actions include. The action returns response data, so the new page documents the response shape.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

