### PR TITLE
Migrate Insteon actions to dedicated action pages

### DIFF
--- a/source/_actions/insteon.add_all_link.markdown
+++ b/source/_actions/insteon.add_all_link.markdown
@@ -1,0 +1,77 @@
+---
+title: "Add All-Link"
+action: insteon.add_all_link
+domain: insteon
+description: "Puts the Insteon Modem into All-Linking mode to link a device."
+related_actions:
+  - insteon.delete_all_link
+  - insteon.add_default_links
+---
+
+The **Add All-Link** action puts the Insteon Modem (IM) into All-Linking mode so you can link a device to it. The modem can be linked as a controller or as a responder.
+
+This is useful when you want to manually build an All-Link between the modem and a device, for example to extend or repair the links that let your Insteon devices talk to each other.
+
+After starting this action, complete the link on the device: if the modem is a controller, put it into linking mode and then press the SET button on the device. If the modem is a responder, press the SET button on the device and then put the modem into linking mode.
+
+{% include actions/ui_header.md %}
+
+To start All-Linking mode from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Insteon: Add All-Link**.
+6. Enter the **Group** number and choose the **Mode**.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label. Only users with administrator rights can run this action.
+
+### Options in the UI
+
+{% options_ui %}
+Group:
+  description: The All-Link group number.
+  required: true
+Mode:
+  description: The linking mode of the Insteon Modem, either `controller` or `responder`.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `insteon.add_all_link`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: insteon.add_all_link
+  data:
+    group: 1
+    mode: controller
+{% endexample %}
+
+This puts the modem into All-Linking mode as a controller for group 1.
+
+### Options in YAML
+
+{% options_yaml %}
+group:
+  description: >
+    The All-Link group number.
+  required: true
+  type: integer
+mode:
+  description: >
+    The linking mode of the Insteon Modem. Set to `controller` or `responder`.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/insteon.add_all_link.markdown
+++ b/source/_actions/insteon.add_all_link.markdown
@@ -70,8 +70,6 @@ mode:
 
 {% include actions/try_it.md %}
 
-{% include actions/more_examples.md %}
-
 {% include actions/stuck.md %}
 
 {% include actions/related.md %}

--- a/source/_actions/insteon.add_default_links.markdown
+++ b/source/_actions/insteon.add_default_links.markdown
@@ -59,8 +59,6 @@ entity_id:
 
 {% include actions/try_it.md %}
 
-{% include actions/more_examples.md %}
-
 {% include actions/stuck.md %}
 
 {% include actions/related.md %}

--- a/source/_actions/insteon.add_default_links.markdown
+++ b/source/_actions/insteon.add_default_links.markdown
@@ -1,0 +1,66 @@
+---
+title: "Add default links"
+action: insteon.add_default_links
+domain: insteon
+description: "Adds the default links between a device and the Insteon Modem."
+related_actions:
+  - insteon.add_all_link
+  - insteon.delete_all_link
+---
+
+The **Add default links** action adds the default set of links between a device and the Insteon Modem (IM). These links let the modem and the device communicate properly.
+
+This is useful when a device is not responding as expected and you want to restore the standard links between it and the modem.
+
+{% include actions/ui_header.md %}
+
+To add default links from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Insteon: Add default links**.
+6. Enter the **Entity** to link.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label. Only users with administrator rights can run this action.
+
+### Options in the UI
+
+{% options_ui %}
+Entity:
+  description: The device to add the default links for.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `insteon.add_default_links`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: insteon.add_default_links
+  data:
+    entity_id: light.1a2b3c
+{% endexample %}
+
+This adds the default links between the given device and the modem.
+
+### Options in YAML
+
+{% options_yaml %}
+entity_id:
+  description: >
+    The device to add the default links for.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/insteon.delete_all_link.markdown
+++ b/source/_actions/insteon.delete_all_link.markdown
@@ -1,0 +1,68 @@
+---
+title: "Delete All-Link"
+action: insteon.delete_all_link
+domain: insteon
+description: "Removes an All-Link record from the Insteon Modem and a device."
+related_actions:
+  - insteon.add_all_link
+  - insteon.add_default_links
+---
+
+The **Delete All-Link** action tells the Insteon Modem (IM) to remove an All-Link record from its own All-Link database and from a device.
+
+This is useful when you want to unlink a device from the modem, for example when you are removing a device or cleaning up links that are no longer needed.
+
+After starting this action, press the SET button on the corresponding device to complete the process.
+
+{% include actions/ui_header.md %}
+
+To remove an All-Link from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Insteon: Delete All-Link**.
+6. Enter the **Group** number to remove.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label. Only users with administrator rights can run this action.
+
+### Options in the UI
+
+{% options_ui %}
+Group:
+  description: The All-Link group number.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `insteon.delete_all_link`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: insteon.delete_all_link
+  data:
+    group: 1
+{% endexample %}
+
+This removes the All-Link record for group 1.
+
+### Options in YAML
+
+{% options_yaml %}
+group:
+  description: >
+    The All-Link group number.
+  required: true
+  type: integer
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/insteon.delete_all_link.markdown
+++ b/source/_actions/insteon.delete_all_link.markdown
@@ -61,8 +61,6 @@ group:
 
 {% include actions/try_it.md %}
 
