### PR TITLE
NX584: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/nx584.bypass_zone.markdown
+++ b/source/_actions/nx584.bypass_zone.markdown
@@ -58,8 +58,6 @@ zone:
 
 {% include actions/try_it.md %}
 
-{% include actions/more_examples.md %}
-
 {% include actions/stuck.md %}
 
 {% include actions/related.md %}

--- a/source/_actions/nx584.bypass_zone.markdown
+++ b/source/_actions/nx584.bypass_zone.markdown
@@ -17,7 +17,7 @@ To bypass a zone from an automation or a script:
 2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
 3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
 4. In the **Then do** section, select **Add action**.
-5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the alarm panel you want to bypass a zone on.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the area, floor, device, label, or entity that has the alarm panel you want to bypass a zone on.
 6. From the actions shown for that target, select **NX584: Bypass zone**.
 7. Set the **Zone** number you want to bypass.
 8. Select **Save**.

--- a/source/_actions/nx584.bypass_zone.markdown
+++ b/source/_actions/nx584.bypass_zone.markdown
@@ -1,0 +1,65 @@
+---
+title: "Bypass zone"
+action: nx584.bypass_zone
+domain: nx584
+description: "Bypasses a zone on an NX584 alarm panel."
+related_actions:
+  - nx584.unbypass_zone
+---
+
+Use this action to bypass a zone on your NX584 alarm panel, so the zone is ignored while the alarm is armed.
+
+{% include actions/ui_header.md %}
+
+To bypass a zone from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the alarm panel you want to bypass a zone on.
+6. From the actions shown for that target, select **NX584: Bypass zone**.
+7. Set the **Zone** number you want to bypass.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Zone:
+  description: The number of the zone to be bypassed.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `nx584.bypass_zone`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: nx584.bypass_zone
+  target:
+    entity_id: alarm_control_panel.house
+  data:
+    zone: 12
+{% endexample %}
+
+This bypasses zone `12` on the alarm panel.
+
+### Options in YAML
+
+{% options_yaml %}
+zone:
+  description: The number of the zone to be bypassed.
+  required: true
+  type: integer
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="alarm_control_panel" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/nx584.bypass_zone.markdown
+++ b/source/_actions/nx584.bypass_zone.markdown
@@ -38,7 +38,7 @@ In YAML, refer to this action as `nx584.bypass_zone`. A basic example looks like
 action: |
   action: nx584.bypass_zone
   target:
-    entity_id: alarm_control_panel.house
+    entity_id: alarm_control_panel.home_alarm
   data:
     zone: 12
 {% endexample %}

--- a/source/_actions/nx584.unbypass_zone.markdown
+++ b/source/_actions/nx584.unbypass_zone.markdown
@@ -38,7 +38,7 @@ In YAML, refer to this action as `nx584.unbypass_zone`. A basic example looks li
 action: |
   action: nx584.unbypass_zone
   target:
-    entity_id: alarm_control_panel.house
+    entity_id: alarm_control_panel.home_alarm
   data:
     zone: 12
 {% endexample %}

--- a/source/_actions/nx584.unbypass_zone.markdown
+++ b/source/_actions/nx584.unbypass_zone.markdown
@@ -58,8 +58,6 @@ zone:
 
 {% include actions/try_it.md %}
 
-{% include actions/more_examples.md %}
-
 {% include actions/stuck.md %}
 
 {% include actions/related.md %}

--- a/source/_actions/nx584.unbypass_zone.markdown
+++ b/source/_actions/nx584.unbypass_zone.markdown
@@ -1,0 +1,65 @@
+---
+title: "Un-bypass zone"
+action: nx584.unbypass_zone
+domain: nx584
+description: "Removes the bypass from a zone on an NX584 alarm panel."
+related_actions:
+  - nx584.bypass_zone
+---
+
+Use this action to remove the bypass from a zone on your NX584 alarm panel, so the zone is monitored again while the alarm is armed.
+
+{% include actions/ui_header.md %}
+
+To un-bypass a zone from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the alarm panel you want to un-bypass a zone on.
+6. From the actions shown for that target, select **NX584: Un-bypass zone**.
+7. Set the **Zone** number you want to un-bypass.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Zone:
+  description: The number of the zone to be un-bypassed.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `nx584.unbypass_zone`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: nx584.unbypass_zone
+  target:
+    entity_id: alarm_control_panel.house
+  data:
+    zone: 12
+{% endexample %}
+
+This removes the bypass from zone `12` on the alarm panel.
+
+### Options in YAML
+
+{% options_yaml %}
+zone:
+  description: The number of the zone to be un-bypassed.
+  required: true
+  type: integer
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="alarm_control_panel" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/nx584.unbypass_zone.markdown
+++ b/source/_actions/nx584.unbypass_zone.markdown
@@ -17,7 +17,7 @@ To unbypass a zone from an automation or a script:
 2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
 3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
 4. In the **Then do** section, select **Add action**.
