### PR TITLE
Viessmann ViCare: migrate set ViCare mode action to a dedicated page

### DIFF
--- a/source/_actions/vicare.set_vicare_mode.markdown
+++ b/source/_actions/vicare.set_vicare_mode.markdown
@@ -52,10 +52,7 @@ This sets the selected climate device to the `heating` mode.
 vicare_mode:
   description: >
     The new ViCare mode. For the values your device supports, see the
-    `vicare_modes` attribute of the climate entity. Depending on the
-    device, supported values include `dhw`, `dhwAndHeating`,
-    `dhwAndHeatingCooling`, `forcedNormal`, `forcedReduced`, `heating`,
-    and `standby`.
+    `vicare_modes` attribute of the climate entity.
   required: true
   type: string
 {% endoptions_yaml %}

--- a/source/_actions/vicare.set_vicare_mode.markdown
+++ b/source/_actions/vicare.set_vicare_mode.markdown
@@ -67,6 +67,33 @@ For a mapping of the standard Home Assistant climate modes to Viessmann operatio
 
 {% include actions/more_examples.md %}
 
+### Automation: Switch to reduced heating at night
+
+This automation sets your Viessmann device to a reduced heating mode every night, then you can pair it with a second automation in the morning to return to your normal mode.
+
+- Trigger: the time is 11:00 PM
+- Action: set the ViCare mode
+  - Target: the living room climate entity
+  - ViCare mode: `heating`
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  alias: "Reduced heating at night"
+  triggers:
+    - trigger: time
+      at: "23:00:00"
+  actions:
+    - action: vicare.set_vicare_mode
+      target:
+        entity_id: climate.living_room
+      data:
+        vicare_mode: heating
+{% endexample %}
+
+{% enddetails %}
+
 {% include actions/stuck.md %}
 
 {% include actions/related.md %}