-{% include actions/more_examples.md %}
-
 {% include actions/stuck.md %}
 
 {% include actions/related.md %}

--- a/source/_actions/insteon.load_all_link_database.markdown
+++ b/source/_actions/insteon.load_all_link_database.markdown
@@ -74,8 +74,6 @@ reload:
 
 {% include actions/try_it.md %}
 
-{% include actions/more_examples.md %}
-
 {% include actions/stuck.md %}
 
 {% include actions/related.md %}

--- a/source/_actions/insteon.load_all_link_database.markdown
+++ b/source/_actions/insteon.load_all_link_database.markdown
@@ -1,0 +1,81 @@
+---
+title: "Load All-Link database"
+action: insteon.load_all_link_database
+domain: insteon
+description: "Loads the All-Link database for a device into memory."
+related_actions:
+  - insteon.print_all_link_database
+  - insteon.print_im_all_link_database
+---
+
+The **Load All-Link database** action loads the All-Link database (ALDB) for a device into memory, so Home Assistant can read the links stored on that device.
+
+This is useful when you want to inspect or work with the links on a device, for example before printing the database or troubleshooting how devices are linked together.
+
+{% caution %}
+Loading a device All-Link database is time consuming and can be inconsistent. It may take a long time and may need to be repeated to obtain all records.
+{% endcaution %}
+
+{% include actions/ui_header.md %}
+
+To load an All-Link database from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Insteon: Load All-Link database**.
+6. Enter the **Entity** to load. Optionally, turn on **Reload** to clear and reload all records.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Entity:
+  description: The device to load. Use `all` to load the database of all devices.
+  required: true
+Reload:
+  description: If turned on, all current records are cleared from memory (this does not affect the device) and reloaded. Otherwise, the existing records are kept and only missing records are added.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `insteon.load_all_link_database`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: insteon.load_all_link_database
+  data:
+    entity_id: light.1a2b3c
+{% endexample %}
+
+This loads the All-Link database for the given device into memory.
+
+### Options in YAML
+
+{% options_yaml %}
+entity_id:
+  description: >
+    The device to load. Use `all` to load the database of all devices.
+  required: true
+  type: string
+reload:
+  description: >
+    If set to `true`, all current records are cleared from memory (this does
+    not affect the device) and reloaded. Otherwise, the existing records are
+    kept and only missing records are added.
+  required: false
+  type: boolean
+  default: false
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/insteon.load_all_link_database.markdown
+++ b/source/_actions/insteon.load_all_link_database.markdown
@@ -13,7 +13,7 @@ The **Load All-Link database** action loads the All-Link database (ALDB) for a d
 This is useful when you want to inspect or work with the links on a device, for example before printing the database or troubleshooting how devices are linked together.
 
 {% caution %}
-Loading a device All-Link database is time consuming and can be inconsistent. It may take a long time and may need to be repeated to obtain all records.
+Loading a device All-Link database is time-consuming and can be inconsistent. It may take a long time and may need to be repeated to obtain all records.
 {% endcaution %}
 
 {% include actions/ui_header.md %}

