### PR TITLE
Yardian: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/yardian.start_irrigation.markdown
+++ b/source/_actions/yardian.start_irrigation.markdown
@@ -58,6 +58,33 @@ duration:
 
 {% include actions/more_examples.md %}
 
+### Automation: Water the lawn early in the morning
+
+This automation waters your front lawn for 10 minutes every morning before sunrise, when evaporation is low.
+
+- Trigger: the time is 5:30 AM
+- Action: start irrigation
+  - Target: the front lawn zone switch
+  - Duration: `10`
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  alias: "Morning lawn watering"
+  triggers:
+    - trigger: time
+      at: "05:30:00"
+  actions:
+    - action: yardian.start_irrigation
+      target:
+        entity_id: switch.front_lawn
+      data:
+        duration: 10
+{% endexample %}
+
+{% enddetails %}
+
 {% include actions/stuck.md %}
 
 {% include actions/related.md %}

--- a/source/_actions/yardian.start_irrigation.markdown
+++ b/source/_actions/yardian.start_irrigation.markdown
@@ -62,10 +62,10 @@ duration:
 
 This automation waters your front lawn for 10 minutes every morning before sunrise, when evaporation is low.
 
-- Trigger: the time is 5:30 AM
-- Action: start irrigation
-  - Target: the front lawn zone switch
-  - Duration: `10`
+- **Trigger**: the time is 5:30 AM
+- **Action**: start irrigation
+  - **Target**: the front lawn zone switch
+  - **Duration**: `10`
 
 {% details "Show example YAML" %}
 

--- a/source/_actions/yardian.start_irrigation.markdown
+++ b/source/_actions/yardian.start_irrigation.markdown
@@ -1,0 +1,63 @@
+---
+title: "Start irrigation"
+action: yardian.start_irrigation
+domain: yardian
+description: "Starts the irrigation for a zone for a set number of minutes."
+---
+
+Use this action to start watering a Yardian zone for a set number of minutes. The target is a Yardian zone switch, and the duration controls how long that zone stays on.
+
+{% include actions/ui_header.md %}
+
+To start irrigation from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Yardian zone switch you want to water.
+6. From the actions shown for that target, select **Start irrigation**.
+7. Enter the **Duration** in minutes.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Duration:
+  description: The number of minutes for the zone to stay on.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `yardian.start_irrigation`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: yardian.start_irrigation
+  target:
+    entity_id: switch.front_lawn
+  data:
+    duration: 10
+{% endexample %}
+
+This waters the `switch.front_lawn` zone for 10 minutes.
+
+### Options in YAML
+
+{% options_yaml %}
+duration:
+  description: The number of minutes for the zone to stay on, between 1 and 1440.
+  required: true
+  type: integer
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="switch" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/yardian.markdown
+++ b/source/_integrations/yardian.markdown
@@ -43,13 +43,4 @@ The **Yardian** integration provides the following entities.
 - **Zone enabled**: `On` if a zone is enabled. These entities are disabled by default and created per zone.
 
 
-## Actions
-
-### yardian.start_irrigation
-
-Start a zone for a given number of minutes. This action accepts an Yardian Zone switch {% term entity %} and allows a given duration.
-
-| Data attribute | Optional | Description                                           |
-| ---------------------- | -------- | ----------------------------------------------------- |
-| `entity_id`            | yes      | The Yardian Zone switch to turn on.                   |
-| `duration`             | no       | Number of minutes for this zone to be turned on.      |
+{% include integrations/actions.md %}


### PR DESCRIPTION
## Proposed change

Migrate the Yardian `start_irrigation` action from the inline block on the integration page to a dedicated action page under `source/_actions`, and replace the inline block with the standard actions include.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

