### PR TITLE
Ombi: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/ombi.submit_movie_request.markdown
+++ b/source/_actions/ombi.submit_movie_request.markdown
@@ -1,0 +1,89 @@
+---
+title: "Submit movie request"
+action: ombi.submit_movie_request
+domain: ombi
+description: "Searches for a movie and requests the first result in Ombi."
+related_actions:
+  - ombi.submit_music_request
+  - ombi.submit_tv_request
+---
+
+The **Submit movie request** action searches your Ombi instance for a movie by name and submits a request for the first matching result.
+
+This is handy when you want to request a film without opening the Ombi interface, for example from a voice assistant or a dashboard button.
+
+{% include actions/ui_header.md %}
+
+To submit a movie request from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Ombi: Submit movie request**.
+6. Enter the **Name** of the movie to search for.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Name:
+  description: The movie to search for.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `ombi.submit_movie_request`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: ombi.submit_movie_request
+  data:
+    name: "Beverly Hills Cop"
+{% endexample %}
+
+This searches Ombi for the movie and requests the first matching result.
+
+### Options in YAML
+
+{% options_yaml %}
+name:
+  description: >
+    The movie to search for.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: request a movie when you tap a button
+
+When you press a dashboard button, request a specific movie in Ombi.
+
+- **Trigger**: A button helper is pressed
+- **Action**: Ombi: Submit movie request
+
+{% details "YAML example for requesting a movie from a button" %}
+
+{% example %}
+automation: |
+  alias: "Request movie of the week"
+  triggers:
+    - trigger: state
+      entity_id: input_button.movie_request
+  actions:
+    - action: ombi.submit_movie_request
+      data:
+        name: "Beverly Hills Cop"
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/ombi.submit_music_request.markdown
+++ b/source/_actions/ombi.submit_music_request.markdown
@@ -1,0 +1,89 @@
+---
+title: "Submit music request"
+action: ombi.submit_music_request
+domain: ombi
+description: "Searches for a music album and requests the first result in Ombi."
+related_actions:
+  - ombi.submit_movie_request
+  - ombi.submit_tv_request
+---
+
+The **Submit music request** action searches your Ombi instance for a music album by name and submits a request for the first matching result.
+
+This is handy when you want to request an album without opening the Ombi interface, for example from a voice assistant or a dashboard button.
+
+{% include actions/ui_header.md %}
+
+To submit a music request from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Ombi: Submit music request**.
+6. Enter the **Name** of the album to search for.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Name:
+  description: The music album to search for.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `ombi.submit_music_request`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: ombi.submit_music_request
+  data:
+    name: "Nevermind"
+{% endexample %}
+
+This searches Ombi for the album and requests the first matching result.
+
+### Options in YAML
+
+{% options_yaml %}
+name:
+  description: >
+    The music album to search for.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: request an album when you tap a button
+
+When you press a dashboard button, request a specific album in Ombi.
+
+- **Trigger**: A button helper is pressed
+- **Action**: Ombi: Submit music request
+
+{% details "YAML example for requesting an album from a button" %}
+
+{% example %}
+automation: |
+  alias: "Request album of the week"
+  triggers:
+    - trigger: state
+      entity_id: input_button.music_request
+  actions:
+    - action: ombi.submit_music_request
+      data:
+        name: "Nevermind"
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/ombi.submit_tv_request.markdown
+++ b/source/_actions/ombi.submit_tv_request.markdown
@@ -90,7 +90,6 @@ automation: |
     - action: ombi.submit_tv_request
       data:
         name: "Breaking Bad"
-        season: latest
 {% endexample %}
 
 {% enddetails %}

--- a/source/_actions/ombi.submit_tv_request.markdown
+++ b/source/_actions/ombi.submit_tv_request.markdown
@@ -1,0 +1,100 @@
+---
+title: "Submit TV request"
+action: ombi.submit_tv_request
+domain: ombi
+description: "Searches for a TV show and requests the first result in Ombi."
+related_actions:
+  - ombi.submit_movie_request
+  - ombi.submit_music_request
+---
+
+The **Submit TV request** action searches your Ombi instance for a TV show by name and submits a request for the first matching result. You can choose which seasons to request.
+
+This is handy when you want to request a show without opening the Ombi interface, for example from a voice assistant or a dashboard button.
+
+{% include actions/ui_header.md %}
+
+To submit a TV request from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Ombi: Submit TV request**.
+6. Enter the **Name** of the show to search for, and choose which **Season** to request.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Name:
+  description: The TV show to search for.
+  required: true
+Season:
+  description: "Which seasons to request: the first season, the latest season, or all seasons. Defaults to the latest season."
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `ombi.submit_tv_request`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: ombi.submit_tv_request
+  data:
+    name: "Breaking Bad"
+    season: all
+{% endexample %}
+
+This searches Ombi for the show and requests all of its seasons.
+
+### Options in YAML
+
+{% options_yaml %}
+name:
+  description: >
+    The TV show to search for.
+  required: true
+  type: string
+season:
+  description: >
+    Which seasons to request. One of `first`, `latest`, or `all`.
+  required: false
+  default: latest
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: request a show when you tap a button
+
+When you press a dashboard button, request the latest season of a specific show in Ombi.
+
+- **Trigger**: A button helper is pressed
+- **Action**: Ombi: Submit TV request
+
+{% details "YAML example for requesting a show from a button" %}
+
+{% example %}
+automation: |
+  alias: "Request show of the week"
+  triggers:
+    - trigger: state
+      entity_id: input_button.tv_request
+  actions:
+    - action: ombi.submit_tv_request
+      data:
+        name: "Breaking Bad"
+        season: latest
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/ombi.markdown
+++ b/source/_integrations/ombi.markdown
@@ -86,33 +86,4 @@ ombi:
   ssl: true
 ```
 
-## Actions
-
-### Submit request actions
-
-Available actions: `submit_movie_request`, `submit_music_request`, `submit_tv_request`
-
-#### Action `submit_movie_request`
-
-Searches and requests the closest matching movie.
-
-| Data attribute | Optional | Description       |
-| ---------------------- | -------- | ----------------- |
-| `name`                 | no       | Search parameter. |
-
-#### Action `submit_music_request`
-
-Searches and requests the closest matching music album.
-
-| Data attribute | Optional | Description       |
-| ---------------------- | -------- | ----------------- |
-| `name`                 | no       | Search parameter. |
-
-#### Action `submit_tv_request`
-
-Searches and requests the closest matching TV show.
-
-| Data attribute | Optional | Description                                                                                |
-| ---------------------- | -------- | ------------------------------------------------------------------------------------------ |
-| `name`                 | no       | Search parameter.                                                                          |
-| `season`               | yes      | Which season(s) to request. Must be one of `first`, `latest` or `all`. Defaults to latest. |
+{% include integrations/actions.md %}


### PR DESCRIPTION
## Proposed change

Moves the Ombi `submit_movie_request`, `submit_music_request`, and `submit_tv_request` actions out of the integration page and into dedicated action pages under `source/_actions/`, replacing the inline block with `{% include integrations/actions.md %}`.

Each action now has its own page documenting the UI and YAML usage.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

