### PR TITLE
Nintendo Switch parental controls: migrate action to a dedicated page

### DIFF
--- a/source/_actions/nintendo_parental_controls.add_bonus_time.markdown
+++ b/source/_actions/nintendo_parental_controls.add_bonus_time.markdown
@@ -1,0 +1,72 @@
+---
+title: "Add bonus time"
+action: nintendo_parental_controls.add_bonus_time
+domain: nintendo_parental_controls
+description: "Adds bonus screen time to a Nintendo Switch."
+---
+
+The **Add bonus time** action grants extra screen time to a Nintendo Switch, on top of the maximum allowed screen time.
+
+This is useful when you want an automation to reward a little extra play time, for example after chores are done or on a special occasion.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, entity, or label. Instead, you select the Nintendo Switch to grant bonus time to through the **Device** option.
+
+{% include actions/ui_header.md %}
+
+To add bonus time from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Nintendo Switch parental controls: Add bonus time**.
+6. Choose the **Device**, then enter the **Bonus time**.
+7. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Device:
+  description: The Nintendo Switch to add bonus time to.
+  required: true
+Bonus time:
+  description: The amount of bonus time to add, in minutes, from 5 to 30.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `nintendo_parental_controls.add_bonus_time`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: nintendo_parental_controls.add_bonus_time
+  data:
+    device_id: 1b4a46c6d0f3406c80d275f5b0c6483b
+    bonus_time: 15
+{% endexample %}
+
+This adds 15 minutes of bonus screen time to the selected Nintendo Switch.
+
+### Options in YAML
+
+{% options_yaml %}
+device_id:
+  description: >
+    The ID of the Nintendo Switch device to add bonus time to.
+  required: true
+  type: string
+bonus_time:
+  description: >
+    The amount of bonus time to add, in minutes, from 5 to 30.
+  required: true
+  type: integer
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/nintendo_parental_controls.add_bonus_time.markdown
+++ b/source/_actions/nintendo_parental_controls.add_bonus_time.markdown
@@ -28,10 +28,8 @@ To add bonus time from an automation or a script:
 {% options_ui %}
 Device:
   description: The Nintendo Switch to add bonus time to.
-  required: true
 Bonus time:
   description: The amount of bonus time to add, in minutes, from 5 to 30.
-  required: true
 {% endoptions_ui %}
 
 {% include actions/yaml_header.md %}

--- a/source/_actions/nintendo_parental_controls.add_bonus_time.markdown
+++ b/source/_actions/nintendo_parental_controls.add_bonus_time.markdown
@@ -65,6 +65,33 @@ bonus_time:
 
 {% include actions/more_examples.md %}
 
+### Automation: Reward bonus time when chores are done
+
+This automation grants 15 minutes of extra screen time whenever a helper that tracks finished chores is switched on.
+
+- Trigger: the chores-done helper turns on
+- Action: add bonus time to the Nintendo Switch
+  - Device: the child's Nintendo Switch
+  - Bonus time: `15`
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  alias: "Bonus screen time for finished chores"
+  triggers:
+    - trigger: state
+      entity_id: input_boolean.chores_done
+      to: "on"
+  actions:
+    - action: nintendo_parental_controls.add_bonus_time
+      data:
+        device_id: 1b4a46c6d0f3406c80d275f5b0c6483b
+        bonus_time: 15
+{% endexample %}
+
+{% enddetails %}
+
 {% include actions/stuck.md %}
 
 {% include actions/related.md %}

--- a/source/_integrations/nintendo_parental_controls.markdown
+++ b/source/_integrations/nintendo_parental_controls.markdown
@@ -95,23 +95,7 @@ The **Nintendo Switch Parental Controls** integration provides the following ent
 - **Bedtime end time**
   - **Description**: The time that bedtime should end. Set to 00:00 to disable. Accepts values between 05:00 and 09:00 for the bedtime end time.
 
-## Actions
-
-The integration provides the following actions.
-
-### Action: Add bonus time
-
-The `nintendo_parental_controls.add_bonus_time` action adds additional bonus screen time to a specified device, which is granted outside of the maximum allowed screentime.
-
-- **Data attribute**: `config_entry_id`
-  - **Description**: The ID of the config entry containing the device to grant bonus time.
-  - **Optional**: No
-- **Data attribute**: `device_id`
-  - **Description**: The ID of the device to grant bonus time.
-  - **Optional**: No
-- **Data attribute**: `bonus_time`
-  - **Description**: The amount of time in minutes to grant (minimum of 5, maximum of 30).
-  - **Optional**: No
+{% include integrations/actions.md %}
 
 ## Known limitations
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project.
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Migrate the Nintendo Switch parental controls **Add bonus time** action from the inline section on the integration page into a dedicated action page under `source/_actions/`, and replace the inline section with `{% include integrations/actions.md %}`.

The inline docs listed a `config_entry_id` field, but the action only accepts `device_id` and `bonus_time`. That field is dropped on the new action page.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to: home-assistant/core (Nintendo Switch parental controls actions)
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - [Documentation for existing features](https://developers.home-assistant.io/docs/documenting/standards#which-branch-to-target) uses the `current` branch.
  - Documentation for new or changing features uses the `next` branch.
- [x] The documentation follows the [Home Assistant documentation standards](https://developers.home-assistant.io/docs/documenting/standards).


- Part of epic: home-assistant/epics#96