--- a/source/_actions/insteon.print_all_link_database.markdown
+++ b/source/_actions/insteon.print_all_link_database.markdown
@@ -1,0 +1,68 @@
+---
+title: "Print All-Link database"
+action: insteon.print_all_link_database
+domain: insteon
+description: "Prints the All-Link database for a device."
+related_actions:
+  - insteon.load_all_link_database
+  - insteon.print_im_all_link_database
+---
+
+The **Print All-Link database** action prints the All-Link database (ALDB) for a device to the Home Assistant log. This requires that the database is loaded into memory first.
+
+This is useful when you want to review which links a device has stored, for example to troubleshoot how your Insteon devices are linked together.
+
+To load the database into memory first, use the [Load All-Link database](/actions/insteon.load_all_link_database/) action.
+
+{% include actions/ui_header.md %}
+
+To print an All-Link database from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Insteon: Print All-Link database**.
+6. Select the **Entity** to print.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Entity:
+  description: The device to print.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `insteon.print_all_link_database`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: insteon.print_all_link_database
+  data:
+    entity_id: light.1a2b3c
+{% endexample %}
+
+This prints the All-Link database for the given device to the log.
+
+### Options in YAML
+
+{% options_yaml %}
+entity_id:
+  description: >
+    The device to print.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/insteon.print_all_link_database.markdown
+++ b/source/_actions/insteon.print_all_link_database.markdown
@@ -61,8 +61,6 @@ entity_id:
 
 {% include actions/try_it.md %}
 
-{% include actions/more_examples.md %}
-
 {% include actions/stuck.md %}
 
 {% include actions/related.md %}

--- a/source/_actions/insteon.print_im_all_link_database.markdown
+++ b/source/_actions/insteon.print_im_all_link_database.markdown
@@ -1,0 +1,47 @@
+---
+title: "Print IM All-Link database"
+action: insteon.print_im_all_link_database
+domain: insteon
+description: "Prints the All-Link database for the Insteon Modem."
+related_actions:
+  - insteon.load_all_link_database
+  - insteon.print_all_link_database
+---
+
+The **Print IM All-Link database** action prints the All-Link database (ALDB) for the Insteon Modem (IM) to the Home Assistant log.
+
+This is useful when you want to review which links the modem itself has stored, for example to troubleshoot how your Insteon network is set up.
+
+{% include actions/ui_header.md %}
+
+To print the modem All-Link database from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Insteon: Print IM All-Link database**.
+6. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+This action has no additional options.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `insteon.print_im_all_link_database`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: insteon.print_im_all_link_database
+{% endexample %}
+
+This prints the modem All-Link database to the log.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/insteon.print_im_all_link_database.markdown
+++ b/source/_actions/insteon.print_im_all_link_database.markdown
@@ -40,8 +40,6 @@ This prints the modem All-Link database to the log.
 
 {% include actions/try_it.md %}
 
-{% include actions/more_examples.md %}
-
 {% include actions/stuck.md %}
 
 {% include actions/related.md %}

--- a/source/_actions/insteon.scene_off.markdown
+++ b/source/_actions/insteon.scene_off.markdown
@@ -1,0 +1,65 @@
+---
+title: "Scene off"
+action: insteon.scene_off
+domain: insteon
+description: "Triggers an Insteon scene to turn off."
+related_actions:
+  - insteon.scene_on
+---
+
+The **Scene off** action triggers an Insteon scene to turn off. An Insteon scene is a grouping of devices that respond together, identified by a group or scene number.
+
+This is useful when you want an automation to deactivate a scene that is stored on your Insteon devices, so all the linked devices switch off at once without Home Assistant controlling each one individually.
+
+{% include actions/ui_header.md %}
+
+To turn off an Insteon scene from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Insteon: Scene off**.
+6. Enter the **Group** number of the scene to turn off.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Group:
+  description: The Insteon group or scene number to turn off.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `insteon.scene_off`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: insteon.scene_off
+  data:
+    group: 25
+{% endexample %}
+
+This turns off Insteon scene 25.
+
+### Options in YAML
+
+{% options_yaml %}
+group:
+  description: >
+    The Insteon group or scene number to turn off.
+  required: true
+  type: integer
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/insteon.scene_off.markdown
+++ b/source/_actions/insteon.scene_off.markdown
@@ -58,8 +58,6 @@ group:
 
 {% include actions/try_it.md %}
 
