### PR TITLE
Netgear LTE: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/netgear_lte.connect_lte.markdown
+++ b/source/_actions/netgear_lte.connect_lte.markdown
@@ -2,14 +2,14 @@
 title: "Connect LTE"
 action: netgear_lte.connect_lte
 domain: netgear_lte
-description: "Asks the Netgear LTE modem to establish its LTE connection."
+description: "Asks the NETGEAR LTE modem to establish its LTE connection."
 related_actions:
   - netgear_lte.disconnect_lte
   - netgear_lte.set_option
   - netgear_lte.delete_sms
 ---
 
-The **Connect LTE** action asks your Netgear LTE modem to establish its LTE connection. This is useful when the modem does not connect on its own.
+The **Connect LTE** action asks your NETGEAR LTE modem to establish its LTE connection. This is useful when the modem does not connect on its own.
 
 This is handy when you want to bring the mobile connection online from an automation, for example as a failover when your wired internet connection goes down.
 

--- a/source/_actions/netgear_lte.connect_lte.markdown
+++ b/source/_actions/netgear_lte.connect_lte.markdown
@@ -1,0 +1,91 @@
+---
+title: "Connect LTE"
+action: netgear_lte.connect_lte
+domain: netgear_lte
+description: "Asks the Netgear LTE modem to establish its LTE connection."
+related_actions:
+  - netgear_lte.disconnect_lte
+  - netgear_lte.set_option
+  - netgear_lte.delete_sms
+---
+
+The **Connect LTE** action asks your Netgear LTE modem to establish its LTE connection. This is useful when the modem does not connect on its own.
+
+This is handy when you want to bring the mobile connection online from an automation, for example as a failover when your wired internet connection goes down.
+
+{% include actions/ui_header.md %}
+
+To connect the modem from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **NETGEAR LTE: Connect LTE**.
+6. If you have more than one modem, enter the **Host** of the modem that should connect.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you select the modem through the **Host** field instead of choosing an area, device, entity, or label. When you have only one modem configured, you can leave it empty.
+
+### Options in the UI
+
+{% options_ui %}
+Host:
+  description: The modem that should connect. Optional when only one modem is configured.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `netgear_lte.connect_lte`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: netgear_lte.connect_lte
+  data:
+    host: 192.168.5.1
+{% endexample %}
+
+This asks the modem at the given host to establish its LTE connection.
+
+### Options in YAML
+
+{% options_yaml %}
+host:
+  description: >
+    The modem that should connect. Optional when only one modem is configured.
+  required: false
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: bring LTE online when wired internet drops
+
+When a connectivity sensor reports that your wired internet is down, ask the modem to connect over LTE.
+
+- **Trigger**: A connectivity sensor turns off
+- **Action**: NETGEAR LTE: Connect LTE
+
+{% details "YAML example for connecting LTE on internet loss" %}
+
+{% example %}
+automation: |
+  alias: "LTE failover on internet loss"
+  triggers:
+    - trigger: state
+      entity_id: binary_sensor.internet_connection
+      to: "off"
+  actions:
+    - action: netgear_lte.connect_lte
+      data:
+        host: 192.168.5.1
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/netgear_lte.delete_sms.markdown
+++ b/source/_actions/netgear_lte.delete_sms.markdown
@@ -67,8 +67,7 @@ sms_id:
   description: >
     A single inbox ID, or a list of inbox IDs, of the messages to delete.
   required: true
-  type: [integer, list]
-{% endoptions_yaml %}
+  type: integer
 
 {% include actions/try_it.md %}
 

--- a/source/_actions/netgear_lte.delete_sms.markdown
+++ b/source/_actions/netgear_lte.delete_sms.markdown
@@ -68,6 +68,7 @@ sms_id:
     A single inbox ID, or a list of inbox IDs, of the messages to delete.
   required: true
   type: integer
+{% endoptions_yaml %}
 
 {% include actions/try_it.md %}
 

--- a/source/_actions/netgear_lte.delete_sms.markdown
+++ b/source/_actions/netgear_lte.delete_sms.markdown
@@ -2,14 +2,14 @@
 title: "Delete SMS"
 action: netgear_lte.delete_sms
 domain: netgear_lte