-5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the alarm panel you want to unbypass a zone on.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the area, floor, device, label, or entity that has the alarm panel you want to unbypass a zone on.
 6. From the actions shown for that target, select **NX584: Unbypass zone**.
 7. Set the **Zone** number you want to unbypass.
 8. Select **Save**.

--- a/source/_actions/nx584.unbypass_zone.markdown
+++ b/source/_actions/nx584.unbypass_zone.markdown
@@ -1,5 +1,5 @@
 ---
-title: "Un-bypass zone"
+title: "Unbypass zone"
 action: nx584.unbypass_zone
 domain: nx584
 description: "Removes the bypass from a zone on an NX584 alarm panel."
@@ -11,22 +11,22 @@ Use this action to remove the bypass from a zone on your NX584 alarm panel, so t
 
 {% include actions/ui_header.md %}
 
-To un-bypass a zone from an automation or a script:
+To unbypass a zone from an automation or a script:
 
 1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
 2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
 3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
 4. In the **Then do** section, select **Add action**.
-5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the alarm panel you want to un-bypass a zone on.
-6. From the actions shown for that target, select **NX584: Un-bypass zone**.
-7. Set the **Zone** number you want to un-bypass.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the alarm panel you want to unbypass a zone on.
+6. From the actions shown for that target, select **NX584: Unbypass zone**.
+7. Set the **Zone** number you want to unbypass.
 8. Select **Save**.
 
 ### Options in the UI
 
 {% options_ui %}
 Zone:
-  description: The number of the zone to be un-bypassed.
+  description: The number of the zone to be unbypassed.
   required: true
 {% endoptions_ui %}
 
@@ -49,7 +49,7 @@ This removes the bypass from zone `12` on the alarm panel.
 
 {% options_yaml %}
 zone:
-  description: The number of the zone to be un-bypassed.
+  description: The number of the zone to be unbypassed.
   required: true
   type: integer
 {% endoptions_yaml %}

--- a/source/_integrations/nx584.markdown
+++ b/source/_integrations/nx584.markdown
@@ -99,6 +99,8 @@ zone_types:
       description: Safety
 {% endconfiguration %}
 
+{% include integrations/actions.md %}
+
 ## Full example
 
 An extended configuration entry could look like this:
@@ -119,4 +121,3 @@ binary_sensor:
     6: moisture
 ```
 
-{% include integrations/actions.md %}

--- a/source/_integrations/nx584.markdown
+++ b/source/_integrations/nx584.markdown
@@ -119,22 +119,4 @@ binary_sensor:
     6: moisture
 ```
 
-## Actions
-
-### Action `bypass_zone`
-
-This action will bypass a given zone.
-
-| Data attribute | Optional | Description                     |
-| ---------------------- | -------- | ------------------------------- |
-| `entity_id`            | yes      | entity_id of the NX584 Alarm.   |
-| `zone`                 | no       | Zone number you want to bypass. |
-
-### Action `unbypass_zone`
-
-This action will unbypass a given zone.
-
-| Data attribute | Optional | Description                       |
-| ---------------------- | -------- | --------------------------------- |
-| `entity_id`            | yes      | entity_id of the NX584 Alarm.     |
-| `zone`                 | no       | Zone number you want to unbypass. |
+{% include integrations/actions.md %}


### PR DESCRIPTION
## Proposed change

Moves the NX584 `bypass_zone` and `unbypass_zone` actions out of the integration page and into dedicated action pages under `source/_actions/`, replacing the inline block with `{% include integrations/actions.md %}`.

Each action now has its own page documenting the UI and YAML usage and the zone option.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

