### PR TITLE
AfterShip: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/aftership.add_tracking.markdown
+++ b/source/_actions/aftership.add_tracking.markdown
@@ -1,0 +1,78 @@
+---
+title: "Add tracking"
+action: aftership.add_tracking
+domain: aftership
+description: "Adds a new tracking number to AfterShip."
+related_actions:
+  - aftership.remove_tracking
+---
+
+The **Add tracking** action adds a new tracking number to your AfterShip account, so its delivery status starts showing up in Home Assistant.
+
+This action does not target an entity. Instead, you provide the tracking number and, optionally, the carrier and a friendly title.
+
+{% include actions/ui_header.md %}
+
+To add a tracking number from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **AfterShip: Add tracking**.
+6. Enter the **Tracking number**, and set any of the options you need.
+7. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Tracking number:
+  description: The tracking number to add.
+  required: true
+Slug:
+  description: The carrier (slug) of the tracking, such as `usps` or `fedex`. When left empty, AfterShip tries to detect the carrier automatically.
+  required: false
+Title:
+  description: A custom title for the tracking, used as a friendly name for the package.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `aftership.add_tracking`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: aftership.add_tracking
+  data:
+    tracking_number: "123456789"
+{% endexample %}
+
+This adds the tracking number to your AfterShip account.
+
+### Options in YAML
+
+{% options_yaml %}
+tracking_number:
+  description: The tracking number to add.
+  required: true
+  type: string
+slug:
+  description: >
+    The carrier (slug) of the tracking, such as `usps` or `fedex`. When left
+    empty, AfterShip tries to detect the carrier automatically.
+  required: false
+  type: string
+title:
+  description: A custom title for the tracking, used as a friendly name for the package.
+  required: false
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/aftership.add_tracking.markdown
+++ b/source/_actions/aftership.add_tracking.markdown
@@ -72,9 +72,6 @@ title:
 {% endoptions_yaml %}
 
 {% include actions/try_it.md %}
-
-{% include actions/more_examples.md %}
-
 {% include actions/stuck.md %}
 
 {% include actions/related.md %}

--- a/source/_actions/aftership.add_tracking.markdown
+++ b/source/_actions/aftership.add_tracking.markdown
@@ -72,6 +72,7 @@ title:
 {% endoptions_yaml %}
 
 {% include actions/try_it.md %}
+
 {% include actions/stuck.md %}
 
 {% include actions/related.md %}

--- a/source/_actions/aftership.add_tracking.markdown
+++ b/source/_actions/aftership.add_tracking.markdown
@@ -9,9 +9,7 @@ related_actions:
 
 The **Add tracking** action adds a new tracking number to your AfterShip account, so its delivery status starts showing up in Home Assistant.
 
-This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
-
-Instead, you provide the tracking number and, optionally, the carrier and a friendly title.
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label. Instead, you provide the tracking number and, optionally, the carrier and a friendly title.
 
 {% include actions/ui_header.md %}
 

--- a/source/_actions/aftership.add_tracking.markdown
+++ b/source/_actions/aftership.add_tracking.markdown
@@ -9,7 +9,9 @@ related_actions:
 
 The **Add tracking** action adds a new tracking number to your AfterShip account, so its delivery status starts showing up in Home Assistant.
 
-This action does not target an entity. Instead, you provide the tracking number and, optionally, the carrier and a friendly title.
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+Instead, you provide the tracking number and, optionally, the carrier and a friendly title.
 
 {% include actions/ui_header.md %}
 

