### PR TITLE
ADS: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/ads.write_data_by_name.markdown
+++ b/source/_actions/ads.write_data_by_name.markdown
@@ -25,7 +25,7 @@ This action does not support targets. In the UI, you are not prompted to choose 
 
 {% options_ui %}
 ADS variable:
-  description: The name of the variable to write to. To access global variables on TwinCAT2, prepend a dot, for example `.myvariable`. For TwinCAT3, use a name such as `GBL.myvariable`.
+  description: The name of the variable to write to. To access global variables on TwinCAT2, prepend a dot, for example `.myvariable`. For TwinCAT3, use a name such as `GVL.myvariable`.
   required: true
 ADS type:
   description: The data type of the variable to write to.
@@ -57,7 +57,7 @@ adsvar:
   description: >
     The name of the variable to write to. To access global variables on
     TwinCAT2, prepend a dot, for example `.myvariable`. For TwinCAT3, use a
-    name such as `GBL.myvariable`.
+    name such as `GVL.myvariable`.
   required: true
   type: string
 adstype:

--- a/source/_actions/ads.write_data_by_name.markdown
+++ b/source/_actions/ads.write_data_by_name.markdown
@@ -76,6 +76,34 @@ value:
 
 {% include actions/more_examples.md %}
 
+### Automation: write a setpoint when a helper changes
+
+Write a new value to a PLC variable whenever an input number helper changes, for example to push a temperature setpoint from Home Assistant to your ADS device.
+
+- **Trigger**: State: Setpoint helper changes
+- **Action**: ADS: Write data by name
+  - **ADS variable**: `.setpoint`
+  - **ADS type**: int
+  - **Value**: `21`
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  - alias: "Push the setpoint to the PLC"
+    triggers:
+      - trigger: state
+        entity_id: input_number.heating_setpoint
+    actions:
+      - action: ads.write_data_by_name
+        data:
+          adsvar: ".setpoint"
+          adstype: int
+          value: "{{ states('input_number.heating_setpoint') | int }}"
+{% endexample %}
+
+{% enddetails %}
+
 {% include actions/stuck.md %}
 
 {% include actions/related.md %}

--- a/source/_actions/ads.write_data_by_name.markdown
+++ b/source/_actions/ads.write_data_by_name.markdown
@@ -83,7 +83,7 @@ Write a new value to a PLC variable whenever an input number helper changes, for
 - **Trigger**: State: Setpoint helper changes
 - **Action**: ADS: Write data by name
   - **ADS variable**: `.setpoint`
-  - **ADS type**: int
+  - **ADS type**: `int`
   - **Value**: `21`
 
 {% details "Show example YAML" %}

--- a/source/_actions/ads.write_data_by_name.markdown
+++ b/source/_actions/ads.write_data_by_name.markdown
@@ -1,0 +1,81 @@
+---
+title: "Write data by name"
+action: ads.write_data_by_name
+domain: ads
+description: "Writes a value to a variable on a connected ADS device."
+---
+
+Use this action to write a value to a variable on your connected ADS device, identified by the variable name.
+
+{% include actions/ui_header.md %}
+
+To write a value from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Search for and select **ADS: Write data by name**.
+6. Enter the **ADS variable** name, choose the **ADS type**, and set the **Value** to write.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+ADS variable:
+  description: The name of the variable to write to. To access global variables on TwinCAT2, prepend a dot, for example `.myvariable`. For TwinCAT3, use a name such as `GBL.myvariable`.
+  required: true
+ADS type:
+  description: The data type of the variable to write to.
+  required: true
+Value:
+  description: The value to write to the variable.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `ads.write_data_by_name`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: ads.write_data_by_name
+  data:
+    adsvar: ".myvariable"
+    adstype: int
+    value: 123
+{% endexample %}
+
+This writes the value `123` as an integer to the variable `.myvariable`.
+
+### Options in YAML
+
+{% options_yaml %}
+adsvar:
+  description: >
+    The name of the variable to write to. To access global variables on
+    TwinCAT2, prepend a dot, for example `.myvariable`. For TwinCAT3, use a
+    name such as `GBL.myvariable`.
+  required: true
+  type: string
+adstype:
+  description: >
+    The data type of the variable to write to. One of `bool`, `byte`,
+    `dint`, `int`, `udint`, or `uint`.
+  required: true
+  type: string
+value:
+  description: The value to write to the variable.
+  required: true
+  type: integer
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/ads.markdown
+++ b/source/_integrations/ads.markdown
@@ -69,24 +69,7 @@ ip_address:
   type: string
 {% endconfiguration %}
 
-<!-- omit in toc -->
-## Actions
-
-The ADS integration registers the `ads.write_data_by_name` action, allowing you to write a value to a variable on your ADS device.
-
-```json
-{
-    "adsvar": ".myvariable",
-    "adstype": "int",
-    "value": 123
-}
-```
-
-Action parameters:
-
-- **adsvar**: Name of the variable on the ADS device. To access global variables on *TwinCAT2*, use a prepending dot (`.myvariable`). For TwinCAT3, use `GBL.myvariable`.
-- **adstype**: Specify the type of the variable. Use one of the following: `bool`, `byte`, `dint`, `int`, `udint`, or `uint`.
-- **value**: The value to write to the variable.
+{% include integrations/actions.md %}
 
 ## Binary sensor
 


### PR DESCRIPTION
## Proposed change

Moves the ADS `write_data_by_name` action out of the integration page and into a dedicated action page under `source/_actions/`, replacing the inline block with `{% include integrations/actions.md %}`.

The new page documents both the UI and YAML usage, with the field types and the variable-naming guidance for TwinCAT2 and TwinCAT3.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

