### PR TITLE
Indevolt: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/indevolt.charge.markdown
+++ b/source/_actions/indevolt.charge.markdown
@@ -86,16 +86,16 @@ This automation starts charging the battery at 06:00 so it is ready to cover mor
 
 {% example %}
 automation: |
-  - alias: "Charge battery every morning"
-    triggers:
+  alias: "Charge battery every morning"
+  triggers:
     - trigger: time
       at: "06:00:00"
-    actions:
-      - action: indevolt.charge
-        data:
-          device_id: your_device_id
-          power: 1000
-          target_soc: 80
+  actions:
+    - action: indevolt.charge
+      data:
+        device_id: your_device_id
+        power: 1000
+        target_soc: 80
 {% endexample %}
 
 {% enddetails %}

--- a/source/_actions/indevolt.charge.markdown
+++ b/source/_actions/indevolt.charge.markdown
@@ -1,0 +1,80 @@
+---
+title: "Charge"
+action: indevolt.charge
+domain: indevolt
+description: "Starts charging an Indevolt battery until the target state of charge is reached."
+related_actions:
+  - indevolt.discharge
+---
+
+Use this action to start charging one or more Indevolt batteries with a set maximum power until the target state of charge is reached. The device switches to real-time control mode if needed.
+
+{% include actions/ui_header.md %}
+
+To start charging from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Search for and select **Indevolt: Charge**.
+6. Select the Indevolt devices in the **Device(s)** field, then set the **Target SOC** and **Max. power**.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you select the Indevolt devices through the **Device(s)** field instead of choosing an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Device(s):
+  description: The Indevolt devices to start charging.
+  required: true
+Target SOC:
+  description: The target state of charge, as a percentage. Charging stops when it is reached.
+  required: true
+Max. power:
+  description: The maximum charging power, in watts.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `indevolt.charge`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: indevolt.charge
+  data:
+    device_id: a1b2c3d4e5f6
+    target_soc: 100
+    power: 1000
+{% endexample %}
+
+This charges the battery at up to 1000 watts until it reaches 100%.
+
+### Options in YAML
+
+{% options_yaml %}
+device_id:
+  description: The Indevolt devices to start charging.
+  required: true
+  type: [string, list]
+target_soc:
+  description: >
+    The target state of charge, as a percentage from 0 to 100. Charging stops
+    when it is reached.
+  required: true
+  type: integer
+power:
+  description: The maximum charging power, in watts, from 0 to 2400.
+  required: true
+  type: integer
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/indevolt.charge.markdown
+++ b/source/_actions/indevolt.charge.markdown
@@ -7,7 +7,7 @@ related_actions:
   - indevolt.discharge
 ---
 
-Use this action to start charging one or more Indevolt batteries with a set maximum power until the target state of charge is reached. The device switches to real-time control mode if needed.
+Use this action to start charging one or more Indevolt batteries with a set maximum power until the target state of charge is reached. Each device switches to real-time control mode if needed.
 
 {% include actions/ui_header.md %}
 

--- a/source/_actions/indevolt.charge.markdown
+++ b/source/_actions/indevolt.charge.markdown
@@ -75,6 +75,31 @@ power:
 
 {% include actions/more_examples.md %}
 
+### Automation: charge the battery every morning before the household wakes up
+
+This automation starts charging the battery at 06:00 so it is ready to cover morning consumption from stored energy rather than the grid.
+
+- **Trigger**: Time: 06:00
+- **Action**: Indevolt: Charge
+
+{% details "YAML example for charging battery every morning" %}
+
+{% example %}
+automation: |
+  - alias: "Charge battery every morning"
+    triggers:
+    - trigger: time
+      at: "06:00:00"
+    actions:
+      - action: indevolt.charge
+        data:
+          device_id: your_device_id
+          power: 1000
+          target_soc: 80
+{% endexample %}
+
+{% enddetails %}
+
 {% include actions/stuck.md %}
 
 {% include actions/related.md %}

--- a/source/_actions/indevolt.discharge.markdown
+++ b/source/_actions/indevolt.discharge.markdown
@@ -87,15 +87,15 @@ When the evening peak tariff window starts and the battery has enough charge, di
 
 {% example %}
 automation: |
-  - alias: "Discharge battery during evening peak tariff"
-    triggers:
+  alias: "Discharge battery during evening peak tariff"
+  triggers:
     - trigger: time
       at: "17:00:00"
-    conditions:
+  conditions:
     - condition: numeric_state
       entity_id: sensor.indevolt_battery_soc
       above: 30
-    actions:
+  actions:
     - action: indevolt.discharge
       data:
         device_id: your_device_id

--- a/source/_actions/indevolt.discharge.markdown
+++ b/source/_actions/indevolt.discharge.markdown
@@ -75,6 +75,36 @@ power:
 
 {% include actions/more_examples.md %}
 
