### PR TITLE
ColorExtractor: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/color_extractor.get_color.markdown
+++ b/source/_actions/color_extractor.get_color.markdown
@@ -9,7 +9,7 @@ related_actions:
 
 The **Get predominant color** action extracts the predominant color from an image and returns it as response data. Unlike [Turn on](/actions/color_extractor.turn_on/), this action does not change any light. It only reports the color, so you can use the result however you like, for example to set a different light, store it, or drive another action.
 
-This action does not target an entity. Instead, you provide the image as a web URL or as a file on the system running Home Assistant.
+To use the returned color in later steps, store it in a response variable. This action does not target an entity. Instead, you provide the image as a web URL or as a file on the system running Home Assistant.
 
 {% include actions/ui_header.md %}
 

--- a/source/_actions/color_extractor.get_color.markdown
+++ b/source/_actions/color_extractor.get_color.markdown
@@ -1,0 +1,85 @@
+---
+title: "Get predominant color"
+action: color_extractor.get_color
+domain: color_extractor
+description: "Returns the predominant RGB color found in an image provided by URL or file path."
+related_actions:
+  - color_extractor.turn_on
+---
+
+The **Get predominant color** action extracts the predominant color from an image and returns it as response data. Unlike [Turn on](/actions/color_extractor.turn_on/), this action does not change any light. It only reports the color, so you can use the result however you like, for example to set a different light, store it, or drive another action.
+
+This action does not target an entity. Instead, you provide the image as a web URL or as a file on the system running Home Assistant.
+
+{% include actions/ui_header.md %}
+
+To get the predominant color from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **ColorExtractor: Get predominant color**.
+6. Enter either an **Image URL** or an **Image path**.
+7. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Image URL:
+  description: The URL of the image to extract the color from. The URL must be allowed in `allowlist_external_urls`. Cannot be combined with an image path.
+  required: false
+Image path:
+  description: The full system path to the image to extract the color from. The path must be allowed in `allowlist_external_dirs`. Cannot be combined with an image URL.
+  required: false
+{% endoptions_ui %}
+
+Provide either an image URL or an image path. You cannot use both in the same action call.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `color_extractor.get_color`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: color_extractor.get_color
+  data:
+    color_extract_url: "https://www.example.com/images/logo.png"
+  response_variable: extracted_color
+{% endexample %}
+
+This extracts the predominant color and stores it in the `extracted_color` response variable.
+
+### Options in YAML
+
+{% options_yaml %}
+color_extract_url:
+  description: >
+    The URL of the image to extract the color from. The URL must be allowed
+    in `allowlist_external_urls`. Cannot be combined with `color_extract_path`.
+  required: false
+  type: string
+color_extract_path:
+  description: >
+    The full system path to the image to extract the color from. The path
+    must be allowed in `allowlist_external_dirs`. Cannot be combined with
+    `color_extract_url`.
+  required: false
+  type: string
+{% endoptions_yaml %}
+
+Provide either `color_extract_url` or `color_extract_path`. The two options are mutually exclusive and cannot be used together.
+
+## Response data
+
+The response data is a mapping with a single `color` field. It holds the predominant color as a list of three RGB values, each from 0 to 255, such as `[255, 128, 0]`.
+
+## Good to know
+
+- Make sure any external URL is added to [`allowlist_external_urls`](/integrations/homeassistant/#allowlist_external_urls) and any local file path is added to [`allowlist_external_dirs`](/integrations/homeassistant/#allowlist_external_dirs). Otherwise, the action cannot access the image and returns an error.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/color_extractor.get_color.markdown
+++ b/source/_actions/color_extractor.get_color.markdown
@@ -11,6 +11,10 @@ The **Get predominant color** action extracts the predominant color from an imag
 
 To use the returned color in later steps, store it in a response variable. This action does not target an entity. Instead, you provide the image as a web URL or as a file on the system running Home Assistant.
 
+## Prerequisites
+
+Before using this action, make sure any external URLs are added to [`allowlist_external_urls`](/integrations/homeassistant/#allowlist_external_urls) and any local file paths are added to [`allowlist_external_dirs`](/integrations/homeassistant/#allowlist_external_dirs). Without this, the action cannot access the image and returns an error.
+
 {% include actions/ui_header.md %}
 
 To get the predominant color from an automation or a script:

--- a/source/_actions/color_extractor.turn_on.markdown
+++ b/source/_actions/color_extractor.turn_on.markdown
@@ -9,7 +9,7 @@ related_actions:
 
 The **Turn on** action extracts the predominant color from an image and turns on one or more lights set to that color. You provide the image as a web URL or as a file on the system running Home Assistant, and the action picks the most dominant color and applies it as the light's RGB color.
 
-Because this action then calls [`light.turn_on`](/integrations/light/), you can also pass any valid `light.turn_on` options, such as `brightness_pct` or `transition`. The `rgb_color` is set for you from the extracted color.
+Because this action then calls [`light.turn_on`](/actions/light.turn_on/), you can also pass any valid `light.turn_on` options, such as `brightness_pct` or `transition`. The `rgb_color` is set for you from the extracted color.
 
 {% include actions/ui_header.md %}
 
@@ -77,7 +77,7 @@ Provide either `color_extract_url` or `color_extract_path`. The two options are 
 ## Good to know
 
 - Make sure any external URL is added to [`allowlist_external_urls`](/integrations/homeassistant/#allowlist_external_urls) and any local file path is added to [`allowlist_external_dirs`](/integrations/homeassistant/#allowlist_external_dirs). Otherwise, the action cannot access the image and returns an error.
-- You can pass any [`light.turn_on`](/integrations/light/) options along with this action, such as `brightness_pct` or `transition`. The RGB color is always set from the extracted color.
+- You can pass any [`light.turn_on`](/actions/light.turn_on/) options along with this action, such as `brightness_pct` or `transition`. The RGB color is always set from the extracted color.
 
 {% include actions/try_it.md %}
 

--- a/source/_actions/color_extractor.turn_on.markdown
+++ b/source/_actions/color_extractor.turn_on.markdown
@@ -11,6 +11,10 @@ The **Turn on** action extracts the predominant color from an image and turns on
 
 Because this action then calls [`light.turn_on`](/actions/light.turn_on/), you can also pass any valid `light.turn_on` options, such as `brightness_pct` or `transition`. The `rgb_color` is set for you from the extracted color.
 
+## Prerequisites
+
+Before using this action, make sure any external URLs are added to [`allowlist_external_urls`](/integrations/homeassistant/#allowlist_external_urls) and any local file paths are added to [`allowlist_external_dirs`](/integrations/homeassistant/#allowlist_external_dirs). Without this, the action cannot access the image and returns an error.
+
 {% include actions/ui_header.md %}
 
 To turn on a light with an extracted color from an automation or a script:

--- a/source/_actions/color_extractor.turn_on.markdown
+++ b/source/_actions/color_extractor.turn_on.markdown
@@ -1,0 +1,117 @@
+---
+title: "Turn on"
+action: color_extractor.turn_on
+domain: color_extractor
+description: "Sets a light to the predominant color found in an image provided by URL or file path."
+related_actions:
+  - color_extractor.get_color
+---
+
+The **Turn on** action extracts the predominant color from an image and turns on one or more lights set to that color. You provide the image as a web URL or as a file on the system running Home Assistant, and the action picks the most dominant color and applies it as the light's RGB color.
+
+Because this action then calls [`light.turn_on`](/integrations/light/), you can also pass any valid `light.turn_on` options, such as `brightness_pct` or `transition`. The `rgb_color` is set for you from the extracted color.
+
+{% include actions/ui_header.md %}
+
+To turn on a light with an extracted color from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the area, floor, device, label, or light entity you want to control.
+6. From the actions shown for that target, select **ColorExtractor: Turn on**.
+7. Enter either an **Image URL** or an **Image path**, and set any of the options you need.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Image URL:
+  description: The URL of the image to extract the color from. The URL must be allowed in `allowlist_external_urls`. Cannot be combined with an image path.
+  required: false
+Image path:
+  description: The full system path to the image to extract the color from. The path must be allowed in `allowlist_external_dirs`. Cannot be combined with an image URL.
+  required: false
+{% endoptions_ui %}
+
+Provide either an image URL or an image path. You cannot use both in the same action call.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `color_extractor.turn_on`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: color_extractor.turn_on
+  target:
+    entity_id: light.shelf_leds
+  data:
+    color_extract_url: "https://www.example.com/images/logo.png"
+{% endexample %}
+
+This extracts the predominant color from the image and turns on `light.shelf_leds` set to that color.
+
+### Options in YAML
+
+{% options_yaml %}
+color_extract_url:
+  description: >
+    The URL of the image to extract the color from. The URL must be allowed
+    in `allowlist_external_urls`. Cannot be combined with `color_extract_path`.
+  required: false
+  type: string
+color_extract_path:
+  description: >
+    The full system path to the image to extract the color from. The path
+    must be allowed in `allowlist_external_dirs`. Cannot be combined with
+    `color_extract_url`.
+  required: false
+  type: string
+{% endoptions_yaml %}
+
+Provide either `color_extract_url` or `color_extract_path`. The two options are mutually exclusive and cannot be used together.
+
+{% include actions/targets.md domain="light" %}
+
+## Good to know
+
+- Make sure any external URL is added to [`allowlist_external_urls`](/integrations/homeassistant/#allowlist_external_urls) and any local file path is added to [`allowlist_external_dirs`](/integrations/homeassistant/#allowlist_external_dirs). Otherwise, the action cannot access the image and returns an error.
+- You can pass any [`light.turn_on`](/integrations/light/) options along with this action, such as `brightness_pct` or `transition`. The RGB color is always set from the extracted color.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: match shelf lights to Chromecast album art
+
+Use this automation to set your shelf lights to the predominant color of the album art whenever it changes on a Chromecast.
+
+- **Trigger**: Chromecast state changes
+- **Action**: ColorExtractor: Turn on
+  - **Target**: Shelf lights
+  - **Image URL**: The Chromecast album art
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  - alias: "Chromecast to shelf lights"
+    triggers:
+      - trigger: state
+        entity_id: media_player.chromecast
+    actions:
+      - action: color_extractor.turn_on
+        target:
+          entity_id: light.shelf_leds
+        data:
+          color_extract_url: "{{ state_attr('media_player.chromecast', 'entity_picture') }}"
+          brightness_pct: 100
+          transition: 5
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/color_extractor.markdown
+++ b/source/_integrations/color_extractor.markdown
@@ -16,8 +16,5 @@ Useful as part of an {% term automation %}.
 
 {% include integrations/config_flow.md %}
 
-{% important %}
-Ensure any [external URLs](/integrations/homeassistant/#allowlist_external_urls) or [external files](/integrations/homeassistant/#allowlist_external_dirs) are authorized for use. You will receive error messages if this {% term integration %} is not allowed access to these external resources.
-{% endimportant %}
 
 {% include integrations/actions.md %}

--- a/source/_integrations/color_extractor.markdown
+++ b/source/_integrations/color_extractor.markdown
@@ -16,69 +16,8 @@ Useful as part of an {% term automation %}.
 
 {% include integrations/config_flow.md %}
 
-## Actions
-
-Because `color_extractor.turn_on` will then call `light.turn_on`, you can pass any valid [`light.turn_on`](/integrations/light#action-lightturn_on) parameters (`rgb_color` will be set for you though) as those will be passed along.
-
-Passing the key `color_extract_url` to the {% term action %} call will download the linked image and extract the predominant color from it. Passing the key `color_extract_path` to the action will process the image file from local storage instead. `color_extract_url` and `color_extract_path` are exclusive and cannot be used together.
-
-| Key                  | Example                               | Description                                                                    |
-| -------------------- | ------------------------------------- | ------------------------------------------------------------------------------ |
-| `color_extract_url`  | `https://example.com/images/logo.png` | The full URL (including schema, `http://`, `https://`) of the image to process |
-| `color_extract_path` | `/tmp/album.png`                      | The full path to the image file on local storage we'll process                 |
-| `entity_id`          | `light.shelf_leds`                    | The RGB capable light we'll set the color of                                   |
-
 {% important %}
 Ensure any [external URLs](/integrations/homeassistant/#allowlist_external_urls) or [external files](/integrations/homeassistant/#allowlist_external_dirs) are authorized for use. You will receive error messages if this {% term integration %} is not allowed access to these external resources.
 {% endimportant %}
 
-### URL Action
-
-Add the parameter key `color_extract_url` to the action.
-
-This {% term action %} allows you to pass in the URL of an image, have it downloaded, get the predominant color from it, and then set a light's RGB value to it.
-
-### File Action
-
-Add the parameter key `color_extract_path` to the action.
-
-This {% term action %} is very similar to the URL action above, except it processes a file from the local file storage.
-
-## Example Automations
-
-Example usage in an {% term automation %}, taking the album art present on a Chromecast and supplying it to `light.shelf_leds` whenever it changes:
-
-
-```yaml
-#automation.yaml
-- alias: "Chromecast to Shelf Lights"
-
-  triggers:
-    - trigger: state
-      entity_id: media_player.chromecast
-
-  actions:
-    - action: color_extractor.turn_on
-      data_template:
-        color_extract_url: "{{ states.media_player.chromecast.attributes.entity_picture }}"
-        entity_id: light.shelf_leds
-```
-
-With a nicer transition period of 5 seconds and setting brightness to 100% each time (part of the [`light.turn_on`](/integrations/light#action-lightturn_on) action parameters):
-
-```yaml
-#automation.yaml
-- alias: "Nicer Chromecast to Shelf Lights"
-
-  triggers:
-    - trigger: state
-      entity_id: media_player.chromecast
-
-  actions:
-    - action: color_extractor.turn_on
-      data_template:
-        color_extract_url: "{{ states.media_player.chromecast.attributes.entity_picture }}"
-        entity_id: light.shelf_leds
-        brightness_pct: 100
-        transition: 5
-```
+{% include integrations/actions.md %}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project.
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Migrate the ColorExtractor **Turn on** and **Get predominant color** actions from the inline sections on the integration page into dedicated action pages under `source/_actions/`, and replace the inline sections with `{% include integrations/actions.md %}`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to: home-assistant/core (ColorExtractor turn on/get color actions)
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - [Documentation for existing features](https://developers.home-assistant.io/docs/documenting/standards#which-branch-to-target) uses the `current` branch.
  - Documentation for new or changing features uses the `next` branch.
- [x] The documentation follows the [Home Assistant documentation standards](https://developers.home-assistant.io/docs/documenting/standards).


- Part of epic: home-assistant/epics#96