### PR TITLE
TP-Link Omada: migrate reconnect client action to a dedicated page

### DIFF
--- a/source/_actions/tplink_omada.reconnect_client.markdown
+++ b/source/_actions/tplink_omada.reconnect_client.markdown
@@ -1,0 +1,69 @@
+---
+title: "Reconnect wireless client"
+action: tplink_omada.reconnect_client
+domain: tplink_omada
+description: "Forces a wireless client to reconnect to the Omada network."
+---
+
+The **Reconnect wireless client** action forces a Wi-Fi client to reconnect to your Omada network. This is useful when a client has a troublesome connection that needs to be reset.
+
+This action does not target an entity. Instead, you select which Omada controller to use and provide the client to reconnect.
+
+{% include actions/ui_header.md %}
+
+To reconnect a wireless client from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **TP-Link Omada: Reconnect wireless client**.
+6. Enter the **MAC address** of the client you want to reconnect. If you have more than one Omada controller, also select the **Omada controller** to use.
+7. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Omada controller:
+  description: The Omada integration the wireless client is connected to. If you have a single controller, you can leave this empty.
+  required: false
+MAC address:
+  description: The MAC address of the wireless client to reconnect.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `tplink_omada.reconnect_client`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: tplink_omada.reconnect_client
+  data:
+    mac: "01-23-45-67-89-AB"
+{% endexample %}
+
+This forces the client with the given MAC address to reconnect to the network.
+
+### Options in YAML
+
+{% options_yaml %}
+config_entry_id:
+  description: >
+    The Omada integration the wireless client is connected to. If you
+    have a single controller, you can leave this out.
+  required: false
+  type: string
+mac:
+  description: The MAC address of the wireless client to reconnect.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/tplink_omada.reconnect_client.markdown
+++ b/source/_actions/tplink_omada.reconnect_client.markdown
@@ -7,7 +7,7 @@ description: "Forces a wireless client to reconnect to the Omada network."
 
 The **Reconnect wireless client** action forces a Wi-Fi client to reconnect to your Omada network. This is useful when a client has a troublesome connection that needs to be reset.
 
-This action does not target an entity. Instead, you select which Omada controller to use and provide the client to reconnect.
+This action does not target an entity. Instead, you select which Omada controller to use and provide the MAC address of the client you want to reconnect.
 
 {% include actions/ui_header.md %}
 
@@ -40,7 +40,7 @@ In YAML, refer to this action as `tplink_omada.reconnect_client`. A basic exampl
 action: |
   action: tplink_omada.reconnect_client
   data:
-    mac: "01-23-45-67-89-AB"
+    mac: "01:23:45:67:89:AB"
 {% endexample %}
 
 This forces the client with the given MAC address to reconnect to the network.

--- a/source/_actions/tplink_omada.reconnect_client.markdown
+++ b/source/_actions/tplink_omada.reconnect_client.markdown
@@ -68,9 +68,9 @@ mac:
 
 This automation forces a wireless client to reconnect to your Omada network whenever a device that depends on it becomes unavailable for a few minutes, which can recover a stuck Wi-Fi connection.
 
-- Trigger: the device's entity stays unavailable for 5 minutes
-- Action: reconnect the wireless client
-  - MAC address: the client's MAC address
+- **Trigger**: the device's entity stays unavailable for 5 minutes
+- **Action**: TP-Link Omada: Reconnect wireless client
+  - **MAC address**: the client's MAC address
 
 {% details "Show example YAML" %}
 

--- a/source/_actions/tplink_omada.reconnect_client.markdown
+++ b/source/_actions/tplink_omada.reconnect_client.markdown
@@ -64,6 +64,33 @@ mac:
 
 {% include actions/more_examples.md %}
 
+### Automation: Reconnect a device when it goes unavailable
+
+This automation forces a wireless client to reconnect to your Omada network whenever a device that depends on it becomes unavailable for a few minutes, which can recover a stuck Wi-Fi connection.
+
+- Trigger: the device's entity stays unavailable for 5 minutes
+- Action: reconnect the wireless client
+  - MAC address: the client's MAC address
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  alias: "Reconnect stuck Wi-Fi device"
+  triggers:
+    - trigger: state
+      entity_id: sensor.garage_sensor_signal
+      to: "unavailable"
+      for:
+        minutes: 5
+  actions:
+    - action: tplink_omada.reconnect_client
+      data:
+        mac: "01:23:45:67:89:AB"
+{% endexample %}
+
+{% enddetails %}
+
 {% include actions/stuck.md %}
 
 {% include actions/related.md %}

--- a/source/_integrations/tplink_omada.markdown
+++ b/source/_integrations/tplink_omada.markdown
@@ -96,20 +96,7 @@ The TP-Link Omada integration fetches data from the Omada Controller every 5 min
 
 Note: The TP-Link Omada controller takes a few minutes to detect when a client disconnects from the Wi-Fi network, even with more regular polling updates.
 
-## Actions
-
-The integration provides the following actions.
-
-### Action: Reconnect client
-
-The `tplink_omada.reconnect_client` action is used to force a Wi-Fi client to reconnect to the network. This is useful if you have a troublesome client network connection that needs to be reset.
-
-- **Data attribute**: `config_entry_id`
-  - **Description**: The instance of the Omada integration that the Wi-Fi client is connected to.
-  - **Optional**: Yes
-- **Data attribute**: `mac`
-  - **Description**: The MAC address of the Wi-Fi client to reconnect.
-  - **Optional**: No
+{% include integrations/actions.md %}
 
 ## Removing the integration
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project.
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Migrate the TP-Link Omada **Reconnect wireless client** action from the inline section on the integration page into a dedicated action page under `source/_actions/`, and replace the inline section with `{% include integrations/actions.md %}`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to: home-assistant/core (TP-Link Omada reconnect client action)
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - [Documentation for existing features](https://developers.home-assistant.io/docs/documenting/standards#which-branch-to-target) uses the `current` branch.
  - Documentation for new or changing features uses the `next` branch.
- [x] The documentation follows the [Home Assistant documentation standards](https://developers.home-assistant.io/docs/documenting/standards).


- Part of epic: home-assistant/epics#96