-description: "Deletes messages from the Netgear LTE modem inbox."
+description: "Deletes messages from the NETGEAR LTE modem inbox."
 related_actions:
   - netgear_lte.connect_lte
   - netgear_lte.disconnect_lte
   - netgear_lte.set_option
 ---
 
-The **Delete SMS** action removes one or more messages from your Netgear LTE modem inbox, using their inbox IDs.
+The **Delete SMS** action removes one or more messages from your NETGEAR LTE modem inbox, using their inbox IDs.
 
 This is handy when you want to keep the modem inbox tidy, for example by deleting an incoming message after an automation has processed it.
 

--- a/source/_actions/netgear_lte.delete_sms.markdown
+++ b/source/_actions/netgear_lte.delete_sms.markdown
@@ -1,0 +1,103 @@
+---
+title: "Delete SMS"
+action: netgear_lte.delete_sms
+domain: netgear_lte
+description: "Deletes messages from the Netgear LTE modem inbox."
+related_actions:
+  - netgear_lte.connect_lte
+  - netgear_lte.disconnect_lte
+  - netgear_lte.set_option
+---
+
+The **Delete SMS** action removes one or more messages from your Netgear LTE modem inbox, using their inbox IDs.
+
+This is handy when you want to keep the modem inbox tidy, for example by deleting an incoming message after an automation has processed it.
+
+{% include actions/ui_header.md %}
+
+To delete messages from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **NETGEAR LTE: Delete SMS**.
+6. Enter the **SMS ID** of the message, or a list of message IDs, to delete. If you have more than one modem, also enter the **Host**.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you select the modem through the **Host** field instead of choosing an area, device, entity, or label. When you have only one modem configured, you can leave it empty.
+
+### Options in the UI
+
+{% options_ui %}
+Host:
+  description: The modem to delete messages from. Optional when only one modem is configured.
+  required: false
+SMS ID:
+  description: A single inbox ID, or a list of inbox IDs, of the messages to delete.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `netgear_lte.delete_sms`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: netgear_lte.delete_sms
+  data:
+    host: 192.168.5.1
+    sms_id:
+      - 7
+      - 8
+{% endexample %}
+
+This deletes the messages with inbox IDs 7 and 8 from the modem.
+
+### Options in YAML
+
+{% options_yaml %}
+host:
+  description: >
+    The modem to delete messages from. Optional when only one modem is
+    configured.
+  required: false
+  type: string
+sms_id:
+  description: >
+    A single inbox ID, or a list of inbox IDs, of the messages to delete.
+  required: true
+  type: [integer, list]
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: delete an SMS after processing it
+
+When a new SMS arrives, process it and then remove it from the modem inbox.
+
+- **Trigger**: A `netgear_lte_sms` event fires
+- **Action**: NETGEAR LTE: Delete SMS
+
+{% details "YAML example for deleting an SMS after processing" %}
+
+{% example %}
+automation: |
+  alias: "Clean up processed SMS"
+  triggers:
+    - trigger: event
+      event_type: netgear_lte_sms
+  actions:
+    - action: netgear_lte.delete_sms
+      data:
+        host: "{{ trigger.event.data.host }}"
+        sms_id: "{{ trigger.event.data.sms_id }}"
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/netgear_lte.disconnect_lte.markdown
+++ b/source/_actions/netgear_lte.disconnect_lte.markdown
@@ -2,14 +2,14 @@
 title: "Disconnect LTE"
 action: netgear_lte.disconnect_lte
 domain: netgear_lte
-description: "Asks the Netgear LTE modem to close its LTE connection."
+description: "Asks the NETGEAR LTE modem to close its LTE connection."
 related_actions:
   - netgear_lte.connect_lte
   - netgear_lte.set_option
   - netgear_lte.delete_sms
 ---
 
-The **Disconnect LTE** action asks your Netgear LTE modem to close its LTE connection.
+The **Disconnect LTE** action asks your NETGEAR LTE modem to close its LTE connection.
 
 This is handy when you want to drop the mobile connection from an automation, for example to switch back to your wired internet connection once it is available again.
 