-{% include actions/more_examples.md %}
-
 {% include actions/stuck.md %}
 
 {% include actions/related.md %}

--- a/source/_actions/insteon.scene_on.markdown
+++ b/source/_actions/insteon.scene_on.markdown
@@ -58,8 +58,6 @@ group:
 
 {% include actions/try_it.md %}
 
-{% include actions/more_examples.md %}
-
 {% include actions/stuck.md %}
 
 {% include actions/related.md %}

--- a/source/_actions/insteon.scene_on.markdown
+++ b/source/_actions/insteon.scene_on.markdown
@@ -1,0 +1,65 @@
+---
+title: "Scene on"
+action: insteon.scene_on
+domain: insteon
+description: "Triggers an Insteon scene to turn on."
+related_actions:
+  - insteon.scene_off
+---
+
+The **Scene on** action triggers an Insteon scene to turn on. An Insteon scene is a grouping of devices that respond together, identified by a group or scene number.
+
+This is useful when you want an automation to activate a scene that is stored on your Insteon devices, so all the linked devices switch on at once without Home Assistant controlling each one individually.
+
+{% include actions/ui_header.md %}
+
+To turn on an Insteon scene from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Insteon: Scene on**.
+6. Enter the **Group** number of the scene to turn on.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Group:
+  description: The Insteon group or scene number to turn on.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `insteon.scene_on`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: insteon.scene_on
+  data:
+    group: 25
+{% endexample %}
+
+This turns on Insteon scene 25.
+
+### Options in YAML
+
+{% options_yaml %}
+group:
+  description: >
+    The Insteon group or scene number to turn on.
+  required: true
+  type: integer
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/insteon.x10_all_lights_off.markdown
+++ b/source/_actions/insteon.x10_all_lights_off.markdown
@@ -1,0 +1,66 @@
+---
+title: "X10 all lights off"
+action: insteon.x10_all_lights_off
+domain: insteon
+description: "Sends an X10 All lights off command for a house code."
+related_actions:
+  - insteon.x10_all_lights_on
+  - insteon.x10_all_units_off
+---
+
+The **X10 all lights off** action sends an X10 *All lights off* command to every X10 light that uses the given house code.
+
+This is useful when you have X10 lights on your Insteon network and want to switch them all off at once, for example as part of a leaving-home or bedtime automation.
+
+{% include actions/ui_header.md %}
+
+To send an X10 All lights off command from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Insteon: X10 all lights off**.
+6. Choose the **Housecode**.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Housecode:
+  description: The X10 house code, from `a` to `p`.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `insteon.x10_all_lights_off`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: insteon.x10_all_lights_off
+  data:
+    housecode: a
+{% endexample %}
+
+This sends an X10 All lights off command to house code `a`.
+
+### Options in YAML
+
+{% options_yaml %}
+housecode:
+  description: >
+    The X10 house code, from `a` to `p`.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/insteon.x10_all_lights_off.markdown
+++ b/source/_actions/insteon.x10_all_lights_off.markdown
@@ -59,8 +59,6 @@ housecode:
 
 {% include actions/try_it.md %}
 
-{% include actions/more_examples.md %}
-
 {% include actions/stuck.md %}
 
 {% include actions/related.md %}

--- a/source/_actions/insteon.x10_all_lights_off.markdown
+++ b/source/_actions/insteon.x10_all_lights_off.markdown
@@ -10,7 +10,7 @@ related_actions:
 
 The **X10 all lights off** action sends an X10 *All lights off* command to every X10 light that uses the given house code.
 
-This is useful when you have X10 lights on your Insteon network and want to switch them all off at once, for example as part of a leaving-home or bedtime automation.
+This is useful when you have X10 lights on your Insteon network and want to switch them all off at once, for example as part of a leaving home or bedtime automation.
 
 {% include actions/ui_header.md %}
 

--- a/source/_actions/insteon.x10_all_lights_on.markdown
+++ b/source/_actions/insteon.x10_all_lights_on.markdown
@@ -59,8 +59,6 @@ housecode:
 
 {% include actions/try_it.md %}
 
-{% include actions/more_examples.md %}
-
 {% include actions/stuck.md %}
 
 {% include actions/related.md %}

