### PR TITLE
Lutron Homeworks: migrate send command action to a dedicated page

### DIFF
--- a/source/_actions/homeworks.send_command.markdown
+++ b/source/_actions/homeworks.send_command.markdown
@@ -1,0 +1,88 @@
+---
+title: "Send command"
+action: homeworks.send_command
+domain: homeworks
+description: "Sends a custom command to a Lutron Homeworks controller."
+---
+
+The **Send command** action sends a custom command to your Lutron Homeworks controller. You can send a single command or a list of commands.
+
+This action does not target an entity. Instead, you provide the controller to send to and the command to send.
+
+In addition to the [commands supported by the controller](https://assets.lutron.com/a/documents/hwi%20rs232%20protocol.pdf), the special command `DELAY <ms>` is supported, where `<ms>` is the number of milliseconds to wait before continuing.
+
+{% include actions/ui_header.md %}
+
+To send a command from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Lutron Homeworks: Send command**.
+6. Enter the **Controller ID** and the **Command** to send.
+7. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Controller ID:
+  description: The controller to which the command is sent.
+  required: true
+Command:
+  description: The command to send to the controller. This can be a single command or a list of commands.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `homeworks.send_command`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: homeworks.send_command
+  data:
+    controller_id: "homeworks"
+    command: "KBP, [02:08:02:01], 1"
+{% endexample %}
+
+This sends a single command to the controller.
+
+### Options in YAML
+
+{% options_yaml %}
+controller_id:
+  description: The controller to which the command is sent.
+  required: true
+  type: string
+command:
+  description: >
+    The command to send to the controller. This can be a single command
+    or a list of commands. The special command `DELAY <ms>` waits the
+    given number of milliseconds before continuing.
+  required: true
+  type: list
+{% endoptions_yaml %}
+
+## Good to know
+
+To send several commands in sequence, pass a list. The following example sends `KBP`, waits 0.5 seconds, then sends `KBR` to simulate a keypad button press that lasts half a second:
+
+{% example %}
+action: |
+  action: homeworks.send_command
+  data:
+    controller_id: "homeworks"
+    command:
+      - "KBP, [02:08:02:01], 1"
+      - "DELAY 500"
+      - "KBR, [02:08:02:01], 1"
+{% endexample %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/homeworks.send_command.markdown
+++ b/source/_actions/homeworks.send_command.markdown
@@ -87,10 +87,9 @@ action: |
 
 This automation simulates a keypad button press on your Homeworks controller every day at sunset, which you can use to recall a scene programmed on the keypad.
 
-- Trigger: the sun sets
-- Action: send a button press and release to the controller
-  - Controller: `homeworks`
-  - Press and release the keypad button with a short delay in between
+- **Trigger**: the sun sets
+- **Action**: Lutron Homeworks: Send command (press and release the keypad button with a short delay in between)
+  - **Controller**: `homeworks`
 
 {% details "YAML example for recalling evening scene at sunset" %}
 

--- a/source/_actions/homeworks.send_command.markdown
+++ b/source/_actions/homeworks.send_command.markdown
@@ -92,7 +92,7 @@ This automation simulates a keypad button press on your Homeworks controller eve
   - Controller: `homeworks`
   - Press and release the keypad button with a short delay in between
 
-{% details "Show example YAML" %}
+{% details "YAML example for recalling evening scene at sunset" %}
 
 {% example %}
 automation: |

--- a/source/_actions/homeworks.send_command.markdown
+++ b/source/_actions/homeworks.send_command.markdown
@@ -61,7 +61,7 @@ command:
     or a list of commands. The special command `DELAY <ms>` waits the
     given number of milliseconds before continuing.
   required: true
-  type: list
+  type: string
 {% endoptions_yaml %}
 
 ## Good to know

--- a/source/_actions/homeworks.send_command.markdown
+++ b/source/_actions/homeworks.send_command.markdown
@@ -83,6 +83,35 @@ action: |
 
 {% include actions/more_examples.md %}
 
+### Automation: Simulate a keypad press at sunset
+
+This automation simulates a keypad button press on your Homeworks controller every day at sunset, which you can use to recall a scene programmed on the keypad.
+
+- Trigger: the sun sets
+- Action: send a button press and release to the controller
+  - Controller: `homeworks`
+  - Press and release the keypad button with a short delay in between
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  alias: "Recall evening scene at sunset"
+  triggers:
+    - trigger: sun
+      event: sunset
+  actions:
+    - action: homeworks.send_command
+      data:
+        controller_id: "homeworks"
+        command:
+          - "KBP, [02:08:02:01], 1"
+          - "DELAY 500"
+          - "KBR, [02:08:02:01], 1"
+{% endexample %}
+
+{% enddetails %}
+
 {% include actions/stuck.md %}
 
 {% include actions/related.md %}

--- a/source/_integrations/homeworks.markdown
+++ b/source/_integrations/homeworks.markdown
@@ -29,27 +29,4 @@ Homeworks keypad buttons are momentary switches. The button is pressed and relea
 
 The protocol for automatically extracting device information from the controller isn't documented. Lights and keypads need to be added manually. This is done by configuring the integration after it has been added.
 
-## Actions
-
-### Action: Send command
-
-The `homeworks.send_command` action sends a custom command to the Lutron Homeworks controller.
-
-| Data attribute | Optional | Example                 | Description                                         |
-| ---------------------- | -------- | ----------------------- | --------------------------------------------------- |
-| `controller_id`        | No       | `homeworks`             | The controller to which the command should be sent to. |
-| `command`              | No       | `KBP, [02:08:02:01], 1` | The command you want to send. This can either be a single command or a list of commands. In addition to the [commands supported by the controller](https://assets.lutron.com/a/documents/hwi%20rs232%20protocol.pdf), the special command `DELAY <ms>` is supported, where ms is the number of milliseconds to sleep. |
-
-#### Sending a list of commands 
-
-The example shows how to send `KBP`, wait 0.5 seconds, then send `KBR` to simulate a keypad button keypress with a duration of a half second.
-
-```yaml
-action: homeworks.send_command
-data:
-  controller_id: "homeworks"
-  command:
-    - "KBP, [02:08:02:01], 1"
-    - "DELAY 500"
-    - "KBR, [02:08:02:01], 1"
-```
+{% include integrations/actions.md %}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project.
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Migrate the Lutron Homeworks **Send command** action from the inline section on the integration page into a dedicated action page under `source/_actions/`, and replace the inline section with `{% include integrations/actions.md %}`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to: home-assistant/core (Lutron Homeworks send command action)
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - [Documentation for existing features](https://developers.home-assistant.io/docs/documenting/standards#which-branch-to-target) uses the `current` branch.
  - Documentation for new or changing features uses the `next` branch.
- [x] The documentation follows the [Home Assistant documentation standards](https://developers.home-assistant.io/docs/documenting/standards).


- Part of epic: home-assistant/epics#96