### PR TITLE
motionEye: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/motioneye.action.markdown
+++ b/source/_actions/motioneye.action.markdown
@@ -1,5 +1,5 @@
 ---
-title: "Action"
+title: "Trigger motionEye action"
 action: motioneye.action
 domain: motioneye
 description: "Triggers a motionEye action."
@@ -17,10 +17,11 @@ To trigger an action from an automation or a script:
 1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
 2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
 3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
-4. Select what you want to control. Under **By target** (see [Targets](#targets)), select the motionEye camera you want to control.
-5. From the actions shown for that target, select **Action**.
-6. Select the **Action** to trigger.
-7. Select **Save**.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the motionEye camera you want to control.
+6. From the actions shown for that target, select **Action**.
+7. Select the **Action** to trigger.
+8. Select **Save**.
 
 ### Options in the UI
 

--- a/source/_actions/motioneye.action.markdown
+++ b/source/_actions/motioneye.action.markdown
@@ -1,0 +1,73 @@
+---
+title: "Action"
+action: motioneye.action
+domain: motioneye
+description: "Triggers a motionEye action."
+related_actions:
+  - motioneye.snapshot
+  - motioneye.set_text_overlay
+---
+
+Use this action to trigger a motionEye [action button](https://github.com/ccrisan/motioneye/wiki/Action-Buttons) on one or more motionEye cameras, such as taking a snapshot, controlling pan and tilt, or moving to a preset.
+
+{% include actions/ui_header.md %}
+
+To trigger an action from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. Select what you want to control. Under **By target** (see [Targets](#targets)), select the motionEye camera you want to control.
+5. From the actions shown for that target, select **Action**.
+6. Select the **Action** to trigger.
+7. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Action:
+  description: The motionEye action to trigger.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `motioneye.action`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: motioneye.action
+  target:
+    entity_id: camera.office
+  data:
+    action: snapshot
+{% endexample %}
+
+This triggers the `snapshot` action on the `camera.office` camera.
+
+### Options in YAML
+
+{% options_yaml %}
+action:
+  description: >
+    The motionEye action to trigger. One of `snapshot`, `record_start`,
+    `record_stop`, `lock`, `unlock`, `light_on`, `light_off`, `alarm_on`,
+    `alarm_off`, `up`, `right`, `down`, `left`, `zoom_in`, `zoom_out`, or
+    `preset1` through `preset9`.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="camera" %}
+
+## Good to know
+
+- The `record_start` and `record_stop` actions are only partially implemented in motionEye itself, so they do not function as expected. See the [relevant motionEye code](https://github.com/ccrisan/motioneye/blob/dev/motioneye/handlers.py#L1741).
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/motioneye.set_text_overlay.markdown
+++ b/source/_actions/motioneye.set_text_overlay.markdown
@@ -1,0 +1,97 @@
+---
+title: "Set text overlay"
+action: motioneye.set_text_overlay
+domain: motioneye
+description: "Sets the text overlay for a camera."
+related_actions:
+  - motioneye.snapshot
+  - motioneye.action
+---
+
+Use this action to set the text overlay shown on the left and right side of one or more motionEye cameras. Each side can show a timestamp, the camera name, custom text, or nothing.
+
+{% include actions/ui_header.md %}
+
+To set a text overlay from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. Select what you want to control. Under **By target** (see [Targets](#targets)), select the motionEye camera you want to change.
+5. From the actions shown for that target, select **Set text overlay**.
+6. Choose what to show with **Left text overlay** and **Right text overlay**. If you pick custom text, enter it in **Left custom text** or **Right custom text**.
+7. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Left text overlay:
+  description: What to show on the left side. One of timestamp, camera name, custom text, or disabled.
+  required: false
+Left custom text:
+  description: The custom text to show on the left, when left text overlay is set to custom text.
+  required: false
+Right text overlay:
+  description: What to show on the right side. One of timestamp, camera name, custom text, or disabled.
+  required: false
+Right custom text:
+  description: The custom text to show on the right, when right text overlay is set to custom text.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `motioneye.set_text_overlay`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: motioneye.set_text_overlay
+  target:
+    entity_id: camera.office
+  data:
+    left_text: timestamp
+    right_text: custom-text
+    custom_right_text: "Alarm armed"
+{% endexample %}
+
+This shows a timestamp on the left and the custom text `Alarm armed` on the right of the `camera.office` camera.
+
+### Options in YAML
+
+{% options_yaml %}
+left_text:
+  description: >
+    What to show on the left side. One of `timestamp`, `camera-name`,
+    `custom-text`, or `disabled`.
+  required: false
+  type: string
+custom_left_text:
+  description: The custom text to show on the left, when `left_text` is set to `custom-text`.
+  required: false
+  type: string
+right_text:
+  description: >
+    What to show on the right side. One of `timestamp`, `camera-name`,
+    `custom-text`, or `disabled`.
+  required: false
+  type: string
+custom_right_text:
+  description: The custom text to show on the right, when `right_text` is set to `custom-text`.
+  required: false
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="camera" %}
+
+## Good to know
+
+- Calling this action resets the motionEye cameras, which briefly pauses the stream, recordings, and motion detection.
+- Make sure the **Text overlay** switch is turned on so the configured text overlays are actually displayed.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/motioneye.set_text_overlay.markdown
+++ b/source/_actions/motioneye.set_text_overlay.markdown
@@ -17,10 +17,11 @@ To set a text overlay from an automation or a script:
 1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
 2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
 3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
-4. Select what you want to control. Under **By target** (see [Targets](#targets)), select the motionEye camera you want to change.
-5. From the actions shown for that target, select **Set text overlay**.
-6. Choose what to show with **Left text overlay** and **Right text overlay**. If you pick custom text, enter it in **Left custom text** or **Right custom text**.
-7. Select **Save**.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the motionEye camera you want to change.
+6. From the actions shown for that target, select **Set text overlay**.
+7. Choose what to show with **Left text overlay** and **Right text overlay**. If you pick custom text, enter it in **Left custom text** or **Right custom text**.
+8. Select **Save**.
 
 ### Options in the UI
 

--- a/source/_actions/motioneye.snapshot.markdown
+++ b/source/_actions/motioneye.snapshot.markdown
@@ -19,9 +19,10 @@ To trigger a snapshot from an automation or a script:
 1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
 2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
 3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
-4. Select what you want to control. Under **By target** (see [Targets](#targets)), select the motionEye camera you want a snapshot from.
-5. From the actions shown for that target, select **Snapshot**.
-6. Select **Save**.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the motionEye camera you want a snapshot from.
+6. From the actions shown for that target, select **Snapshot**.
+7. Select **Save**.
 
 ### Options in the UI
 

--- a/source/_actions/motioneye.snapshot.markdown
+++ b/source/_actions/motioneye.snapshot.markdown
@@ -1,0 +1,55 @@
+---
+title: "Snapshot"
+action: motioneye.snapshot
+domain: motioneye
+description: "Triggers a motionEye still snapshot."
+related_actions:
+  - motioneye.action
+  - motioneye.set_text_overlay
+---
+
+Use this action to trigger a still snapshot on one or more motionEye cameras, for example to save an image to disk when motion is detected.
+
+This action is a convenient shortcut for the [`motioneye.action`](/actions/motioneye.action/) action with the `snapshot` action selected.
+
+{% include actions/ui_header.md %}
+
+To trigger a snapshot from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. Select what you want to control. Under **By target** (see [Targets](#targets)), select the motionEye camera you want a snapshot from.
+5. From the actions shown for that target, select **Snapshot**.
+6. Select **Save**.
+
+### Options in the UI
+
+This action has no additional options beyond the target.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `motioneye.snapshot`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: motioneye.snapshot
+  target:
+    entity_id: camera.office
+{% endexample %}
+
+This triggers a snapshot on the `camera.office` camera.
+
+### Options in YAML
+
+This action has no additional YAML options beyond the target.
+
+{% include actions/targets.md domain="camera" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/motioneye.markdown
+++ b/source/_integrations/motioneye.markdown
@@ -211,66 +211,7 @@ in automations (etc).
 }
 ```
 
-## Actions
-
-All actions accept either an `entity_id` or `device_id`.
-
-### motioneye.snapshot
-
-Trigger a camera snapshot (e.g. saving an image to disk).
-
-Parameters:
-
-| Parameter               | Description                                           |
-| ----------------------- | ----------------------------------------------------- |
-| `entity_id` `device_id` | An entity id or device id to trigger the snapshot on. |
-
-Note: This is a thin wrapper on the [`motioneye.action` call](#action).
-
-<a name="action"></a>
-
-### motioneye.action
-
-Trigger a motionEye action (see [motionEye Action Buttons](https://github.com/ccrisan/motioneye/wiki/Action-Buttons)).
-
-Parameters:
-
-| Parameter               | Description                                                                                                                                                                                                                                              |
-| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `entity_id` `device_id` | An entity id or device id to trigger the action on.                                                                                                                                                                                                      |
-| `action`                | A string representing the motionEye action to trigger. One of `snapshot`, `lock`, `unlock`, `light_on`, `light_off`, `alarm_on`, `alarm_off`, `up`, `right`, `down`, `left`, `zoom_in`, `zoom_out`, `preset1`-`preset9`, `record_start` or `record_stop` |
-
-**Note**: `record_start` and `record_stop` action are only partially implemented in motionEye itself and thus do not function as would be expected ([relevant code](https://github.com/ccrisan/motioneye/blob/dev/motioneye/handlers.py#L1741)).
-
-### motioneye.set_text_overlay
-
-Set the text overlay for a camera.
-
-Parameters:
-
-| Parameter                              | Description                                                                                                                                                                 |
-| -------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `entity_id` `device_id`                | An entity id or device id to set the text overlay on.                                                                                                                       |
-| `left_text` `right_text`               | One of `timestamp`, `camera-name`, `custom-text` or `disabled` to show a timestamp, the  name of the camera, custom text or nothing at all, on the left or right-hand side. |
-| `custom_left_text` `custom_right_text` | Custom text to show on the left or right, if the `custom-text` value is selected.                                                                                           |
-
-**Note**:
-
-- Calling this action triggers a reset of the motionEye cameras which will pause the
-  stream / recordings / motion detection (etc).
-- Ensure the `Text Overlay` switch is turned on to actually display the configured text overlays.
-
-#### Example:
-
-```yaml
-action: motioneye.set_text_overlay
-data:
-  left_text: timestamp
-  right_text: custom-text
-  custom_right_text: "Alarm armed"
-target:
-  entity_id: camera.office
-```
+{% include integrations/actions.md %}
 
 ## Media Browsing
 


### PR DESCRIPTION
## Proposed change

Migrate the three motionEye actions (`snapshot`, `action`, and `set_text_overlay`) from the inline blocks on the integration page to dedicated action pages under `source/_actions`, and replace the inline blocks with the standard actions include.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