--- a/source/_actions/insteon.x10_all_lights_on.markdown
+++ b/source/_actions/insteon.x10_all_lights_on.markdown
@@ -10,7 +10,7 @@ related_actions:
 
 The **X10 all lights on** action sends an X10 *All lights on* command to every X10 light that uses the given house code.
 
-This is useful when you have X10 lights on your Insteon network and want to switch them all on at once, for example as part of an arriving-home automation.
+This is useful when you have X10 lights on your Insteon network and want to switch them all on at once, for example as part of an arriving home automation.
 
 {% include actions/ui_header.md %}
 

--- a/source/_actions/insteon.x10_all_lights_on.markdown
+++ b/source/_actions/insteon.x10_all_lights_on.markdown
@@ -1,0 +1,66 @@
+---
+title: "X10 all lights on"
+action: insteon.x10_all_lights_on
+domain: insteon
+description: "Sends an X10 All lights on command for a house code."
+related_actions:
+  - insteon.x10_all_lights_off
+  - insteon.x10_all_units_off
+---
+
+The **X10 all lights on** action sends an X10 *All lights on* command to every X10 light that uses the given house code.
+
+This is useful when you have X10 lights on your Insteon network and want to switch them all on at once, for example as part of an arriving-home automation.
+
+{% include actions/ui_header.md %}
+
+To send an X10 All lights on command from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Insteon: X10 all lights on**.
+6. Choose the **Housecode**.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Housecode:
+  description: The X10 house code, from `a` to `p`.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `insteon.x10_all_lights_on`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: insteon.x10_all_lights_on
+  data:
+    housecode: a
+{% endexample %}
+
+This sends an X10 All lights on command to house code `a`.
+
+### Options in YAML
+
+{% options_yaml %}
+housecode:
+  description: >
+    The X10 house code, from `a` to `p`.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/insteon.x10_all_units_off.markdown
+++ b/source/_actions/insteon.x10_all_units_off.markdown
@@ -59,8 +59,6 @@ housecode:
 
 {% include actions/try_it.md %}
 
-{% include actions/more_examples.md %}
-
 {% include actions/stuck.md %}
 
 {% include actions/related.md %}

--- a/source/_actions/insteon.x10_all_units_off.markdown
+++ b/source/_actions/insteon.x10_all_units_off.markdown
@@ -8,7 +8,7 @@ related_actions:
   - insteon.x10_all_lights_off
 ---
 
-The **X10 all units off** action sends an X10 *All units off* command to every X10 device that uses the given house code.
+The **X10 all units off** action sends an X10 **All units off** command to every X10 device that uses the given house code.
 
 This is useful when you have X10 devices on your Insteon network and want to switch them all off at once, for example as part of a leaving home or bedtime automation.
 
@@ -45,7 +45,7 @@ action: |
     housecode: a
 {% endexample %}
 
-This sends an X10 All units off command to house code `a`.
+This sends an X10 **All units off** command to house code `a`.
 
 ### Options in YAML
 

--- a/source/_actions/insteon.x10_all_units_off.markdown
+++ b/source/_actions/insteon.x10_all_units_off.markdown
@@ -10,7 +10,7 @@ related_actions:
 
 The **X10 all units off** action sends an X10 *All units off* command to every X10 device that uses the given house code.
 
-This is useful when you have X10 devices on your Insteon network and want to switch them all off at once, for example as part of a leaving-home or bedtime automation.
+This is useful when you have X10 devices on your Insteon network and want to switch them all off at once, for example as part of a leaving home or bedtime automation.
 
 {% include actions/ui_header.md %}
 

--- a/source/_actions/insteon.x10_all_units_off.markdown
+++ b/source/_actions/insteon.x10_all_units_off.markdown
@@ -1,0 +1,66 @@
+---
+title: "X10 all units off"
+action: insteon.x10_all_units_off
+domain: insteon
+description: "Sends an X10 All units off command for a house code."
+related_actions:
+  - insteon.x10_all_lights_on
+  - insteon.x10_all_lights_off
+---
+
+The **X10 all units off** action sends an X10 *All units off* command to every X10 device that uses the given house code.
+
+This is useful when you have X10 devices on your Insteon network and want to switch them all off at once, for example as part of a leaving-home or bedtime automation.
+
+{% include actions/ui_header.md %}
+
+To send an X10 All units off command from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Insteon: X10 all units off**.
+6. Choose the **Housecode**.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Housecode:
+  description: The X10 house code, from `a` to `p`.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `insteon.x10_all_units_off`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: insteon.x10_all_units_off
+  data:
+    housecode: a
+{% endexample %}
+
+This sends an X10 All units off command to house code `a`.
+
+### Options in YAML
+
+{% options_yaml %}
+housecode:
+  description: >
+    The X10 house code, from `a` to `p`.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/insteon.markdown
+++ b/source/_integrations/insteon.markdown
@@ -123,7 +123,7 @@ Editing a device's All-Link Database can cause the device to become unresponsive
 
 ## Controlling Insteon scenes
 