--- a/source/_actions/aftership.remove_tracking.markdown
+++ b/source/_actions/aftership.remove_tracking.markdown
@@ -1,0 +1,70 @@
+---
+title: "Remove tracking"
+action: aftership.remove_tracking
+domain: aftership
+description: "Removes a tracking number from AfterShip."
+related_actions:
+  - aftership.add_tracking
+---
+
+The **Remove tracking** action removes a tracking number from your AfterShip account, so it no longer shows up in Home Assistant.
+
+This action does not target an entity. Instead, you provide the carrier and the tracking number to remove.
+
+{% include actions/ui_header.md %}
+
+To remove a tracking number from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **AfterShip: Remove tracking**.
+6. Enter the **Slug** and **Tracking number**.
+7. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Slug:
+  description: The carrier (slug) of the tracking to remove, such as `usps` or `fedex`.
+  required: true
+Tracking number:
+  description: The tracking number to remove.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `aftership.remove_tracking`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: aftership.remove_tracking
+  data:
+    slug: "usps"
+    tracking_number: "123456789"
+{% endexample %}
+
+This removes the tracking number from your AfterShip account.
+
+### Options in YAML
+
+{% options_yaml %}
+slug:
+  description: The carrier (slug) of the tracking to remove, such as `usps` or `fedex`.
+  required: true
+  type: string
+tracking_number:
+  description: The tracking number to remove.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/aftership.remove_tracking.markdown
+++ b/source/_actions/aftership.remove_tracking.markdown
@@ -9,9 +9,7 @@ related_actions:
 
 The **Remove tracking** action removes a tracking number from your AfterShip account, so it no longer shows up in Home Assistant.
 
-This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
-
-Instead, you provide the carrier and the tracking number to remove.
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label. Instead, you provide the carrier and the tracking number to remove.
 
 {% include actions/ui_header.md %}
 

--- a/source/_actions/aftership.remove_tracking.markdown
+++ b/source/_actions/aftership.remove_tracking.markdown
@@ -9,7 +9,9 @@ related_actions:
 
 The **Remove tracking** action removes a tracking number from your AfterShip account, so it no longer shows up in Home Assistant.
 
-This action does not target an entity. Instead, you provide the carrier and the tracking number to remove.
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+Instead, you provide the carrier and the tracking number to remove.
 
 {% include actions/ui_header.md %}
 
@@ -62,8 +64,6 @@ tracking_number:
 {% endoptions_yaml %}
 
 {% include actions/try_it.md %}
-
-{% include actions/more_examples.md %}
 
 {% include actions/stuck.md %}
 

--- a/source/_integrations/aftership.markdown
+++ b/source/_integrations/aftership.markdown
@@ -26,24 +26,7 @@ AfterShip removed the Tracking API functionality from the Forever Free plan, and
 
 {% include integrations/config_flow.md %}
 
-## Action `add_tracking`
-
- You can use the `aftership.add_tracking` action to add trackings to AfterShip.
-
-| Data attribute | Required | Type | Description |
-| ---------------------- | -------- | -------- | ----------- |
-| `tracking_number` | `True` | string | Tracking number
-| `slug` | `False` | string | Carrier e.g.,  `fedex`
-| `title` | `False` | string | Friendly name of package
-
-## Action `remove_tracking`
-
- You can use the `aftership.remove_tracking` action to remove trackings from AfterShip.
-
-| Data attribute | Required | Type | Description |
-| ---------------------- | -------- | -------- | ----------- |
-| `tracking_number` | `True` | string | Tracking number
-| `slug` | `True` | string | Carrier e.g.,  `fedex`
+{% include integrations/actions.md %}
 
 {% note %}
 This integration retrieves data from AfterShip public REST API, but the integration is not affiliated with AfterShip.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project.
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Migrate the AfterShip **Add tracking** and **Remove tracking** actions from the inline sections on the integration page into dedicated action pages under `source/_actions/`, and replace the inline sections with `{% include integrations/actions.md %}`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to: home-assistant/core (AfterShip add tracking/remove tracking actions)
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - [Documentation for existing features](https://developers.home-assistant.io/docs/documenting/standards#which-branch-to-target) uses the `current` branch.
  - Documentation for new or changing features uses the `next` branch.
- [x] The documentation follows the [Home Assistant documentation standards](https://developers.home-assistant.io/docs/documenting/standards).


- Part of epic: home-assistant/epics#96