### PR TITLE
Duck DNS: migrate set TXT action to a dedicated page

### DIFF
--- a/source/_actions/duckdns.set_txt.markdown
+++ b/source/_actions/duckdns.set_txt.markdown
@@ -59,12 +59,35 @@ config_entry_id:
 txt:
   description: >
     The value for the TXT record. Omit to clear the TXT record.
+  required: false
   type: string
 {% endoptions_yaml %}
 
 {% include actions/try_it.md %}
 
 {% include actions/more_examples.md %}
+
+### Script: clear the TXT record after a challenge
+
+Clear the TXT record once an <abbr title="Automatic Certificate Management Environment">ACME</abbr> DNS-01 challenge is complete, so the validation value is no longer published.
+
+- **Action**: Duck DNS: Set TXT
+  - **Integration ID**: Your Duck DNS integration
+  - **TXT**: Leave empty to clear the record
+
+{% details "Show example YAML" %}
+
+{% example %}
+script: |
+  clear_duckdns_txt:
+    alias: "Clear the Duck DNS TXT record"
+    sequence:
+      - action: duckdns.set_txt
+        data:
+          config_entry_id: YOUR_CONFIG_ENTRY_ID
+{% endexample %}
+
+{% enddetails %}
 
 {% include actions/stuck.md %}
 

--- a/source/_actions/duckdns.set_txt.markdown
+++ b/source/_actions/duckdns.set_txt.markdown
@@ -9,7 +9,7 @@ The **Set TXT** action sets the TXT record of your Duck DNS subdomain.
 
 This is mostly useful for automating an <abbr title="Automatic Certificate Management Environment">ACME</abbr> DNS-01 challenge, where a certificate authority asks you to publish a specific value in your domain's TXT record to prove that you control the domain.
 
-This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label. Instead, you select which Duck DNS integration to update through the **Integration ID** option. If you only have one Duck DNS integration set up, you can leave it empty.
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label. Select the Duck DNS integration to update in **Integration ID**. Leaving **Integration ID** empty is deprecated and will be removed in a future release.
 
 {% include actions/ui_header.md %}
 
@@ -20,14 +20,14 @@ To set the TXT record from an automation or a script:
 3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
 4. In the **Then do** section, select **Add action**.
 5. From the search box, search for and select **Duck DNS: Set TXT**.
-6. Optionally choose the **Integration ID**, then enter the **TXT** value.
+6. Choose the **Integration ID**, then enter the **TXT** value.
 7. Select **Save**.
 
 ### Options in the UI
 
 {% options_ui %}
 Integration ID:
-  description: The Duck DNS integration to update. If you only have one Duck DNS integration set up, you can leave this empty.
+  description: The Duck DNS integration to update. Leaving this empty is deprecated and will be removed in a future release.
   required: false
 TXT:
   description: The value for the TXT record. Leave empty to clear the TXT record.
@@ -42,6 +42,7 @@ In YAML, refer to this action as `duckdns.set_txt`. A basic example looks like t
 action: |
   action: duckdns.set_txt
   data:
+    config_entry_id: YOUR_CONFIG_ENTRY_ID
     txt: LoqXcYV8...jxAjEuX0.9jg46WB3...fm21mqTI
 {% endexample %}
 
@@ -52,14 +53,12 @@ This sets the TXT record of your Duck DNS subdomain to the given value.
 {% options_yaml %}
 config_entry_id:
   description: >
-    The ID of the Duck DNS integration to update. If you only have one
-    Duck DNS integration set up, you can leave this out.
+    The ID of the Duck DNS integration to update. Leaving this out is deprecated and will be removed in a future release.
   required: false
   type: string
 txt:
   description: >
-    The value for the TXT record. Leave empty to clear the TXT record.
-  required: false
+    The value for the TXT record. Omit to clear the TXT record.
   type: string
 {% endoptions_yaml %}
 

--- a/source/_actions/duckdns.set_txt.markdown
+++ b/source/_actions/duckdns.set_txt.markdown
@@ -27,7 +27,7 @@ To set the TXT record from an automation or a script:
 
 {% options_ui %}
 Integration ID:
-  description: The Duck DNS integration to update. Leaving this empty is deprecated and will be removed in a future release.
+  description: The Duck DNS integration to update. Leaving this empty is deprecated and will not be an option in a future release.
   required: false
 TXT:
   description: The value for the TXT record. Leave empty to clear the TXT record.
@@ -53,7 +53,7 @@ This sets the TXT record of your Duck DNS subdomain to the given value.
 {% options_yaml %}
 config_entry_id:
   description: >
-    The ID of the Duck DNS integration to update. Leaving this out is deprecated and will be removed in a future release.
+    The ID of the Duck DNS integration to update. Leaving this empty is deprecated and will not be an option in a future release.
   required: false
   type: string
 txt:

--- a/source/_actions/duckdns.set_txt.markdown
+++ b/source/_actions/duckdns.set_txt.markdown
@@ -1,0 +1,72 @@
+---
+title: "Set TXT"
+action: duckdns.set_txt
+domain: duckdns
+description: "Sets the TXT record of your Duck DNS subdomain."
+---
+
+The **Set TXT** action sets the TXT record of your Duck DNS subdomain.
+
+This is mostly useful for automating an <abbr title="Automatic Certificate Management Environment">ACME</abbr> DNS-01 challenge, where a certificate authority asks you to publish a specific value in your domain's TXT record to prove that you control the domain.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label. Instead, you select which Duck DNS integration to update through the **Integration ID** option. If you only have one Duck DNS integration set up, you can leave it empty.
+
+{% include actions/ui_header.md %}
+
+To set the TXT record from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Duck DNS: Set TXT**.
+6. Optionally choose the **Integration ID**, then enter the **TXT** value.
+7. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Integration ID:
+  description: The Duck DNS integration to update. If you only have one Duck DNS integration set up, you can leave this empty.
+  required: false
+TXT:
+  description: The value for the TXT record. Leave empty to clear the TXT record.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `duckdns.set_txt`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: duckdns.set_txt
+  data:
+    txt: LoqXcYV8...jxAjEuX0.9jg46WB3...fm21mqTI
+{% endexample %}
+
+This sets the TXT record of your Duck DNS subdomain to the given value.
+
+### Options in YAML
+
+{% options_yaml %}
+config_entry_id:
+  description: >
+    The ID of the Duck DNS integration to update. If you only have one
+    Duck DNS integration set up, you can leave this out.
+  required: false
+  type: string
+txt:
+  description: >
+    The value for the TXT record. Leave empty to clear the TXT record.
+  required: false
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/duckdns.markdown
+++ b/source/_integrations/duckdns.markdown
@@ -47,29 +47,9 @@ To set up the integration, you need your Duck DNS subdomain and token. You can f
     required: true
 {% endconfiguration_basic %}
 
-## Action `set_txt`
+{% include integrations/actions.md %}
 
-Set the TXT record of your Duck DNS subdomain.
-
-| Data attribute         | Optional | Description                 |
-| ---------------------- | -------- | --------------------------- |
-| `config_entry_id`      | no       | The Duck DNS integration ID.|
-| `txt`                  | yes      | Payload for the TXT record. |
-
-{% details "Example YAML configuration" %}
-
-
-```yaml
-action: duckdns.set_txt
-data:
-  config_entry_id: 01234567890ABCDEF # Replace with your actual config entry ID
-  txt: LoqXcYV8...jxAjEuX0.9jg46WB3...fm21mqTI # Replace with a valid ACME DNS-01 challenge
-```
-
-
-{% enddetails %}
-
-## Data updates  
+## Data updates
 
 This integration syncs your public IP with your Duck DNS subdomain every 5 minutes.
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project.
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Migrate the Duck DNS **Set TXT** action from the inline section on the integration page into a dedicated action page under `source/_actions/`, and replace the inline section with `{% include integrations/actions.md %}`.

The inline docs marked the integration ID field as required, but the action accepts it as optional and falls back to the single configured entry. That is corrected on the new action page.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to: home-assistant/core (Duck DNS set TXT action)
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - [Documentation for existing features](https://developers.home-assistant.io/docs/documenting/standards#which-branch-to-target) uses the `current` branch.
  - Documentation for new or changing features uses the `next` branch.
- [x] The documentation follows the [Home Assistant documentation standards](https://developers.home-assistant.io/docs/documenting/standards).


- Part of epic: home-assistant/epics#96