--- a/source/_actions/netgear_lte.disconnect_lte.markdown
+++ b/source/_actions/netgear_lte.disconnect_lte.markdown
@@ -1,0 +1,92 @@
+---
+title: "Disconnect LTE"
+action: netgear_lte.disconnect_lte
+domain: netgear_lte
+description: "Asks the Netgear LTE modem to close its LTE connection."
+related_actions:
+  - netgear_lte.connect_lte
+  - netgear_lte.set_option
+  - netgear_lte.delete_sms
+---
+
+The **Disconnect LTE** action asks your Netgear LTE modem to close its LTE connection.
+
+This is handy when you want to drop the mobile connection from an automation, for example to switch back to your wired internet connection once it is available again.
+
+{% include actions/ui_header.md %}
+
+To disconnect the modem from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **NETGEAR LTE: Disconnect LTE**.
+6. If you have more than one modem, enter the **Host** of the modem that should disconnect.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you select the modem through the **Host** field instead of choosing an area, device, entity, or label. When you have only one modem configured, you can leave it empty.
+
+### Options in the UI
+
+{% options_ui %}
+Host:
+  description: The modem that should disconnect. Optional when only one modem is configured.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `netgear_lte.disconnect_lte`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: netgear_lte.disconnect_lte
+  data:
+    host: 192.168.5.1
+{% endexample %}
+
+This asks the modem at the given host to close its LTE connection.
+
+### Options in YAML
+
+{% options_yaml %}
+host:
+  description: >
+    The modem that should disconnect. Optional when only one modem is
+    configured.
+  required: false
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: drop LTE when wired internet returns
+
+When a connectivity sensor reports that your wired internet is back, ask the modem to close the LTE connection.
+
+- **Trigger**: A connectivity sensor turns on
+- **Action**: NETGEAR LTE: Disconnect LTE
+
+{% details "YAML example for disconnecting LTE when internet returns" %}
+
+{% example %}
+automation: |
+  alias: "Drop LTE when internet returns"
+  triggers:
+    - trigger: state
+      entity_id: binary_sensor.internet_connection
+      to: "on"
+  actions:
+    - action: netgear_lte.disconnect_lte
+      data:
+        host: 192.168.5.1
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/netgear_lte.set_option.markdown
+++ b/source/_actions/netgear_lte.set_option.markdown
@@ -2,14 +2,14 @@
 title: "Set option"
 action: netgear_lte.set_option
 domain: netgear_lte
-description: "Sets connection options on the Netgear LTE modem."
+description: "Sets connection options on the NETGEAR LTE modem."
 related_actions:
   - netgear_lte.connect_lte
   - netgear_lte.disconnect_lte
   - netgear_lte.delete_sms
 ---
 
-The **Set option** action changes connection settings on your Netgear LTE modem, the same options that are otherwise available in the modem web interface. You can set the failover mode, the auto-connect mode, or both.
+The **Set option** action changes connection settings on your NETGEAR LTE modem, the same options that are otherwise available in the modem web interface. You can set the failover mode, the auto-connect mode, or both.
 
 This is handy when you want to adjust how the modem manages its connection from an automation, for example to allow mobile data only while you are away from home.
 