--- a/source/_actions/vicare.set_vicare_mode.markdown
+++ b/source/_actions/vicare.set_vicare_mode.markdown
@@ -1,0 +1,75 @@
+---
+title: "Set ViCare mode"
+action: vicare.set_vicare_mode
+domain: vicare
+description: "Sets the mode of the climate device as defined by Viessmann."
+---
+
+The **Set ViCare mode** action sets the mode of the climate device as defined by Viessmann.
+
+This gives you more fine-grained control of the heating modes than the standard [`climate.set_hvac_mode`](/integrations/climate/) action, because it exposes the Viessmann operation modes directly.
+
+{% include actions/targets.md domain="climate" %}
+
+{% include actions/ui_header.md %}
+
+To set the ViCare mode from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Viessmann ViCare: Set ViCare mode**.
+6. Select the climate entity as the target, then enter the **ViCare mode**.
+7. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+ViCare mode:
+  description: The new ViCare mode. For the values your device supports, see the `vicare_modes` attribute of the climate entity.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `vicare.set_vicare_mode`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: vicare.set_vicare_mode
+  target:
+    entity_id: climate.living_room
+  data:
+    vicare_mode: heating
+{% endexample %}
+
+This sets the selected climate device to the `heating` mode.
+
+### Options in YAML
+
+{% options_yaml %}
+vicare_mode:
+  description: >
+    The new ViCare mode. For the values your device supports, see the
+    `vicare_modes` attribute of the climate entity. Depending on the
+    device, supported values include `dhw`, `dhwAndHeating`,
+    `dhwAndHeatingCooling`, `forcedNormal`, `forcedReduced`, `heating`,
+    and `standby`.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+## Good to know
+
+The available modes depend on your specific Viessmann device. Always check the `vicare_modes` attribute of the climate entity for the values it accepts.
+
+For a mapping of the standard Home Assistant climate modes to Viessmann operation modes, see [setting the HVAC mode](/integrations/vicare/#setting-the-hvac-mode) on the integration page.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/vicare.markdown
+++ b/source/_integrations/vicare.markdown
@@ -108,67 +108,27 @@ Number entities are available to adjust values like the predefined temperature f
 
 Select entities allow configuring the domestic hot water (<abbr title="domestic hot water">DHW</abbr>) operating mode of your Viessmann device. Available options depend on the specific device model and may include `balanced`, `economical`, or `off` modes.
 
-## Actions
+{% include integrations/actions.md %}
 
-The following actions of the [climate integration](/integrations/climate/) are provided by the ViCare integration: `set_temperature`, `set_hvac_mode`, `set_preset_mode` 
+## Climate and water heater control
 
-The following actions of the [water_heater integration](/integrations/water_heater/) are provided by the ViCare integration: `set_temperature`
+The ViCare integration also provides the standard [climate](/integrations/climate/) and [water_heater](/integrations/water_heater/) actions. The ViCare integration provides `set_temperature`, `set_hvac_mode`, and `set_preset_mode` for climate entities, and `set_temperature` for the water heater. A few of these behave in ViCare-specific ways.
 
-### Action: Set ViCare mode
+### Setting the temperature
 
-The `vicare.set_vicare_mode` action sets the mode for the climate device as defined by Viessmann (see [set_hvac_mode](#action-set-hvac-mode) for a mapping to Home Assistant Climate modes). This allows more fine-grained control of the heating modes.
+The `climate.set_temperature` action always affects the current normal temperature or, if a preset is set, the temperature of the preset (that is, a Viessmann program such as eco or comfort).
 
-| Data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `entity_id` | yes | String or list of strings that point at `entity_id`'s of climate devices to control. To target all entities, use the `all` keyword instead of entity_id. |
-| `vicare_mode` | no | New value of ViCare mode. For supported values, see the `vicare_modes` attribute of the climate {% term entity %}. |
+### Setting the HVAC mode
 
-### Action: Set temperature
+The ViCare integration maps the Home Assistant HVAC modes to Viessmann operation modes as follows:
 
-The `climate.set_temperature` action sets the target temperature to the given temperature.
+- `off`: maps to `ForcedReduced`, which permanently sets heating to the reduced temperature. This also deactivates domestic hot water.
+- `heat`: maps to `ForcedNormal`, which permanently sets heating to the normal temperature.
+- `auto`: maps to `DHWandHeating`, which switches between the reduced and normal temperature based on the heating schedule programmed in your device.
 
-| Data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `entity_id` | yes | String or list of strings that point at `entity_id`'s of climate devices to control. To target all entities, use `all` keyword instead of entity_id. |
-| `temperature` | no | Desired target temperature. |
+### Setting the preset mode
 
-Note that `set_temperature` will always affect the current normal temperature or, if a preset is set, the temperature of the preset (that is, Viessman program like eco or comfort).
-
-### Action: Set HVAC mode
-
-The `climate.set_hvac_mode` action sets the HVAC mode for the climate device. The following modes are supported:
-
-The ViCare {% term integration %} has the following mapping of HVAC modes to Viessmann operation modes:
-
-| HVAC mode | Viessmann mode | Description |
-| ---------------------- | -------- | ----------- |
-| `off` | `ForcedReduced` | Permanently set heating to reduced temperature. Note: This will also deactivate domestic hot water. |
-| `heat` | `ForcedNormal` | Permanently set heating to normal temperature. |
-| `auto` | `DHWandHeating` | Switches between reduced and normal temperature as by the heating schedule programmed in your device. |
- 
-| Data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `entity_id` | yes | String or list of strings that point at `entity_id`'s of climate devices to control. To target all entities, use `all` keyword instead of entity_id. |
-| `hvac_mode` | no | New value of HVAC mode. |
-
-### Action: Set preset mode
-
-The `climate.set_preset_mode` action sets the preset mode. Supported preset modes are *eco* and *comfort*. These are identical to the respective Viessmann programs and are only active temporarily for 8 hours.
-Eco mode reduces the target temperature by 3°C, whereas Comfort mode sets the target temperature to a configurable value. Please consult your heating device manual for more information.
-
-| Data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `entity_id` | yes | String or list of strings that point at `entity_id`'s of climate devices to control. To target all entities, use `all` keyword instead of entity_id. |
-| `preset_mode` | no | New value of preset mode. |
-
-### Action: Set water heater temperature
-
-The `water_heater.set_temperature` action sets the target temperature of domestic hot water to the given temperature.
-
-| Data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `entity_id` | yes | String or list of strings that point at `entity_id`'s of climate devices to control. |
-| `temperature` | no | New target temperature for water heater. |
+The `climate.set_preset_mode` action supports the *eco* and *comfort* preset modes. These are identical to the respective Viessmann programs and are only active temporarily for 8 hours. Eco mode reduces the target temperature by 3°C, whereas comfort mode sets the target temperature to a configurable value. Consult your heating device manual for more information.
 
 ## Troubleshooting
 

--- a/source/_integrations/vicare.markdown
+++ b/source/_integrations/vicare.markdown
@@ -128,7 +128,7 @@ The ViCare integration maps the Home Assistant HVAC modes to Viessmann operation
 
 ### Setting the preset mode
 
-The `climate.set_preset_mode` action supports the *eco* and *comfort* preset modes. These are identical to the respective Viessmann programs and are only active temporarily for 8 hours. Eco mode reduces the target temperature by 3°C, whereas comfort mode sets the target temperature to a configurable value. Consult your heating device manual for more information.
+The `climate.set_preset_mode` action supports the *eco* and *comfort* preset modes. These are identical to the respective Viessmann programs and are only active temporarily for 8 hours. Eco mode reduces the target temperature by 3°C, whereas Comfort mode sets the target temperature to a configurable value. Consult your heating device manual for more information.
 
 ## Troubleshooting
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project.
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Migrate the Viessmann ViCare **Set ViCare mode** action from the inline section on the integration page into a dedicated action page under `source/_actions/`, and replace the inline section with `{% include integrations/actions.md %}`. The ViCare-specific behavioral notes for the standard climate and water heater actions are kept in a separate section, with the tables converted to lists.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to: home-assistant/core (ViCare set ViCare mode action)
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - [Documentation for existing features](https://developers.home-assistant.io/docs/documenting/standards#which-branch-to-target) uses the `current` branch.
  - Documentation for new or changing features uses the `next` branch.
- [x] The documentation follows the [Home Assistant documentation standards](https://developers.home-assistant.io/docs/documenting/standards).


- Part of epic: home-assistant/epics#96