### PR TITLE
Motionblinds: migrate action to a dedicated page

### DIFF
--- a/source/_actions/motion_blinds.set_absolute_position.markdown
+++ b/source/_actions/motion_blinds.set_absolute_position.markdown
@@ -84,6 +84,33 @@ width:
 
 {% include actions/more_examples.md %}
 
+### Automation: Set blinds to a privacy position in the evening
+
+This automation moves a Top Down Bottom Up blind to a privacy position every evening, covering the lower part of the window while leaving the top open for light.
+
+- Trigger: the sun sets
+- Action: set the absolute position of the blind
+  - Target: the bedroom blind
+  - Absolute position: `40`
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  alias: "Evening privacy position"
+  triggers:
+    - trigger: sun
+      event: sunset
+  actions:
+    - action: motion_blinds.set_absolute_position
+      target:
+        entity_id: cover.bedroom_blind
+      data:
+        absolute_position: 40
+{% endexample %}
+
+{% enddetails %}
+
 {% include actions/stuck.md %}
 
 {% include actions/related.md %}

--- a/source/_actions/motion_blinds.set_absolute_position.markdown
+++ b/source/_actions/motion_blinds.set_absolute_position.markdown
@@ -76,9 +76,9 @@ width:
 
 ## Good to know
 
-- For simple blinds, this action does the same as the [cover set position](/integrations/cover/) action.
-- For TDBU blinds, the absolute position is relative to the window, so `0` is the bottom of the window and `100` is the top. The [cover set position](/integrations/cover/) action instead uses a scaled position relative to the space the blind is allowed to move in.
-- On tilt-capable blinds, the blind first moves to the new position and then adjusts its tilt. Using the separate cover position and cover tilt position actions one after the other makes the blind stop and tilt before it reaches the position.
+- For simple blinds, this action does the same as the [`cover.set_cover_position`](/actions/cover.set_cover_position/) action.
+- For TDBU blinds, the absolute position is relative to the window, so `0` is the bottom of the window and `100` is the top. The [`cover.set_cover_position`](/actions/cover.set_cover_position/) action instead uses a scaled position relative to the space the blind is allowed to move in.
+- On tilt-capable blinds, the blind first moves to the new position and then adjusts its tilt. Using the separate [`cover.set_cover_position`](/actions/cover.set_cover_position/) and [`cover.set_cover_tilt_position`](/actions/cover.set_cover_tilt_position/) actions one after the other makes the blind stop and tilt before it reaches the intended position.
 
 {% include actions/try_it.md %}
 

--- a/source/_actions/motion_blinds.set_absolute_position.markdown
+++ b/source/_actions/motion_blinds.set_absolute_position.markdown
@@ -1,0 +1,89 @@
+---
+title: "Set absolute position"
+action: motion_blinds.set_absolute_position
+domain: motion_blinds
+description: "Moves a Motionblinds cover to an exact position."
+---
+
+The **Set absolute position** action moves a Motionblinds cover to an exact position, and on tilt-capable blinds it can also set the tilt at the same time.
+
+This is useful when you want an automation to move a blind to a precise position, in particular for Top Down Bottom Up (TDBU) blinds, where the position is set relative to the window itself.
+
+{% include actions/targets.md domain="cover" %}
+
+{% include actions/ui_header.md %}
+
+To set the absolute position from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Motionblinds: Set absolute position**.
+6. Choose the Motionblinds cover, then enter the **Absolute position** and any other options.
+7. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Absolute position:
+  description: The position to move to, from 0 to 100.
+  required: true
+Tilt position:
+  description: The tilt position to move to, from 0 to 100. Only applies to tilt-capable blinds.
+  required: false
+Width:
+  description: The width that is covered, from 0 to 100. Only applies to TDBU Combined entities.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `motion_blinds.set_absolute_position`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: motion_blinds.set_absolute_position
+  target:
+    entity_id: cover.blind
+  data:
+    absolute_position: 70
+{% endexample %}
+
+This moves the selected cover to position `70`.
+
+### Options in YAML
+
+{% options_yaml %}
+absolute_position:
+  description: >
+    The position to move to, from 0 to 100.
+  required: true
+  type: integer
+tilt_position:
+  description: >
+    The tilt position to move to, from 0 to 100. Only applies to tilt-capable
+    blinds.
+  required: false
+  type: integer
+width:
+  description: >
+    The width that is covered, from 0 to 100. Only applies to TDBU Combined
+    entities.
+  required: false
+  type: integer
+{% endoptions_yaml %}
+
+## Good to know
+
+- For simple blinds, this action does the same as the [cover set position](/integrations/cover/) action.
+- For TDBU blinds, the absolute position is relative to the window, so `0` is the bottom of the window and `100` is the top. The [cover set position](/integrations/cover/) action instead uses a scaled position relative to the space the blind is allowed to move in.
+- On tilt-capable blinds, the blind first moves to the new position and then adjusts its tilt. Using the separate cover position and cover tilt position actions one after the other makes the blind stop and tilt before it reaches the position.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/motion_blinds.markdown
+++ b/source/_integrations/motion_blinds.markdown
@@ -172,25 +172,7 @@ When the `motion_blinds.set_absolute_position` action is used with values that w
 
 Therefore it is always safe to use any of the actions in Home Assistant with the TDBU blinds.
 
-## Action `motion_blinds.set_absolute_position`
-
-For simple blinds the `motion_blinds.set_absolute_position` does the same as `cover.set_cover_position` action.
-
-### TDBU blinds
-
-For TDBU blinds `motion_blinds.set_absolute_position` will set the absolute position relative to the window itself.
-The `cover.set_cover_position` will set the scaled position relative to the space in which the TDBU blind is allowed to move.
-
-### Tilt capable blinds
-
-For tilt capable blinds a new position and tilt can be specified and the blind will move to the new position and then adjust its tilt. If the normal `cover.set_cover_position` is issued and immediately after a `cover.set_cover_tilt_position` is issued, the blind will stop moving and start adjusting the tilt before it reaches the intended position.
-
-| Data attribute | Optional | Description                                                                                       |
-| ---------------------- | -------- | ------------------------------------------------------------------------------------------------- |
-| `entity_id`            | yes      | Name of the Motionblinds cover entity to control. For example `cover.TopDownBottomUp-Bottom-0001` |
-| `absolute_position`    | no       | Absolute position to move to. For example 70                                                      |
-| `tilt_position`        | yes      | Tilt position to move to. For example 50                                                          |
-| `width`                | yes      | Optionally specify the width that is covered, only for TDBU Combined entities. For example 30     |
+{% include integrations/actions.md %}
 
 ## Troubleshooting
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project.
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Migrate the Motionblinds **Set absolute position** action from the inline section on the integration page into a dedicated action page under `source/_actions/`, and replace the inline section with `{% include integrations/actions.md %}`.

The behavioral notes about simple, TDBU, and tilt-capable blinds are preserved on the action page, and the integration page keeps its broader Top Down Bottom Up explanation.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to: home-assistant/core (Motionblinds actions)
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - [Documentation for existing features](https://developers.home-assistant.io/docs/documenting/standards#which-branch-to-target) uses the `current` branch.
  - Documentation for new or changing features uses the `next` branch.
- [x] The documentation follows the [Home Assistant documentation standards](https://developers.home-assistant.io/docs/documenting/standards).


- Part of epic: home-assistant/epics#96