### PR TITLE
YoLink: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/yolink.play_on_speaker_hub.markdown
+++ b/source/_actions/yolink.play_on_speaker_hub.markdown
@@ -94,6 +94,38 @@ repeat:
 
 {% include actions/more_examples.md %}
 
+### Automation: Announce when a door is left open
+
+This automation plays a spoken alert on your YoLink SpeakerHub when the front door stays open for more than two minutes.
+
+- Trigger: the front door sensor stays open for 2 minutes
+- Action: play a message on the SpeakerHub
+  - SpeakerHub device: your SpeakerHub
+  - Text message: "The front door is open"
+  - Tone: `alert`
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  alias: "Announce front door left open"
+  triggers:
+    - trigger: state
+      entity_id: binary_sensor.front_door
+      to: "on"
+      for:
+        minutes: 2
+  actions:
+    - action: yolink.play_on_speaker_hub
+      data:
+        target_device: 12a34b56c7d8ef9ghijklm0n1op2345q
+        message: "The front door is open"
+        tone: "alert"
+        volume: 8
+{% endexample %}
+
+{% enddetails %}
+
 {% include actions/stuck.md %}
 
 {% include actions/related.md %}

--- a/source/_actions/yolink.play_on_speaker_hub.markdown
+++ b/source/_actions/yolink.play_on_speaker_hub.markdown
@@ -54,7 +54,6 @@ action: |
     target_device: 12a34b56c7d8ef9ghijklm0n1op2345q
     message: "The front door is open"
     tone: "alert"
-    volume: 8
     repeat: 1
 {% endexample %}
 
@@ -98,13 +97,13 @@ repeat:
 
 This automation plays a spoken alert on your YoLink SpeakerHub when the front door stays open for more than two minutes.
 
-- Trigger: the front door sensor stays open for 2 minutes
-- Action: play a message on the SpeakerHub
-  - SpeakerHub device: your SpeakerHub
-  - Text message: "The front door is open"
-  - Tone: `alert`
+- **Trigger**: the front door sensor stays open for 2 minutes
+- **Action**: play a message on the SpeakerHub
+  - **SpeakerHub device**: your SpeakerHub
+  - **Text message**: "The front door is open"
+  - **Tone**: `alert`
 
-{% details "Show example YAML" %}
+{% details "YAML example for announcing an open door" %}
 
 {% example %}
 automation: |
@@ -121,7 +120,6 @@ automation: |
         target_device: 12a34b56c7d8ef9ghijklm0n1op2345q
         message: "The front door is open"
         tone: "alert"
-        volume: 8
 {% endexample %}
 
 {% enddetails %}

--- a/source/_actions/yolink.play_on_speaker_hub.markdown
+++ b/source/_actions/yolink.play_on_speaker_hub.markdown
@@ -12,7 +12,7 @@ The **Play on SpeakerHub** action converts a text message to speech and plays it
 To play a message from an automation or a script:
 
 1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
-2. Open an existing automation or script, or select **Create** to start a new one.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
 3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger.
 4. In the **Then do** section, select **Add action**.
 5. From the search box, search for and select **YoLink: Play on SpeakerHub**.
@@ -74,13 +74,15 @@ message:
 tone:
   description: >
     The tone to play before the message. One of `emergency`, `alert`, `warn`,
-    or `tip`. Defaults to `tip`.
+    or `tip`.
   required: false
   type: string
+  default: tip
 volume:
-  description: The volume for this message only, between 0 and 15. Defaults to 8.
+  description: The volume for this message only, between 0 and 15.
   required: false
   type: integer
+  default: 8
 repeat:
   description: The number of times to repeat the message, between 0 and 10.
   required: false

--- a/source/_actions/yolink.play_on_speaker_hub.markdown
+++ b/source/_actions/yolink.play_on_speaker_hub.markdown
@@ -1,0 +1,97 @@
+---
+title: "Play on SpeakerHub"
+action: yolink.play_on_speaker_hub
+domain: yolink
+description: "Converts text to speech for playback on a YoLink SpeakerHub."
+---
+
+The **Play on SpeakerHub** action converts a text message to speech and plays it on a YoLink SpeakerHub. You can optionally play a tone first, set the volume for this message, and repeat the message.
+
+{% include actions/ui_header.md %}
+
+To play a message from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create** to start a new one.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **YoLink: Play on SpeakerHub**.
+6. Select the **SpeakerHub device** to play the message on.
+7. Enter the **Text message** to play.
+8. Optionally, set a **Tone**, **Volume**, and **Repeat** count.
+9. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label. You select the SpeakerHub through the **SpeakerHub device** option instead.
+
+### Options in the UI
+
+{% options_ui %}
+SpeakerHub device:
+  description: The SpeakerHub device to play the message on.
+  required: true
+Text message:
+  description: The text message to play.
+  required: true
+Tone:
+  description: The tone to play before the message.
+  required: false
+Volume:
+  description: The volume for this message only, between 0 and 15.
+  required: false
+Repeat:
+  description: The number of times to repeat the message, between 0 and 10.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `yolink.play_on_speaker_hub`:
+
+{% example %}
+action: |
+  action: yolink.play_on_speaker_hub
+  data:
+    target_device: 12a34b56c7d8ef9ghijklm0n1op2345q
+    message: "The front door is open"
+    tone: "alert"
+    volume: 8
+    repeat: 1
+{% endexample %}
+
+This plays an alert tone followed by the message on the selected SpeakerHub.
+
+### Options in YAML
+
+{% options_yaml %}
+target_device:
+  description: The device ID of the SpeakerHub to play the message on.
+  required: true
+  type: string
+message:
+  description: The text message to play.
+  required: true
+  type: string
+tone:
+  description: >
+    The tone to play before the message. One of `emergency`, `alert`, `warn`,
+    or `tip`. Defaults to `tip`.
+  required: false
+  type: string
+volume:
+  description: The volume for this message only, between 0 and 15. Defaults to 8.
+  required: false
+  type: integer
+repeat:
+  description: The number of times to repeat the message, between 0 and 10.
+  required: false
+  type: integer
+  default: 0
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/yolink.markdown
+++ b/source/_integrations/yolink.markdown
@@ -107,19 +107,7 @@ The integration is tested and verified for the following devices from YoLink:
 - YS4103-UC (Sprinkler Timer)
 - YS7914-UC (Leak Sensor)
 
-## Actions
-
-### `Play on SpeakerHub`
-
-With this action, you can convert text to speech for playback on SpeakerHub.
-
-| Data attribute  | Optional | Description                                                       |
-| --------------- | -------- | ----------------------------------------------------------------- |
-| `target_device` | no       | SpeakerHub device ID for audio playback.                          |
-| `message`       | no       | Text for speech conversion.                                       |
-| `tone`          | yes      | Tone before playing audio.                                        |
-| `volume`        | yes      | Override the speaker volume during playback of this message only. |
-| `repeat`        | yes      | The number of times the text will be repeated.                    |
+{% include integrations/actions.md %}
 
 ## Community notes
 


### PR DESCRIPTION
## Proposed change

Migrate the YoLink `play_on_speaker_hub` action from the inline block on the integration page to a dedicated action page under `source/_actions`, and replace the inline block with the standard actions include.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

