### PR TITLE
Portainer: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/portainer.prune_images.markdown
+++ b/source/_actions/portainer.prune_images.markdown
@@ -34,7 +34,7 @@ Until:
   description: Only prune images that have been unused for at least this time duration in the past. If not provided, all unused images are pruned.
   required: false
 Dangling:
-  description: Only prune dangling images.
+  description: Only prune dangling images. When not set, all unused images are pruned.
   required: false
 {% endoptions_ui %}
 
@@ -64,7 +64,7 @@ until:
   required: false
   type: map
 dangling:
-  description: If true, only prune dangling images.
+  description: If true, only prune dangling images. When not set, all unused images are pruned.
   required: false
   default: false
   type: boolean

--- a/source/_actions/portainer.prune_images.markdown
+++ b/source/_actions/portainer.prune_images.markdown
@@ -1,0 +1,108 @@
+---
+title: Prune unused images
+action: portainer.prune_images
+domain: portainer
+description: "Removes unused images from a Portainer endpoint."
+related_actions:
+  - portainer.recreate_container
+---
+
+The **Prune unused images** action removes unused images from a Portainer endpoint to free up disk space. You can limit the cleanup to images that have been unused for at least a certain time, or to dangling images only.
+
+{% include actions/ui_header.md %}
+
+To prune images from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create** to start a new one.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Portainer: Prune unused images**.
+6. Select the **Endpoint** to prune images on.
+7. Optionally, set how far back to keep images and whether to limit the cleanup to dangling images.
+8. Select **Save**.
+
+This action does not support targets. In the UI, you select the endpoint through the **Endpoint** field instead of choosing an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Endpoint:
+  description: The endpoint to prune images on.
+  required: true
+Until:
+  description: Only prune images that have been unused for at least this time duration in the past. If not provided, all unused images are pruned.
+  required: false
+Dangling:
+  description: Only prune dangling images.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `portainer.prune_images`:
+
+{% example %}
+action: |
+  action: portainer.prune_images
+  data:
+    device_id: a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4
+    until:
+      hours: 24
+    dangling: true
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+device_id:
+  description: The ID of the endpoint device to prune images on.
+  required: true
+  type: string
+until:
+  description: Only prune images that have been unused for at least this time duration in the past, such as `hours: 24`. If not provided, all unused images are pruned.
+  required: false
+  type: map
+dangling:
+  description: If true, only prune dangling images.
+  required: false
+  default: false
+  type: boolean
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: clean up images every week
+
+This automation prunes images that have been unused for more than a week, keeping the Docker host tidy without removing images you still rely on.
+
+- **Trigger**: A scheduled time
+- **Action**: Portainer: Prune unused images
+
+{% details "YAML example for weekly image cleanup" %}
+
+{% example %}
+automation: |
+  alias: "Weekly Portainer image cleanup"
+  triggers:
+    - trigger: time
+      at: "03:00:00"
+  conditions:
+    - condition: time
+      weekday:
+        - sun
+  actions:
+    - action: portainer.prune_images
+      data:
+        device_id: a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4
+        until:
+          hours: 168
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/portainer.prune_images.markdown
+++ b/source/_actions/portainer.prune_images.markdown
@@ -60,7 +60,7 @@ device_id:
   required: true
   type: string
 until:
-  description: Only prune images that have been unused for at least this time duration in the past, such as `hours: 24`. If not provided, all unused images are pruned.
+  description: "Only prune images that have been unused for at least this time duration in the past, such as `hours: 24`. If not provided, all unused images are pruned."
   required: false
   type: map
 dangling:

--- a/source/_actions/portainer.recreate_container.markdown
+++ b/source/_actions/portainer.recreate_container.markdown
@@ -62,7 +62,7 @@ device_id:
   required: true
   type: string
 timeout:
-  description: The time to wait for the container to stop before killing it, such as `minutes: 5`. If not provided, a default of 5 minutes is used.
+  description: "The time to wait for the container to stop before killing it, such as `minutes: 5`. If not provided, a default of 5 minutes is used."
   required: false
   type: map
 pull_image:

