### PR TITLE
StreamLabs: migrate action to a dedicated page

### DIFF
--- a/source/_actions/streamlabswater.set_away_mode.markdown
+++ b/source/_actions/streamlabswater.set_away_mode.markdown
@@ -67,6 +67,31 @@ location_id:
 
 {% include actions/more_examples.md %}
 
+### Automation: Switch to away mode when everyone leaves
+
+This automation sets your StreamLabs Water Monitor to away mode whenever everyone leaves home, so it watches water usage differently while the house is empty.
+
+- Trigger: the home zone changes to having nobody present
+- Action: set the monitor to away mode
+  - Away mode: `away`
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  alias: "Water monitor away mode when nobody is home"
+  triggers:
+    - trigger: numeric_state
+      entity_id: zone.home
+      below: 1
+  actions:
+    - action: streamlabswater.set_away_mode
+      data:
+        away_mode: away
+{% endexample %}
+
+{% enddetails %}
+
 {% include actions/stuck.md %}
 
 {% include actions/related.md %}

--- a/source/_actions/streamlabswater.set_away_mode.markdown
+++ b/source/_actions/streamlabswater.set_away_mode.markdown
@@ -71,9 +71,9 @@ location_id:
 
 This automation sets your StreamLabs Water Monitor to away mode whenever everyone leaves home, so it watches water usage differently while the house is empty.
 
-- Trigger: the home zone changes to having nobody present
-- Action: set the monitor to away mode
-  - Away mode: `away`
+- **Trigger**: the home zone changes to having nobody present
+- **Action**: StreamLabs: Set away mode
+  - **Away mode**: `away`
 
 {% details "Show example YAML" %}
 

--- a/source/_actions/streamlabswater.set_away_mode.markdown
+++ b/source/_actions/streamlabswater.set_away_mode.markdown
@@ -5,11 +5,11 @@ domain: streamlabswater
 description: "Sets the home or away mode for a StreamLabs Water Monitor."
 ---
 
-The **Set away mode** action sets a StreamLabs Water Monitor to home or away mode.
+Use this action to set home or away mode for a StreamLabs Water Monitor location.
 
 This is useful when you want an automation to switch the monitor to away mode while you are out, for example to change how it watches for water usage.
 
-This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label. If you have more than one location, use the **Location ID** option to choose which one to change. When you leave it empty, the first available location is used.
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label. If you have more than one location, use the **Location ID** option to choose which one to change. If you leave it empty, the first available location is used.
 
 {% include actions/ui_header.md %}
 

--- a/source/_actions/streamlabswater.set_away_mode.markdown
+++ b/source/_actions/streamlabswater.set_away_mode.markdown
@@ -1,0 +1,72 @@
+---
+title: "Set away mode"
+action: streamlabswater.set_away_mode
+domain: streamlabswater
+description: "Sets the home or away mode for a StreamLabs Water Monitor."
+---
+
+The **Set away mode** action sets a StreamLabs Water Monitor to home or away mode.
+
+This is useful when you want an automation to switch the monitor to away mode while you are out, for example to change how it watches for water usage.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label. If you have more than one location, use the **Location ID** option to choose which one to change. When you leave it empty, the first available location is used.
+
+{% include actions/ui_header.md %}
+
+To set the away mode from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **StreamLabs: Set away mode**.
+6. Choose the **Away mode**. If you have more than one location, also enter the **Location ID**.
+7. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Away mode:
+  description: The mode to set, either `home` or `away`.
+  required: true
+Location ID:
+  description: The location ID of the StreamLabs Water Monitor to change. Leave it empty to use the first available location.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `streamlabswater.set_away_mode`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: streamlabswater.set_away_mode
+  data:
+    away_mode: away
+{% endexample %}
+
+This sets the monitor at the first available location to away mode.
+
+### Options in YAML
+
+{% options_yaml %}
+away_mode:
+  description: >
+    The mode to set, either `home` or `away`.
+  required: true
+  type: string
+location_id:
+  description: >
+    The location ID of the StreamLabs Water Monitor to change. Leave it empty
+    to use the first available location.
+  required: false
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/streamlabswater.markdown
+++ b/source/_integrations/streamlabswater.markdown
@@ -29,11 +29,4 @@ In preparation for using this integration you will need to request an API key fo
 
 {% include integrations/config_flow.md %}
 
-## Action `set_away_mode`
-
-You can use the `streamlabswater.set_away_mode` action to set the mode to `home` or `away`. The away mode will only be changed for the configured location.
-
-| Data attribute | Optional | Description                                                                        |
-|------------------------|----------|------------------------------------------------------------------------------------|
-| `away_mode`            | no       | String, must be `away` or `home`.                                                  |
-| `location_id`          | yes      | String, location id to change away mode for. Defaults to first available location. |
+{% include integrations/actions.md %}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project.
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Migrate the StreamLabs **Set away mode** action from the inline section on the integration page into a dedicated action page under `source/_actions/`, and replace the inline section with `{% include integrations/actions.md %}`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to: home-assistant/core (StreamLabs actions)
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - [Documentation for existing features](https://developers.home-assistant.io/docs/documenting/standards#which-branch-to-target) uses the `current` branch.
  - Documentation for new or changing features uses the `next` branch.
- [x] The documentation follows the [Home Assistant documentation standards](https://developers.home-assistant.io/docs/documenting/standards).


- Part of epic: home-assistant/epics#96