### PR TITLE
Huawei LTE: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/huawei_lte.resume_integration.markdown
+++ b/source/_actions/huawei_lte.resume_integration.markdown
@@ -57,8 +57,6 @@ url:
 
 {% include actions/try_it.md %}
 
-{% include actions/more_examples.md %}
-
 {% include actions/stuck.md %}
 
 {% include actions/related.md %}

--- a/source/_actions/huawei_lte.resume_integration.markdown
+++ b/source/_actions/huawei_lte.resume_integration.markdown
@@ -1,0 +1,64 @@
+---
+title: "Resume integration"
+action: huawei_lte.resume_integration
+domain: huawei_lte
+description: "Resumes a suspended integration."
+related_actions:
+  - huawei_lte.suspend_integration
+---
+
+The **Resume integration** action resumes the integration after it was suspended with the [Suspend integration](/actions/huawei_lte.suspend_integration/) action. The integration logs back in to the router on demand.
+
+This action does not target an entity. Only users with administrator rights can run it. If you have more than one router configured, you provide the router URL.
+
+{% include actions/ui_header.md %}
+
+To resume the integration from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Huawei LTE: Resume integration**.
+6. If you have more than one router configured, enter the **URL** of the router to resume.
+7. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+URL:
+  description: The URL of the router to resume the integration for. Optional when only one router is configured.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `huawei_lte.resume_integration`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: huawei_lte.resume_integration
+  data:
+    url: "http://192.168.100.1/"
+{% endexample %}
+
+This resumes the integration for the given router.
+
+### Options in YAML
+
+{% options_yaml %}
+url:
+  description: >
+    The URL of the router to resume the integration for. Optional when
+    only one router is configured.
+  required: false
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/huawei_lte.suspend_integration.markdown
+++ b/source/_actions/huawei_lte.suspend_integration.markdown
@@ -16,7 +16,7 @@ This action does not target an entity. Only users with administrator rights can 
 To suspend the integration from an automation or a script:
 
 1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
-2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+2. Open an existing automation or script, or select **Create** to start a new one.
 3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
 4. In the **Then do** section, select **Add action**.
 5. From the search box, search for and select **Huawei LTE: Suspend integration**.
@@ -56,8 +56,6 @@ url:
 {% endoptions_yaml %}
 
 {% include actions/try_it.md %}
-
-{% include actions/more_examples.md %}
 
 {% include actions/stuck.md %}
 

--- a/source/_actions/huawei_lte.suspend_integration.markdown
+++ b/source/_actions/huawei_lte.suspend_integration.markdown
@@ -1,0 +1,64 @@
+---
+title: "Suspend integration"
+action: huawei_lte.suspend_integration
+domain: huawei_lte
+description: "Suspends the integration and logs it out from the router."
+related_actions:
+  - huawei_lte.resume_integration
+---
+
+The **Suspend integration** action suspends the integration. It logs the integration out from the router and stops accessing it. This is useful when you temporarily need to access the router web interface from another source, such as a web browser. Use the [Resume integration](/actions/huawei_lte.resume_integration/) action to resume.
+
+This action does not target an entity. Only users with administrator rights can run it. If you have more than one router configured, you provide the router URL.
+
+{% include actions/ui_header.md %}
+
+To suspend the integration from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Huawei LTE: Suspend integration**.
+6. If you have more than one router configured, enter the **URL** of the router to suspend.
+7. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+URL:
+  description: The URL of the router to suspend the integration for. Optional when only one router is configured.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `huawei_lte.suspend_integration`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: huawei_lte.suspend_integration
+  data:
+    url: "http://192.168.100.1/"
+{% endexample %}
+
+This suspends the integration for the given router.
+
+### Options in YAML
+
+{% options_yaml %}
+url:
+  description: >
+    The URL of the router to suspend the integration for. Optional when
+    only one router is configured.
+  required: false
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/huawei_lte.markdown
+++ b/source/_integrations/huawei_lte.markdown
@@ -100,25 +100,7 @@ Unauthenticated mode:
   description: Whether to run in unauthenticated mode. See above for more information between authenticated and unauthenticated modes.
 {% endconfiguration_basic %}
 
-## Actions
-
-The following router action actions are available. When invoked by a user, administrator access is required.
-
-### Action: Suspend integration
-
-The `huawei_lte.suspend_integration` action suspends the integration. This logs the integration out from the router and stops accessing it. This is useful if accessing the router web interface from another source (such as a web browser) is temporarily required. Invoke the `huawei_lte.resume_integration` action to resume.
-
-| Data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `url`                  | yes, if only one router configured | Router URL. |
-
-### Action: Resume integration
-
-The `huawei_lte.resume_integration` action resumes the suspended integration.
-
-| Data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `url`                  | yes, if only one router configured | Router URL. |
+{% include integrations/actions.md %}
 
 ## Tested devices
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project.
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Migrate the Huawei LTE **Suspend integration** and **Resume integration** actions from the inline sections on the integration page into dedicated action pages under `source/_actions/`, and replace the inline sections with `{% include integrations/actions.md %}`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to: home-assistant/core (Huawei LTE suspend/resume actions)
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - [Documentation for existing features](https://developers.home-assistant.io/docs/documenting/standards#which-branch-to-target) uses the `current` branch.
  - Documentation for new or changing features uses the `next` branch.
- [x] The documentation follows the [Home Assistant documentation standards](https://developers.home-assistant.io/docs/documenting/standards).


- Part of epic: home-assistant/epics#96