--- a/source/_actions/portainer.recreate_container.markdown
+++ b/source/_actions/portainer.recreate_container.markdown
@@ -1,0 +1,107 @@
+---
+title: Recreate container
+action: portainer.recreate_container
+domain: portainer
+description: "Recreates a container on a Portainer endpoint."
+related_actions:
+  - portainer.prune_images
+---
+
+The **Recreate container** action recreates a container on a Portainer endpoint. This is more disruptive than a restart, because the container is stopped, removed, and then created again with the same configuration. You can optionally pull the image first to update the container to the latest version.
+
+{% caution %}
+Recreating a container stops it, removes it, and creates it again. Any data that is not stored in a volume or bind mount is lost. Use this action with care.
+{% endcaution %}
+
+{% include actions/ui_header.md %}
+
+To recreate a container from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create** to start a new one.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Portainer: Recreate container**.
+6. Select the **Container** to recreate.
+7. Optionally, set a timeout and whether to pull the image first.
+8. Select **Save**.
+
+This action does not support targets. In the UI, you select the container through the **Container** field instead of choosing an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Container:
+  description: The container to recreate.
+  required: true
+Timeout:
+  description: The time to wait for the container to stop before killing it. If not provided, a default of 5 minutes is used.
+  required: false
+Pull image:
+  description: Pull the image before recreating the container. This can be used to update the container to the latest version of the image.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `portainer.recreate_container`:
+
+{% example %}
+action: |
+  action: portainer.recreate_container
+  data:
+    device_id: a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4
+    timeout:
+      minutes: 5
+    pull_image: true
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+device_id:
+  description: The ID of the container device to recreate.
+  required: true
+  type: string
+timeout:
+  description: The time to wait for the container to stop before killing it, such as `minutes: 5`. If not provided, a default of 5 minutes is used.
+  required: false
+  type: map
+pull_image:
+  description: Whether to pull the image before recreating the container. This can be used to update the container to the latest version of the image.
+  required: false
+  default: false
+  type: boolean
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: update a container to the latest image
+
+This automation recreates a container and pulls the latest image first, so the running container picks up a new release.
+
+- **Trigger**: A scheduled time
+- **Action**: Portainer: Recreate container
+
+{% details "YAML example for updating a container to the latest image" %}
+
+{% example %}
+automation: |
+  alias: "Update Portainer container to latest image"
+  triggers:
+    - trigger: time
+      at: "04:30:00"
+  actions:
+    - action: portainer.recreate_container
+      data:
+        device_id: a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4
+        pull_image: true
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/portainer.recreate_container.markdown
+++ b/source/_actions/portainer.recreate_container.markdown
@@ -51,8 +51,6 @@ action: |
   action: portainer.recreate_container
   data:
     device_id: a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4
-    timeout:
-      minutes: 5
     pull_image: true
 {% endexample %}
 

--- a/source/_integrations/portainer.markdown
+++ b/source/_integrations/portainer.markdown
@@ -124,23 +124,7 @@ automation:
           message: "Container went down!"
 ```
 
-## Actions
-
-Portainer provides the following actions.
-
-### Action: Prune images
-
-The `portainer.prune_images` can be used to prune unused images more granually, such as a duration and/or if images are dangling.
-
-- **Data attribute**: `device_id`
-    - **Description**: The ID of the device/endpoint to prune images on.
-    - **Optional**: No
-- **Data attribute**: `until`
-    - **Description**: The duration in time in the past.
-    - **Optional**: Yes
-- **Data attribute**: `dangling`
-    - **Description**: If true, only prune dangling images.
-    - **Optional**: Yes
+{% include integrations/actions.md %}
 
 ## Supported devices
 

--- a/source/_integrations/portainer.markdown
+++ b/source/_integrations/portainer.markdown
@@ -97,6 +97,8 @@ There is currently support for the following device types within Home Assistant:
 - **Container**: Starts or stops an individual Docker container.
 - **Stack**: Starts or stops all containers in a stack.
 
+{% include integrations/actions.md %}
+
 ## Examples
 
 The following examples show how to use the Portainer integration in Home Assistant automations. These examples are just a starting point, and you can use them as inspiration to create your own automations.
@@ -124,7 +126,6 @@ automation:
           message: "Container went down!"
 ```
 
-{% include integrations/actions.md %}
 
 ## Supported devices
 


### PR DESCRIPTION
## Proposed change

Moves the Portainer actions out of the integration page into dedicated action pages under `source/_actions/`, replacing the inline `## Actions` block with `{% include integrations/actions.md %}`. The previously undocumented `portainer.recreate_container` action is documented as part of this migration.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

