### PR TITLE
AlarmDecoder: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/alarmdecoder.alarm_keypress.markdown
+++ b/source/_actions/alarmdecoder.alarm_keypress.markdown
@@ -1,0 +1,65 @@
+---
+title: "Key press"
+action: alarmdecoder.alarm_keypress
+domain: alarmdecoder
+description: "Sends custom key presses to an AlarmDecoder alarm panel."
+related_actions:
+  - alarmdecoder.alarm_toggle_chime
+---
+
+Use this action to send a string of characters to your AlarmDecoder alarm panel, as if you had pressed those keys on a keypad.
+
+{% include actions/ui_header.md %}
+
+To send key presses from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the alarm panel you want to send key presses to.
+6. From the actions shown for that target, select **AlarmDecoder: Key press**.
+7. Enter the **Key press** string to send.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Key press:
+  description: The string to send to the alarm panel.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `alarmdecoder.alarm_keypress`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: alarmdecoder.alarm_keypress
+  target:
+    entity_id: alarm_control_panel.alarm_panel
+  data:
+    keypress: "*71"
+{% endexample %}
+
+This sends the key sequence `*71` to the alarm panel.
+
+### Options in YAML
+
+{% options_yaml %}
+keypress:
+  description: The string to send to the alarm panel.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="alarm_control_panel" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/alarmdecoder.alarm_keypress.markdown
+++ b/source/_actions/alarmdecoder.alarm_keypress.markdown
@@ -58,8 +58,6 @@ keypress:
 
 {% include actions/try_it.md %}
 
-{% include actions/more_examples.md %}
-
 {% include actions/stuck.md %}
 
 {% include actions/related.md %}

--- a/source/_actions/alarmdecoder.alarm_toggle_chime.markdown
+++ b/source/_actions/alarmdecoder.alarm_toggle_chime.markdown
@@ -1,0 +1,65 @@
+---
+title: "Toggle chime"
+action: alarmdecoder.alarm_toggle_chime
+domain: alarmdecoder
+description: "Toggles the chime on an AlarmDecoder alarm panel."
+related_actions:
+  - alarmdecoder.alarm_keypress
+---
+
+Use this action to send the toggle chime command to your AlarmDecoder alarm panel, switching the chime on or off.
+
+{% include actions/ui_header.md %}
+
+To toggle the chime from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the alarm panel you want to toggle the chime on.
+6. From the actions shown for that target, select **AlarmDecoder: Toggle chime**.
+7. Enter the **Code** to toggle the chime with.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Code:
+  description: The code to toggle the alarm control panel chime with.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `alarmdecoder.alarm_toggle_chime`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: alarmdecoder.alarm_toggle_chime
+  target:
+    entity_id: alarm_control_panel.alarm_panel
+  data:
+    code: "1234"
+{% endexample %}
+
+This toggles the chime on the alarm panel.
+
+### Options in YAML
+
+{% options_yaml %}
+code:
+  description: The code to toggle the alarm control panel chime with.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="alarm_control_panel" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/alarmdecoder.alarm_toggle_chime.markdown
+++ b/source/_actions/alarmdecoder.alarm_toggle_chime.markdown
@@ -58,8 +58,6 @@ code:
 
 {% include actions/try_it.md %}
 
-{% include actions/more_examples.md %}
-
 {% include actions/stuck.md %}
 
 {% include actions/related.md %}

--- a/source/_integrations/alarmdecoder.markdown
+++ b/source/_integrations/alarmdecoder.markdown
@@ -98,15 +98,13 @@ There are several attributes available on the alarm panel to give you more infor
 - `zone_bypassed`: Set to `true` if your system is currently bypassing a zone.
 - `code_arm_required`: Set to the value specified in your AlarmDecoder options.
 
-## Actions
+{% include integrations/actions.md %}
 
-The **Alarm Decoder** {% term integration %} gives you access to several {% term actions %} to control your alarm. Alongside the standard alarm control panel actions, arm away, arm home, arm night, and disarm, it provides the integration-specific actions listed below.
+Alongside these, the **AlarmDecoder** {% term integration %} supports the standard alarm control panel actions to control your alarm: arm away, arm home, arm night, and disarm.
 
 {% note %}
-`alarm_arm_custom_bypass` and `alarm_trigger`, while available in the actions list in Home Assistant, are not currently implemented in the Alarm Decoder platform.
+`alarm_arm_custom_bypass` and `alarm_trigger`, while available in the actions list in Home Assistant, are not currently implemented in the AlarmDecoder platform.
 {% endnote %}
-
-{% include integrations/actions.md %}
 
 ## Examples
 

--- a/source/_integrations/alarmdecoder.markdown
+++ b/source/_integrations/alarmdecoder.markdown
@@ -100,25 +100,19 @@ There are several attributes available on the alarm panel to give you more infor
 
 ## Actions
 
-The **Alarm Decoder** {% term integration %} gives you access to several {% term actions %} for you to control your alarm with.
-
-- `alarm_arm_away`: Arms the alarm in away mode; all faults will trigger the alarm.
-- `alarm_arm_home`: Arms the alarm in stay mode; faults to the doors or windows will trigger the alarm.
-- `alarm_arm_night`: Arms the alarm according to the `Alternative Night Mode` option.
-- `alarm_disarm`: Disarms the alarm from any state.
-- `alarmdecoder.alarm_keypress`: Sends a string of characters to the alarm, as if you had touched those keys on a keypad.
-- `alarmdecoder.alarm_toggle_chime`: Toggles the alarm's chime state.
+The **Alarm Decoder** {% term integration %} gives you access to several {% term actions %} to control your alarm. Alongside the standard alarm control panel actions, arm away, arm home, arm night, and disarm, it provides the integration-specific actions listed below.
 
 {% note %}
 `alarm_arm_custom_bypass` and `alarm_trigger`, while available in the actions list in Home Assistant, are not currently implemented in the Alarm Decoder platform.
 {% endnote %}
 
-### Examples
+{% include integrations/actions.md %}
 
-Using a combination of the available {% term actions %} and attributes, you can create switch templates.
+## Examples
 
 ### Chime status and control
 
+Using a combination of the available {% term actions %} and attributes, you can create switch templates.
 
 ```yaml
 - platform: template


### PR DESCRIPTION
## Proposed change

Moves the AlarmDecoder `alarm_keypress` and `alarm_toggle_chime` actions out of the integration page and into dedicated action pages under `source/_actions/`, replacing the inline block with `{% include integrations/actions.md %}`.

The intro keeps a short pointer to the standard alarm control panel actions and the note about the unimplemented generic actions, and the chime template example is retained.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

