### PR TITLE
Migrate KNX actions to dedicated action pages

### DIFF
--- a/source/_actions/knx.event_register.markdown
+++ b/source/_actions/knx.event_register.markdown
@@ -1,0 +1,110 @@
+---
+title: "Register knx_event"
+action: knx.event_register
+domain: knx
+description: "Adds or removes group addresses for the knx_event filter."
+related_actions:
+  - knx.send
+  - knx.read
+  - knx.exposure_register
+---
+
+The **Register knx_event** action adds or removes group addresses on the `knx_event` filter. When a group address is registered, telegrams sent to that address fire a `knx_event` on the Home Assistant event bus, which you can use as an automation trigger.
+
+This is useful when you want to react to KNX addresses that are not modeled as entities, and to do so only at certain times by registering and unregistering them on the fly.
+
+Group addresses configured through the `event` key in your {% term "configuration.yaml" %} are always active and cannot be removed with this action. For more details, see the [Events](/integrations/knx/#events) section.
+
+{% include actions/ui_header.md %}
+
+To register a group address from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **KNX: Register knx_event**.
+6. Enter the **Group address** to register. Optionally, set a **Value type** to decode the payload, or turn on **Remove event registration** to remove the address.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label. Only users with administrator rights can run this action.
+
+### Options in the UI
+
+{% options_ui %}
+Group address:
+  description: The group address(es) to add or remove. Provide a list to register multiple group addresses.
+  required: true
+Value type:
+  description: If set, the payload is decoded as the given DPT and written to the event data `value` key. The KNX sensor types are valid values. See the list of types in the [KNX sensor](/integrations/knx/#sensor) section.
+  required: false
+Remove event registration:
+  description: If turned on, the group address(es) are removed from the filter.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `knx.event_register`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: knx.event_register
+  data:
+    address: "0/4/20"
+{% endexample %}
+
+This registers group address `0/4/20` so that telegrams sent to it fire a `knx_event`.
+
+### Options in YAML
+
+{% options_yaml %}
+address:
+  description: >
+    The group address(es) to add or remove. A list registers multiple group
+    addresses.
+  required: true
+  type: [string, list]
+type:
+  description: >
+    If set, the payload is decoded as the given DPT and written to the event
+    data `value` key. The KNX sensor types are valid values. See the list of
+    types in the [KNX sensor](/integrations/knx/#sensor) section.
+  required: false
+  type: [string, integer]
+remove:
+  description: >
+    If set to `true`, the group address(es) are removed from the filter.
+  required: false
+  type: boolean
+  default: false
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: register a group address on startup
+
+This automation registers a cover-move group address when Home Assistant starts, so that its telegrams fire a `knx_event` you can act on.
+
+{% details "YAML example for registering a group address on startup" %}
+
+{% example %}
+automation: |
+  alias: "Register KNX event on startup"
+  triggers:
+    - trigger: homeassistant
+      event: start
+  actions:
+    - action: knx.event_register
+      data:
+        # Cover move trigger
+        address: "0/4/20"
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/knx.event_register.markdown
+++ b/source/_actions/knx.event_register.markdown
@@ -9,7 +9,7 @@ related_actions:
   - knx.exposure_register
 ---
 
-The **Register knx_event** action adds or removes group addresses on the `knx_event` filter. When a group address is registered, telegrams sent to that address fire a `knx_event` on the Home Assistant event bus, which you can use as an automation trigger.
+The **Register knx_event** action adds or removes group addresses in the `knx_event` filter. When a group address is registered, telegrams sent to that address fire a `knx_event` on the Home Assistant event bus, which you can use as an automation trigger.
 
 This is useful when you want to react to KNX addresses that are not modeled as entities, and to do so only at certain times by registering and unregistering them on the fly.
 

--- a/source/_actions/knx.event_register.markdown
+++ b/source/_actions/knx.event_register.markdown
@@ -15,6 +15,12 @@ This is useful when you want to react to KNX addresses that are not modeled as e
 
 Group addresses configured through the `event` key in your {% term "configuration.yaml" %} are always active and cannot be removed with this action. For more details, see the [Events](/integrations/knx/#events) section.
 
+{% tip %}
+
+This action is mainly intended for blueprint creators and for registering group addresses on the fly. To react to telegrams in an automation, use the [KNX telegram](/integrations/knx/#telegram-trigger) trigger instead.
+
+{% endtip %}
+
 {% include actions/ui_header.md %}
 
 To register a group address from an automation or a script:

--- a/source/_actions/knx.event_register.markdown
+++ b/source/_actions/knx.event_register.markdown
@@ -2,7 +2,7 @@
 title: "Register knx_event"
 action: knx.event_register
 domain: knx
-description: "Adds or removes group addresses for the knx_event filter."
+description: "Adds or removes group addresses in the knx_event filter."
 related_actions:
   - knx.send
   - knx.read

--- a/source/_actions/knx.exposure_register.markdown
+++ b/source/_actions/knx.exposure_register.markdown
@@ -15,6 +15,12 @@ This is useful when you want other KNX devices to react to or read Home Assistan
 
 Exposures defined through your {% term "configuration.yaml" %} cannot be removed with this action. Per address, only one exposure can be registered. For more details, and for additional exposure options like `value_template`, `cooldown`, `periodic_send`, and `respond_to_read`, see the [Exposing entity states, entity attributes or time to KNX bus](/integrations/knx/#exposing-entity-states-entity-attributes-or-time-to-knx-bus) section.
 
+{% tip %}
+
+This action is mainly intended for blueprint creators and for registering exposures on the fly. For exposures that should run all the time, set them up through the UI or YAML expose configuration instead.
+
+{% endtip %}
+
 {% include actions/ui_header.md %}
 
 To register an exposure from an automation or a script:

--- a/source/_actions/knx.exposure_register.markdown
+++ b/source/_actions/knx.exposure_register.markdown
@@ -1,0 +1,121 @@
+---
+title: "Expose to KNX bus"
+action: knx.exposure_register
+domain: knx
+description: "Adds or removes exposures to the KNX bus."
+related_actions:
+  - knx.send
+  - knx.read
+  - knx.event_register
+---
+
+The **Expose to KNX bus** action adds or removes an exposure that sends a Home Assistant entity state or attribute to a KNX group address. Once registered, state and attribute updates are written to the bus, and GroupValueRead requests for that address are answered.
+
+This is useful when you want other KNX devices to react to or read Home Assistant values, and to manage those exposures dynamically instead of defining them all up front.
+
+Exposures defined through your {% term "configuration.yaml" %} cannot be removed with this action. Per address, only one exposure can be registered. For more details, see the [Exposing entity states, entity attributes or time to KNX bus](/integrations/knx/#exposing-entity-states-entity-attributes-or-time-to-knx-bus) section.
+
+{% include actions/ui_header.md %}
+
+To register an exposure from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **KNX: Expose to KNX bus**.
+6. Enter the **Group address**, the **Value type**, and the **Entity** to expose. Optionally, set an **Entity attribute** and a **Default value**, or turn on **Remove exposure** to remove the exposure.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label. Only users with administrator rights can run this action.
+
+### Options in the UI
+
+{% options_ui %}
+Group address:
+  description: The group address that state or attribute updates are sent to, and that answers GroupValueRead requests.
+  required: true
+Value type:
+  description: The DPT that telegrams are encoded as. `binary` and all KNX sensor types are valid values. See the list of types in the [KNX sensor](/integrations/knx/#sensor) section.
+  required: true
+Entity:
+  description: The entity whose state or attribute is exposed.
+  required: true
+Entity attribute:
+  description: The attribute of the entity to send to the KNX bus. If not set, the state is sent. For example, for a light the state is either on or off, while the `brightness` attribute exposes its brightness.
+  required: false
+Default value:
+  description: The value to send to the bus when the state or attribute value is none. For example, a light with state off has no brightness attribute, so a default value of `0` could be used. If not set, no value is sent and a GroupValueRead request returns the last known value.
+  required: false
+Remove exposure:
+  description: If turned on, the exposure is removed. Only the group address is required for removal.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `knx.exposure_register`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: knx.exposure_register
+  data:
+    address: "1/1/0"
+    type: percentU8
+    entity_id: light.living_room
+    attribute: brightness
+    default: 0
+{% endexample %}
+
+This exposes the brightness of `light.living_room` to group address `1/1/0`.
+
+### Options in YAML
+
+{% options_yaml %}
+address:
+  description: >
+    The group address that state or attribute updates are sent to, and that
+    answers GroupValueRead requests.
+  required: true
+  type: string
+type:
+  description: >
+    The DPT that telegrams are encoded as. `binary` and all KNX sensor types
+    are valid values. See the list of types in the
+    [KNX sensor](/integrations/knx/#sensor) section.
+  required: true
+  type: string
+entity_id:
+  description: >
+    The entity whose state or attribute is exposed.
+  required: true
+  type: string
+attribute:
+  description: >
+    The attribute of the entity to send to the KNX bus. If not set, the state
+    is sent.
+  required: false
+  type: string
+default:
+  description: >
+    The value to send to the bus when the state or attribute value is none. If
+    not set, no value is sent and a GroupValueRead request returns the last
+    known value.
+  required: false
+  type: [string, integer, float]
+remove:
+  description: >
+    If set to `true`, the exposure is removed. Only `address` is required for
+    removal.
+  required: false
+  type: boolean
+  default: false
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/knx.exposure_register.markdown
+++ b/source/_actions/knx.exposure_register.markdown
@@ -13,7 +13,7 @@ The **Expose to KNX bus** action adds or removes an exposure that sends a Home A
 
 This is useful when you want other KNX devices to react to or read Home Assistant values, and to manage those exposures dynamically instead of defining them all up front.
 
-Exposures defined through your {% term "configuration.yaml" %} cannot be removed with this action. Per address, only one exposure can be registered. For more details, see the [Exposing entity states, entity attributes or time to KNX bus](/integrations/knx/#exposing-entity-states-entity-attributes-or-time-to-knx-bus) section.
+Exposures defined through your {% term "configuration.yaml" %} cannot be removed with this action. Per address, only one exposure can be registered. For more details, and for additional exposure options like `value_template`, `cooldown`, `periodic_send`, and `respond_to_read`, see the [Exposing entity states, entity attributes or time to KNX bus](/integrations/knx/#exposing-entity-states-entity-attributes-or-time-to-knx-bus) section.
 
 {% include actions/ui_header.md %}
 
@@ -45,7 +45,7 @@ Entity attribute:
   description: The attribute of the entity to send to the KNX bus. If not set, the state is sent. For example, for a light the state is either on or off, while the `brightness` attribute exposes its brightness.
   required: false
 Default value:
-  description: The value to send to the bus when the state or attribute value is none. For example, a light with state off has no brightness attribute, so a default value of `0` could be used. If not set, no value is sent and a GroupValueRead request returns the last known value.
+  description: The value to send to the bus when the state or attribute value is not available. For example, a light with state off has no brightness attribute, so a default value of `0` could be used. If not set, no value is sent and a GroupValueRead request returns the last known value.
   required: false
 Remove exposure:
   description: If turned on, the exposure is removed. Only the group address is required for removal.
@@ -98,8 +98,8 @@ attribute:
   type: string
 default:
   description: >
-    The value to send to the bus when the state or attribute value is none. If
-    not set, no value is sent and a GroupValueRead request returns the last
+    The value to send to the bus when the state or attribute value is not
+    available. If not set, no value is sent and a GroupValueRead request returns the last
     known value.
   required: false
   type: [string, integer, float]

--- a/source/_actions/knx.exposure_register.markdown
+++ b/source/_actions/knx.exposure_register.markdown
@@ -120,8 +120,6 @@ remove:
 
 {% include actions/try_it.md %}
 
-{% include actions/more_examples.md %}
-
 {% include actions/stuck.md %}
 
 {% include actions/related.md %}

--- a/source/_actions/knx.read.markdown
+++ b/source/_actions/knx.read.markdown
@@ -13,7 +13,7 @@ The **Read from KNX bus** action sends a GroupValueRead request to one or more K
 
 This is useful when you want to actively ask a KNX device for its current value, for example to refresh a cover position after it has been moving for a while, instead of waiting for the device to report on its own.
 
-To issue GroupValueRead requests for all state addresses of an entity at once, you can use the [Home Assistant: Update entity](/integrations/homeassistant/) action instead.
+To issue GroupValueRead requests for all state addresses of an entity at once, you can use the [Home Assistant: Update entity](/integrations/homeassistant/#action-update-entity) action instead.
 
 {% include actions/ui_header.md %}
 

--- a/source/_actions/knx.read.markdown
+++ b/source/_actions/knx.read.markdown
@@ -1,0 +1,93 @@
+---
+title: "Read from KNX bus"
+action: knx.read
+domain: knx
+description: "Sends GroupValueRead requests to the KNX bus."
+related_actions:
+  - knx.send
+  - knx.event_register
+  - knx.exposure_register
+---
+
+The **Read from KNX bus** action sends a GroupValueRead request to one or more KNX group addresses. The response can be used in automations through the [KNX telegram](/integrations/knx/#telegram-trigger) trigger, and it is processed in KNX entities.
+
+This is useful when you want to actively ask a KNX device for its current value, for example to refresh a cover position after it has been moving for a while, instead of waiting for the device to report on its own.
+
+To issue GroupValueRead requests for all state addresses of an entity at once, you can use the [Home Assistant: Update entity](/integrations/homeassistant/) action instead.
+
+{% include actions/ui_header.md %}
+
+To read from the KNX bus in an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **KNX: Read from KNX bus**.
+6. Enter the **Group address** to read from.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Group address:
+  description: The group address(es) to send the read request to. Provide a list to read multiple group addresses.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `knx.read`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: knx.read
+  data:
+    address: "1/0/15"
+{% endexample %}
+
+This sends a GroupValueRead request to group address `1/0/15`.
+
+### Options in YAML
+
+{% options_yaml %}
+address:
+  description: >
+    The group address(es) to send the read request to. A list reads multiple
+    group addresses.
+  required: true
+  type: [string, list]
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: update a cover position after movement
+
+This automation reacts to a cover-move telegram and, after a short delay, reads the cover position address so Home Assistant stays in sync.
+
+{% details "YAML example for reading a cover position" %}
+
+{% example %}
+automation: |
+  alias: "Update cover position"
+  triggers:
+    - trigger: knx.telegram
+      # Cover move trigger
+      destination: "0/4/20"
+  actions:
+    - delay: "0:0:10"
+    - action: knx.read
+      data:
+        # Cover position address
+        address: "0/4/21"
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/knx.send.markdown
+++ b/source/_actions/knx.send.markdown
@@ -1,0 +1,130 @@
+---
+title: "Send to KNX bus"
+action: knx.send
+domain: knx
+description: "Sends arbitrary data directly to the KNX bus."
+related_actions:
+  - knx.read
+  - knx.event_register
+  - knx.exposure_register
+---
+
+The **Send to KNX bus** action writes data directly to one or more KNX group addresses. You can send a raw payload or have Home Assistant encode a value using a KNX datapoint type (DPT).
+
+This is useful when you want to control a KNX device or update a value on the bus from an automation or script, without modeling that device as a separate {% term entity %} in Home Assistant.
+
+{% include actions/ui_header.md %}
+
+To send data to the KNX bus from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **KNX: Send to KNX bus**.
+6. Enter the **Group address** and the **Payload** to send. Optionally, set a **Value type** to encode the payload as a DPT.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Group address:
+  description: The group address(es) to write to. Provide a list to send to multiple group addresses one after another.
+  required: true
+Payload:
+  description: The payload to send to the bus. When no value type is set, the payload is sent as raw bytes. Integers are then treated as DPT 1, 2, or 3 payloads. For DPTs larger than 6 bits, send a list where each value represents one octet (0-255).
+  required: true
+Value type:
+  description: If set, the payload is encoded as the given DPT instead of being sent as raw bytes. The KNX sensor types are valid values. See the list of types in the [KNX sensor](/integrations/knx/#sensor) section.
+  required: false
+Send as response:
+  description: If turned on, the telegram is sent as a `GroupValueResponse` instead of a `GroupValueWrite`.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `knx.send`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: knx.send
+  data:
+    address: "1/1/1"
+    type: percent
+    payload: 50
+{% endexample %}
+
+This sends the value `50` to group address `1/1/1`, encoded as a percentage.
+
+### Options in YAML
+
+{% options_yaml %}
+address:
+  description: >
+    The group address(es) to write to. A list sends to multiple group
+    addresses one after another.
+  required: true
+  type: [string, list]
+payload:
+  description: >
+    The payload to send to the bus. When `type` is not set, raw bytes are
+    sent. Integers are then treated as DPT 1, 2, or 3 payloads. For DPTs
+    larger than 6 bits, send a list where each value represents one octet
+    (0-255).
+  required: true
+  type: [integer, list]
+type:
+  description: >
+    If set, the payload is encoded as the given DPT instead of being sent as
+    raw bytes. The KNX sensor types are valid values. See the list of types
+    in the [KNX sensor](/integrations/knx/#sensor) section.
+  required: false
+  type: [string, integer, float]
+response:
+  description: >
+    If set to `true`, the telegram is sent as a `GroupValueResponse` instead
+    of a `GroupValueWrite`.
+  required: false
+  type: boolean
+  default: false
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Script: send a fixed value and an entity state
+
+This script sends a value to the bus in three different ways: encoded as a DPT, as a raw byte value, and from a Home Assistant entity state.
+
+{% details "YAML example for sending values to the KNX bus" %}
+
+{% example %}
+script: |
+  alias: "Send values to KNX"
+  sequence:
+    - action: knx.send
+      data:
+        address: "1/1/1"
+        type: percent
+        payload: 50
+    - action: knx.send
+      data:
+        # 50% as a 1-byte raw value
+        address: "1/1/1"
+        payload: [128]
+    - action: knx.send
+      data:
+        address: "3/3/3"
+        type: temperature
+        payload: "{{ states('sensor.dew_point') }}"
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/knx.send.markdown
+++ b/source/_actions/knx.send.markdown
@@ -34,7 +34,7 @@ Group address:
   description: The group address(es) to write to. Provide a list to send to multiple group addresses one after another.
   required: true
 Payload:
-  description: The payload to send to the bus. When no value type is set, the payload is sent as raw bytes. Integers are then treated as DPT 1, 2, or 3 payloads. For DPTs larger than 6 bits, send a list where each value represents one octet (0-255).
+  description: The payload to send to the bus. When no value type is set, the payload is sent as raw bytes. Integers are then treated as DPT 1, 2, or 3 payloads. For DPTs larger than 6 bits, send a list where each value represents one octet (0-255), and pad the list with `0` to match the DPT byte length.
   required: true
 Value type:
   description: If set, the payload is encoded as the given DPT instead of being sent as raw bytes. The KNX sensor types are valid values. See the list of types in the [KNX sensor](/integrations/knx/#sensor) section.
@@ -73,7 +73,7 @@ payload:
     The payload to send to the bus. When `type` is not set, raw bytes are
     sent. Integers are then treated as DPT 1, 2, or 3 payloads. For DPTs
     larger than 6 bits, send a list where each value represents one octet
-    (0-255).
+    (0-255), and pad the list with `0` to match the DPT byte length.
   required: true
   type: [integer, list]
 type:

--- a/source/_integrations/knx.markdown
+++ b/source/_integrations/knx.markdown
@@ -452,130 +452,7 @@ Every telegram that matches an address pattern with its destination field will b
 - `telegramtype` the APCI service of the telegram. "GroupValueWrite", "GroupValueRead" or "GroupValueResponse" generate a knx_event.
 - `value` contains the decoded payload value if `type` is configured for the address. Will be `None` for "GroupValueRead" telegrams.
 
-## Actions
-
-To directly interact with the KNX bus, you can use the following actions:
-
-### Send
-
-```txt
-Domain: knx
-Action: send
-Data: {"address": "1/0/15", "payload": 0, "type": "temperature"}
-```
-
-{% configuration %}
-address:
-  description: KNX group address.
-  type: string
-payload:
-  description: Payload to send to the bus. When `type` is not set, raw bytes are sent. Integers are then treated as DPT 1/2/3 payloads. For DPTs > 6 bits send a list. Each value represents 1 octet (0-255). Pad with 0 to DPT byte length.
-  type: [integer, list]
-type:
-  description: If set, the payload will not be sent as raw bytes, but encoded as given DPT. KNX sensor types are valid values - see table in [KNX Sensor](#sensor).
-  type: [string, integer, float]
-response:
-  description: If set to `true`, the telegram will be sent as a `GroupValueResponse` instead of a `GroupValueWrite`.
-  type: boolean
-  default: false
-{% endconfiguration %}
-
-```yaml
-# Example script to send a fixed value and the state of an entity
-alias: "My Script"
-sequence:
-  - action: knx.send
-    data:
-      address: 1/1/1
-      type: percent
-      payload: 50
-      response: false
-  - action: knx.send
-    data:
-      address: 1/1/1
-      payload: [128]  # 50 % as 1-byte raw value
-      response: false
-  - action: knx.send
-    data:
-      address: 3/3/3
-      type: temperature
-      payload: "{{ states('sensor.dew_point') }}"
-      response: false
-```
-
-### Read
-
-You can use the `homeassistant.update_entity` action call to issue GroupValueRead requests for all `*state_address` of an entity.
-To manually send GroupValueRead requests, use the `knx.read` action. The response can be used in automations by the `knx.telegram` trigger and it will be processed in KNX entities.
-
-```txt
-Domain: knx
-Action: read
-Data: {"address": "1/0/15"}
-```
-
-{% configuration %}
-address:
-  description: Group address(es) to send read request to. Lists will read multiple group addresses.
-  type: [string, list]
-{% endconfiguration %}
-
-```yaml
-# Example automation to update a cover position after 10 seconds of movement initiation
-automation:
-  - triggers:
-      - trigger: knx.telegram
-        # Cover move trigger
-        destination: "0/4/20"
-    actions:
-      - delay: 0:0:10
-      - action: knx.read
-        data:
-          # Cover position address
-          address: "0/4/21"
-
-  - triggers:
-      - trigger: homeassistant
-        event: start
-    actions:
-      # Register the group address to trigger a knx_event
-      - action: knx.event_register
-        data:
-          # Cover move trigger
-          address: "0/4/20"
-```
-
-### Register event
-
-The `knx.event_register` action can be used to register (or unregister) group addresses to fire `knx_event` Events. Events for group addresses configured in the `event` key in {% term "`configuration.yaml`" %} cannot be unregistered. See [knx_event](#events)
-
-{% configuration %}
-address:
-  description: Group address that shall be added or removed.
-  required: true
-  type: [string, list]
-remove:
-  description: If `true` the group address will be removed.
-  required: false
-  type: boolean
-  default: false
-type:
-  description: If set, the payload will be decoded as given DPT in the event data `value` key. KNX sensor types are valid values [KNX Sensor](#sensor) (e.g., "2byte_float" or "1byte_signed").
-  type: [string, integer]
-  required: false
-{% endconfiguration %}
-
-### Register exposure
-
-The `knx.exposure_register` action can be used to register (or unregister) exposures to the KNX bus. Exposures defined in {% term "`configuration.yaml`" %} cannot be unregistered. Per address only one exposure can be registered. See [expose](#exposing-entity-states-entity-attributes-or-time-to-knx-bus)
-
-{% configuration %}
-remove:
-  description: In addition to the configuration variables of [expose](#exposing-entity-states-entity-attributes-or-time-to-knx-bus) `remove` set to `true` can be used to remove exposures. Only `address` is required for removal.
-  required: false
-  type: boolean
-  default: false
-{% endconfiguration %}
+{% include integrations/actions.md %}
 
 ## Exposing entity states, entity attributes or time to KNX bus
 
@@ -728,7 +605,7 @@ The KNX binary sensor platform allows you to monitor [KNX](https://www.knx.org/)
 
 {% note %}
 
-Binary sensors are read-only entities. To write to the KNX bus, configure a [KNX Switch entity](#switch) or use the [`knx.send` action](#send).
+Binary sensors are read-only entities. To write to the KNX bus, configure a [KNX Switch entity](#switch) or use the [`knx.send` action](/actions/knx.send/).
 
 {% endnote %}
 
@@ -1936,7 +1813,7 @@ The KNX sensor platform allows you to monitor [KNX](https://www.knx.org/) sensor
 
 {% note %}
 
-Sensors are read-only entities. To write to the KNX bus, configure a [KNX Number entity](#number) or use the [`knx.send` action](#send).
+Sensors are read-only entities. To write to the KNX bus, configure a [KNX Number entity](#number) or use the [`knx.send` action](/actions/knx.send/).
 
 {% endnote %}
 


### PR DESCRIPTION
## Proposed change

Migrates the KNX bus actions (`knx.send`, `knx.read`, `knx.event_register`, and `knx.exposure_register`) from the inline `## Actions` block on the integration page to dedicated pages under `source/_actions`, and replaces the inline block with `{% include integrations/actions.md %}`.

Each action page follows the standard action page structure with UI-first instructions, UI and YAML options, and examples. The admin-only actions (`knx.event_register` and `knx.exposure_register`) note the administrator requirement. Two stale in-page `#send` links were updated to point to the new action page.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