+### Automation: discharge the battery during evening peak to avoid grid draw
+
+When the evening peak tariff window starts and the battery has enough charge, discharge the battery to cover home consumption and avoid drawing expensive and carbon-intensive peak-time grid electricity.
+
+- **Trigger**: Time: 17:00
+- **Condition**: Battery SOC above 30 %
+- **Action**: Indevolt: Discharge (at 800 watts to 20 % SOC)
+
+{% details "YAML example for discharging battery during evening peak" %}
+
+{% example %}
+automation: |
+  - alias: "Discharge battery during evening peak tariff"
+    triggers:
+    - trigger: time
+      at: "17:00:00"
+    conditions:
+    - condition: numeric_state
+      entity_id: sensor.indevolt_battery_soc
+      above: 30
+    actions:
+    - action: indevolt.discharge
+      data:
+        device_id: your_device_id
+        power: 800
+        target_soc: 20
+{% endexample %}
+
+{% enddetails %}
+
 {% include actions/stuck.md %}
 
 {% include actions/related.md %}

--- a/source/_actions/indevolt.discharge.markdown
+++ b/source/_actions/indevolt.discharge.markdown
@@ -7,7 +7,7 @@ related_actions:
   - indevolt.charge
 ---
 
-Use this action to start discharging one or more Indevolt batteries with a set maximum power until the target state of charge is reached. The device switches to real-time control mode if needed.
+Use this action to start discharging one or more Indevolt batteries with a set maximum power until the target state of charge is reached. Each device switches to real-time control mode if needed.
 
 {% include actions/ui_header.md %}
 

--- a/source/_actions/indevolt.discharge.markdown
+++ b/source/_actions/indevolt.discharge.markdown
@@ -1,0 +1,80 @@
+---
+title: "Discharge"
+action: indevolt.discharge
+domain: indevolt
+description: "Starts discharging an Indevolt battery until the target state of charge is reached."
+related_actions:
+  - indevolt.charge
+---
+
+Use this action to start discharging one or more Indevolt batteries with a set maximum power until the target state of charge is reached. The device switches to real-time control mode if needed.
+
+{% include actions/ui_header.md %}
+
+To start discharging from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Search for and select **Indevolt: Discharge**.
+6. Select the Indevolt devices in the **Device(s)** field, then set the **Target SOC** and **Max. power**.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you select the Indevolt devices through the **Device(s)** field instead of choosing an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Device(s):
+  description: The Indevolt devices to start discharging.
+  required: true
+Target SOC:
+  description: The target state of charge, as a percentage. Discharging stops when it is reached.
+  required: true
+Max. power:
+  description: The maximum discharging power, in watts.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `indevolt.discharge`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: indevolt.discharge
+  data:
+    device_id: a1b2c3d4e5f6
+    target_soc: 10
+    power: 800
+{% endexample %}
+
+This discharges the battery at up to 800 watts until it reaches 10%.
+
+### Options in YAML
+
+{% options_yaml %}
+device_id:
+  description: The Indevolt devices to start discharging.
+  required: true
+  type: [string, list]
+target_soc:
+  description: >
+    The target state of charge, as a percentage from 0 to 100. Discharging
+    stops when it is reached.
+  required: true
+  type: integer
+power:
+  description: The maximum discharging power, in watts, from 0 to 2400.
+  required: true
+  type: integer
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/indevolt.markdown
+++ b/source/_integrations/indevolt.markdown
@@ -150,55 +150,7 @@ In addition to the read-only sensors listed above, the Indevolt integration also
 - Bypass socket: Enable or disable the bypass socket (switch)
 - LED indicator: Enable or disable the LED indicator (switch)
 
-## Actions
-
-### Action: Charge the battery (real-time control mode)
-
-The `indevolt.change_energy_mode` action configures the battery to start charging with specified maximum power to the target SOC. The device will automatically switch to real-time control mode if needed.
-
-- **Data attribute**: `device_id`
-  - **Description**: The `device_id` of the Indevolt device(s)
-  - **Optional**: No
-- **Data attribute**: `power`
-  - **Description**: The maximum charging power (0 - 2400W)
-  - **Optional**: No
-- **Data attribute**: `target_soc`
-  - **Description**: The target SOC (%): charging will stop when reached
-  - **Optional**: No
-
-#### Example
-
-```yaml
-action: indevolt.charge
-data:
-  device_id: YOUR_DEVICE_ID
-  power: 1000
-  target_soc: 100
-```
-
-### Action: Discharge the battery (real-time control mode)
-
-The `indevolt.change_energy_mode` action configure the battery to start discharging with specified maximum power to the target SOC. The device will automatically switch to real-time control mode if needed.
-
-- **Data attribute**: `device_id`
-  - **Description**: The `device_id` of the Indevolt device(s)
-  - **Optional**: No
-- **Data attribute**: `power`
-  - **Description**: The maximum charging power (0 - 2400W), keeping network limitations in mind
-  - **Optional**: No
-- **Data attribute**: `target_soc`
-  - **Description**: The target SOC (%): discharging will stop when reached
-  - **Optional**: No
-
-#### Example
-
-```yaml
-action: indevolt.discharge
-data:
-  device_id: YOUR_DEVICE_ID
-  power: 800
-  target_soc: 10
-```
+{% include integrations/actions.md %}
 
 ## Examples
 


### PR DESCRIPTION
## Proposed change

Moves the Indevolt `charge` and `discharge` actions out of the integration page and into dedicated action pages under `source/_actions/`, replacing the inline block with `{% include integrations/actions.md %}`.

Each action now has its own page documenting the UI and YAML usage. This also corrects the inline text, which referred to a non-existent `indevolt.change_energy_mode` action.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