--- a/source/_actions/netgear_lte.set_option.markdown
+++ b/source/_actions/netgear_lte.set_option.markdown
@@ -1,0 +1,116 @@
+---
+title: "Set option"
+action: netgear_lte.set_option
+domain: netgear_lte
+description: "Sets connection options on the Netgear LTE modem."
+related_actions:
+  - netgear_lte.connect_lte
+  - netgear_lte.disconnect_lte
+  - netgear_lte.delete_sms
+---
+
+The **Set option** action changes connection settings on your Netgear LTE modem, the same options that are otherwise available in the modem web interface. You can set the failover mode, the auto-connect mode, or both.
+
+This is handy when you want to adjust how the modem manages its connection from an automation, for example to allow mobile data only while you are away from home.
+
+{% include actions/ui_header.md %}
+
+To set modem options from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **NETGEAR LTE: Set option**.
+6. Set the **Failover** mode, the **Auto-connect** mode, or both. If you have more than one modem, also enter the **Host**.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you select the modem through the **Host** field instead of choosing an area, device, entity, or label. When you have only one modem configured, you can leave it empty.
+
+### Options in the UI
+
+{% options_ui %}
+Host:
+  description: The modem to set options on. Optional when only one modem is configured.
+  required: false
+Failover:
+  description: "The failover mode: `wire` (wired connection only), `mobile` (mobile connection only), or `auto` (wired connection with failover to mobile)."
+  required: false
+Auto-connect:
+  description: "The auto-connect mode: `never`, `home` (connect only when not roaming), or `always`."
+  required: false
+{% endoptions_ui %}
+
+You need to set at least one of **Failover** or **Auto-connect**.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `netgear_lte.set_option`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: netgear_lte.set_option
+  data:
+    host: 192.168.5.1
+    failover: auto
+    autoconnect: home
+{% endexample %}
+
+This sets the failover and auto-connect modes on the modem.
+
+### Options in YAML
+
+{% options_yaml %}
+host:
+  description: >
+    The modem to set options on. Optional when only one modem is configured.
+  required: false
+  type: string
+failover:
+  description: >
+    The failover mode. One of `wire` (wired connection only), `mobile` (mobile
+    connection only), or `auto` (wired connection with failover to mobile).
+  required: false
+  type: string
+autoconnect:
+  description: >
+    The auto-connect mode. One of `never`, `home` (connect only when not
+    roaming), or `always`.
+  required: false
+  type: string
+{% endoptions_yaml %}
+
+You need to set at least one of `failover` or `autoconnect`.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: allow mobile data only while away
+
+When you leave home, set the modem to always connect. When you return, switch it back to connecting only on your home network.
+
+- **Trigger**: A presence sensor changes
+- **Action**: NETGEAR LTE: Set option
+
+{% details "YAML example for changing auto-connect based on presence" %}
+
+{% example %}
+automation: |
+  alias: "Mobile data only while away"
+  triggers:
+    - trigger: state
+      entity_id: person.me
+      to: not_home
+  actions:
+    - action: netgear_lte.set_option
+      data:
+        host: 192.168.5.1
+        autoconnect: always
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/netgear_lte.set_option.markdown
+++ b/source/_actions/netgear_lte.set_option.markdown
@@ -86,10 +86,9 @@ You need to set at least one of `failover` or `autoconnect`.
 
 {% include actions/more_examples.md %}
 
-### Automation: allow mobile data only while away
+### Automation: set auto-connect mode when you leave home
 
-When you leave home, set the modem to always connect. When you return, switch it back to connecting only on your home network.
-
+When you leave home, set the modem to always connect.
 - **Trigger**: A presence sensor changes
 - **Action**: NETGEAR LTE: Set option
 

--- a/source/_integrations/netgear_lte.markdown
+++ b/source/_integrations/netgear_lte.markdown
@@ -52,42 +52,7 @@ Messages arriving in the modem inbox are sent as events of type `netgear_lte_sms
 | `from`               | The sender of the message.
 | `message`            | The SMS message content.
 
-## Actions
-
-### Action: Connect LTE
-
-The `netgear_lte.connect_lte` action asks the modem to establish its LTE connection, useful if the modem does not autoconnect.
-
-| Data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `host`                 | yes      | The modem that should connect (optional when just one modem is configured).
-
-### Action: Disconnect LTE
-
-The `netgear_lte.disconnect_lte` action asks the modem to close its LTE connection.
-
-| Data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `host`                 | yes      | The modem that should disconnect (optional when just one modem is configured).
-
-### Action: Delete SMS
-
-The `netgear_lte.delete_sms` action deletes messages from the modem inbox. This can be used to clean up after incoming SMS events.
-
-| Data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `host`                 | yes      | The modem that should have a message deleted (optional when just one modem is configured).
-| `sms_id`               | no       | Integer or list of integers with inbox IDs of messages to delete.
-
-### Action: Set option
-
-The `netgear_lte.set_option` action sets modem configuration options (otherwise available in the modem web UI).
-
-| Data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `host`                 | yes      | The modem to set options on (optional when just one modem is configured).
-| `autoconnect`          | yes      | Autoconnect value: `never`/`home`/`always`, with `home` meaning "not roaming".
-| `failover`             | yes      | Failover mode: `wire` (wired connection only), `mobile` (mobile connection only), `auto` (wired connection with failover to mobile connection).
+{% include integrations/actions.md %}
 
 ## Examples
 


### PR DESCRIPTION
## Proposed change

Moves the Netgear LTE `connect_lte`, `disconnect_lte`, `delete_sms`, and `set_option` actions out of the integration page and into dedicated action pages under `source/_actions/`, replacing the inline block with `{% include integrations/actions.md %}`.

Each action now has its own page documenting the UI and YAML usage.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

