### PR TITLE
Ness Alarm: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/ness_alarm.aux.markdown
+++ b/source/_actions/ness_alarm.aux.markdown
@@ -1,0 +1,101 @@
+---
+title: "Aux"
+action: ness_alarm.aux
+domain: ness_alarm
+description: "Changes the state of an aux output on the Ness alarm panel."
+related_actions:
+  - ness_alarm.panic
+---
+
+The **Aux** action changes the state of an auxiliary output on your Ness alarm panel. This requires PCB version 7.8 or higher.
+
+This is handy when you want to drive an extra output from Home Assistant, for example to switch a gate relay or a siren that is wired to one of the panel's aux outputs.
+
+{% include actions/ui_header.md %}
+
+To change an aux output from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Ness Alarm: Aux**.
+6. Enter the **Output ID** you want to change, and set the **State** on or off.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Output ID:
+  description: The aux output you want to change. A number from 1 to 8.
+  required: true
+State:
+  description: The on or off state of the output. When P14xE 8E is enabled, turning on pulses the output for the time set in P14(x+4)E.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `ness_alarm.aux`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: ness_alarm.aux
+  data:
+    output_id: 1
+    state: true
+{% endexample %}
+
+This turns on aux output 1.
+
+### Options in YAML
+
+{% options_yaml %}
+output_id:
+  description: >
+    The aux output you want to change. A number from 1 to 8.
+  required: true
+  type: integer
+state:
+  description: >
+    The on or off state of the output. When P14xE 8E is enabled, turning on
+    pulses the output for the time set in P14(x+4)E.
+  required: false
+  default: true
+  type: boolean
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: switch an aux output with a helper
+
+When a switch helper turns on, turn on aux output 1 on the panel.
+
+- **Trigger**: A switch helper turns on
+- **Action**: Ness Alarm: Aux
+
+{% details "YAML example for switching an aux output" %}
+
+{% example %}
+automation: |
+  alias: "Drive Ness aux output"
+  triggers:
+    - trigger: state
+      entity_id: input_boolean.gate_relay
+      to: "on"
+  actions:
+    - action: ness_alarm.aux
+      data:
+        output_id: 1
+        state: true
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/ness_alarm.aux.markdown
+++ b/source/_actions/ness_alarm.aux.markdown
@@ -45,7 +45,6 @@ action: |
   action: ness_alarm.aux
   data:
     output_id: 1
-    state: true
 {% endexample %}
 
 This turns on aux output 1.
@@ -60,7 +59,7 @@ output_id:
   type: integer
 state:
   description: >
-    The on or off state of the output. When P14xE 8E is enabled, turning on
+    The on (`true`) or off (`false`) state of the output. When P14xE 8E is enabled, turning on
     pulses the output for the time set in P14(x+4)E.
   required: false
   default: true
@@ -91,7 +90,6 @@ automation: |
     - action: ness_alarm.aux
       data:
         output_id: 1
-        state: true
 {% endexample %}
 
 {% enddetails %}

--- a/source/_actions/ness_alarm.panic.markdown
+++ b/source/_actions/ness_alarm.panic.markdown
@@ -1,0 +1,88 @@
+---
+title: "Panic"
+action: ness_alarm.panic
+domain: ness_alarm
+description: "Triggers a panic alarm on the Ness alarm panel."
+related_actions:
+  - ness_alarm.aux
+---
+
+The **Panic** action triggers a panic alarm on your Ness alarm panel, using a user code.
+
+This is handy when you want a fast way to raise the alarm, for example from a dashboard button or a wall-mounted tablet during an emergency.
+
+{% include actions/ui_header.md %}
+
+To trigger a panic alarm from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Ness Alarm: Panic**.
+6. Enter the user **Code** to trigger the panic alarm.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Code:
+  description: The user code to trigger the panic alarm.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `ness_alarm.panic`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: ness_alarm.panic
+  data:
+    code: "1234"
+{% endexample %}
+
+This triggers a panic alarm on the panel.
+
+### Options in YAML
+
+{% options_yaml %}
+code:
+  description: >
+    The user code to trigger the panic alarm.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: trigger panic from a button
+
+When a dashboard button is pressed, trigger a panic alarm on the panel.
+
+- **Trigger**: A button helper is pressed
+- **Action**: Ness Alarm: Panic
+
+{% details "YAML example for triggering panic from a button" %}
+
+{% example %}
+automation: |
+  alias: "Panic button"
+  triggers:
+    - trigger: state
+      entity_id: input_button.panic
+  actions:
+    - action: ness_alarm.panic
+      data:
+        code: "1234"
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/ness_alarm.markdown
+++ b/source/_integrations/ness_alarm.markdown
@@ -69,21 +69,4 @@ After setting up the integration, you can add zones through the UI:
 
 You can reconfigure a zone's device class at any time by selecting the zone's configure button.
 
-## Actions
-
-### Action `aux`
-
-Trigger an aux output. This requires PCB version 7.8 or higher.
-
-| Data attribute | Optional | Description                                                                                                                                                         |
-| ---------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `output_id`            | No       | The aux output you wish to change. A number from 1-8.                                                                                                              |
-| `state`                | Yes      | The On/Off State, represented as true/false. Default is true. If P14xE 8E is enabled then a value of true will pulse output x for the time specified in P14(x+4)E. |
-
-### Action `panic`
-
-Trigger a panic
-
-| Data attribute | Optional | Description                                |
-| ---------------------- | -------- | ------------------------------------------ |
-| `code`                 | No       | The user code to use to trigger the panic. |
+{% include integrations/actions.md %}


### PR DESCRIPTION
## Proposed change

Moves the Ness Alarm `aux` and `panic` actions out of the integration page and into dedicated action pages under `source/_actions/`, replacing the inline block with `{% include integrations/actions.md %}`.

Each action now has its own page documenting the UI and YAML usage.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