-Insteon scenes are controlled through automations. Use the [Scene on](/actions/insteon.scene_on/) action to turn a scene on and the [Scene off](/actions/insteon.scene_off/) action to turn it off. Both take the Insteon group or scene number.
+Insteon scenes are controlled through automations and scripts. Use the [Scene on](/actions/insteon.scene_on/) action to turn a scene on and the [Scene off](/actions/insteon.scene_off/) action to turn it off. Both take the Insteon group or scene number.
 
 ## Events and Mini-Remotes
 

--- a/source/_integrations/insteon.markdown
+++ b/source/_integrations/insteon.markdown
@@ -123,22 +123,7 @@ Editing a device's All-Link Database can cause the device to become unresponsive
 
 ## Controlling Insteon scenes
 
-Controlling an Insteon scene on or off is done via automations. Two actions are provided to support this feature:
-
-- **insteon.scene_on**
-  - **group**: (required) The Insteon scene number to trigger.
-- **insteon.scene_off**
-  - **group**: (required) The Insteon scene to turn off
-
-```yaml
-automation:
-  # Control an Insteon scene 25
-  - alias: "Turn on scene 25"
-    actions:
-      - action: insteon.scene_on
-        data:
-          group: 25
-```
+Insteon scenes are controlled through automations. Use the [Scene on](/actions/insteon.scene_on/) action to turn a scene on and the [Scene off](/actions/insteon.scene_off/) action to turn it off. Both take the Insteon group or scene number.
 
 ## Events and Mini-Remotes
 
@@ -189,16 +174,7 @@ automation:
           entity_id: light.some_light
 ```
 
-## Actions
-
-The following actions are available:
-
-- **insteon.add_all_link**: Puts the Insteon Modem (IM) into All-Linking mode. The IM can be set as a controller or a responder. If the IM is a controller, put the IM into linking mode then press the SET button on the device. If the IM is a responder, press the SET button on the device then put the IM into linking mode.
-- **insteon.delete_all_link**: Tells the Insteon Modem (IM) to remove an All-Link record from the All-Link Database of the IM and a device. Once the IM is set to delete the link, press the SET button on the corresponding device to complete the process.
-- **insteon.load_all_link_database**: Load the All-Link Database for a device. WARNING - Loading a device All-Link database may take a LONG time and may need to be repeated to obtain all records.
-- **insteon.print_all_link_database**: Print the All-Link Database for a device. Requires that the All-Link Database is loaded first.
-- **insteon.print_im_all_link_database**: Print the All-Link Database for the Insteon Modem (IM).
-- **insteon.add_default_links**: Add a set of default links between the modem and the device to facilitate proper communication between them.
+{% include integrations/actions.md %}
 
 ## Device overrides
 


### PR DESCRIPTION
## Proposed change

Migrates the Insteon actions from the inline action lists on the integration page to dedicated pages under `source/_actions`, and replaces the inline blocks with `{% include integrations/actions.md %}`.

This covers the eight actions that were documented inline (`scene_on`, `scene_off`, `add_all_link`, `delete_all_link`, `load_all_link_database`, `print_all_link_database`, `print_im_all_link_database`, and `add_default_links`). It also adds pages for the three X10 actions (`x10_all_units_off`, `x10_all_lights_on`, and `x10_all_lights_off`), which are callable in Home Assistant but were not documented before, so the action list is complete.

The administrator-only actions (`add_all_link`, `delete_all_link`, and `add_default_links`) note the administrator requirement. The "Controlling Insteon scenes" section is kept as a short conceptual note that links to the new scene action pages.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

