### PR TITLE
Intent Script: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/intent_script.reload.markdown
+++ b/source/_actions/intent_script.reload.markdown
@@ -1,0 +1,74 @@
+---
+title: Reload intent scripts
+action: intent_script.reload
+domain: intent_script
+description: "Reloads the intent scripts from the YAML configuration."
+---
+
+The **Reload intent scripts** action reloads your intent scripts from the YAML configuration. Use it after you change your intent script configuration and want Home Assistant to apply those changes without a restart.
+
+{% include actions/ui_header.md %}
+
+To use this action in an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Intent Script: Reload**.
+6. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+This action has no additional options in the UI.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `intent_script.reload`:
+
+{% example %}
+action: |
+  action: intent_script.reload
+{% endexample %}
+
+This reloads your intent scripts from the YAML configuration.
+
+### Options in YAML
+
+This action has no additional options in YAML.
+
+## Good to know
+
+- Only an administrator account can run this action.
+- If you have not changed your intent script configuration, running this action does not make any visible changes.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: reload intent scripts after a scheduled YAML sync
+
+If another process updates your intent script YAML before a set time, you can schedule this action so Home Assistant picks up those changes automatically.
+
+- **Trigger**: A scheduled time
+- **Action**: Intent Script: Reload
+
+{% details "YAML example for reloading intent scripts after a scheduled sync" %}
+
+{% example %}
+automation: |
+  alias: "Reload intent scripts after nightly YAML sync"
+  triggers:
+    - trigger: time
+      at: "03:05:00"
+  actions:
+    - action: intent_script.reload
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/intent_script.markdown
+++ b/source/_integrations/intent_script.markdown
@@ -119,12 +119,4 @@ intent_script:
       text: "{{ action_response['calendar.my_calendar'].events | length }}"   # use the action's response
 ```
 
-## Actions
-
-Available actions: `reload`.
-
-### Action: Reload
-
-The `intent_script.reload` action reloads the intent script from the YAML configuration, as a quicker alternative to restarting Home Assistant.
-
-This action takes no data attributes.
+{% include integrations/actions.md %}


### PR DESCRIPTION
## Proposed change

Moves the Intent Script `reload` action out of the integration page and into a dedicated action page under `source/_actions/`, replacing the inline block with `{% include integrations/actions.md %}`.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

