### PR TITLE
System Bridge: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/system_bridge.get_process_by_id.markdown
+++ b/source/_actions/system_bridge.get_process_by_id.markdown
@@ -1,0 +1,97 @@
+---
+title: "Get process by ID"
+action: system_bridge.get_process_by_id
+domain: system_bridge
+description: "Gets a running process from a System Bridge server by its process ID."
+related_actions:
+  - system_bridge.get_processes_by_name
+---
+
+The **Get process by ID** action returns a single running process from a System Bridge server, looked up by its process ID (PID).
+
+This action returns its result in a response variable, which you can use in later steps of the same automation or script.
+
+{% include actions/ui_header.md %}
+
+To get a process by its ID from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create** to start a new one.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **System Bridge: Get process by ID**.
+6. Select the **Bridge** server and enter the process **ID**.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you select the System Bridge server through the **Bridge** field instead of choosing an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Bridge:
+  description: The System Bridge server to talk to.
+  required: true
+ID:
+  description: The ID of the process to get.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `system_bridge.get_process_by_id`. Store the result in a response variable so you can use it in later steps:
+
+{% example %}
+action: |
+  action: system_bridge.get_process_by_id
+  data:
+    bridge: 1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
+    id: 17752
+  response_variable: process
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+bridge:
+  description: The device ID of the System Bridge server to talk to.
+  required: true
+  type: string
+id:
+  description: The ID of the process to get.
+  required: true
+  type: integer
+{% endoptions_yaml %}
+
+## Response data
+
+The response describes the matching process and includes the following fields:
+
+- `id`: The process ID (PID).
+- `name`: The name of the process.
+- `cpu_usage`: The percentage of CPU the process is using.
+- `memory_usage`: The percentage of memory the process is using.
+- `created`: The time the process was created, as a Unix timestamp.
+- `path`: The path to the executable on the server.
+- `status`: The current status of the process, such as `running`.
+- `username`: The user the process is running as.
+- `working_directory`: The working directory of the process, if available.
+
+An example of the response looks like this:
+
+```yaml
+id: 17752
+name: steam.exe
+cpu_usage: 0.9
+created: 1698951361.6117153
+memory_usage: 0.23782578821487121
+path: C:\Program Files (x86)\Steam\steam.exe
+status: running
+username: hostname\user
+working_directory:
+```
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/system_bridge.get_processes_by_name.markdown
+++ b/source/_actions/system_bridge.get_processes_by_name.markdown
@@ -1,0 +1,93 @@
+---
+title: "Get processes by name"
+action: system_bridge.get_processes_by_name
+domain: system_bridge
+description: "Gets the running processes from a System Bridge server that match a name."
+related_actions:
+  - system_bridge.get_process_by_id
+---
+
+The **Get processes by name** action returns a count and a list of the running processes on a System Bridge server whose name matches the name you provide.
+
+This action returns its result in a response variable, which you can use in later steps of the same automation or script.
+
+{% include actions/ui_header.md %}
+
+To get processes by name from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create** to start a new one.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **System Bridge: Get processes by name**.
+6. Select the **Bridge** server and enter the process **Name**.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you select the System Bridge server through the **Bridge** field instead of choosing an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Bridge:
+  description: The System Bridge server to talk to.
+  required: true
+Name:
+  description: The name of the process to get.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `system_bridge.get_processes_by_name`. Store the result in a response variable so you can use it in later steps:
+
+{% example %}
+action: |
+  action: system_bridge.get_processes_by_name
+  data:
+    bridge: 1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
+    name: discord
+  response_variable: result
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+bridge:
+  description: The device ID of the System Bridge server to talk to.
+  required: true
+  type: string
+name:
+  description: The name of the process to get.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+## Response data
+
+The response contains the following fields:
+
+- `count`: The number of matching processes.
+- `processes`: A list of the matching processes. Each process includes the
+  same fields as the [Get process by ID](/actions/system_bridge.get_process_by_id/) response.
+
+An example of the response looks like this:
+
+```yaml
+count: 1
+processes:
+  - id: 11196
+    name: Discord.exe
+    cpu_usage: 0.3
+    created: 1698951365.770648
+    memory_usage: 0.07285296297215042
+    path: C:\Users\user\AppData\Local\Discord\app\Discord.exe
+    status: running
+    username: hostname\user
+    working_directory:
+```
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/system_bridge.get_processes_by_name.markdown
+++ b/source/_actions/system_bridge.get_processes_by_name.markdown
@@ -45,7 +45,7 @@ action: |
   action: system_bridge.get_processes_by_name
   data:
     bridge: 1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
-    name: discord
+    name: "discord"
   response_variable: result
 {% endexample %}
 

--- a/source/_actions/system_bridge.open_path.markdown
+++ b/source/_actions/system_bridge.open_path.markdown
@@ -1,0 +1,88 @@
+---
+title: "Open path"
+action: system_bridge.open_path
+domain: system_bridge
+description: "Opens a file on a System Bridge server with the default application."
+related_actions:
+  - system_bridge.open_url
+---
+
+The **Open path** action opens a file on a System Bridge server using the default application for that file type.
+
+This action returns its result in a response variable, which you can use in later steps of the same automation or script.
+
+{% include actions/ui_header.md %}
+
+To open a path from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create** to start a new one.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **System Bridge: Open path**.
+6. Select the **Bridge** server and enter the **Path** to open.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you select the System Bridge server through the **Bridge** field instead of choosing an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Bridge:
+  description: The System Bridge server to talk to.
+  required: true
+Path:
+  description: The path to open.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `system_bridge.open_path`. Store the result in a response variable so you can use it in later steps:
+
+{% example %}
+action: |
+  action: system_bridge.open_path
+  data:
+    bridge: 1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
+    path: "C:\\image.jpg"
+  response_variable: result
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+bridge:
+  description: The device ID of the System Bridge server to talk to.
+  required: true
+  type: string
+path:
+  description: The path to open.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+## Response data
+
+The response confirms the path that was opened and includes the following fields:
+
+- `id`: The ID of the request.
+- `type`: The result type, such as `OPENED`.
+- `data`: The data that was sent, such as the `path` that was opened.
+- `message`: A human-readable result message.
+
+An example of the response looks like this:
+
+```yaml
+id: abc123
+type: OPENED
+data:
+  path: C:\image.jpg
+message: Path opened
+```
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/system_bridge.open_url.markdown
+++ b/source/_actions/system_bridge.open_url.markdown
@@ -1,0 +1,88 @@
+---
+title: "Open URL"
+action: system_bridge.open_url
+domain: system_bridge
+description: "Opens a URL on a System Bridge server with the default application."
+related_actions:
+  - system_bridge.open_path
+---
+
+The **Open URL** action opens a URL on a System Bridge server using the default application, such as the default web browser.
+
+This action returns its result in a response variable, which you can use in later steps of the same automation or script.
+
+{% include actions/ui_header.md %}
+
+To open a URL from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create** to start a new one.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **System Bridge: Open URL**.
+6. Select the **Bridge** server and enter the **URL** to open.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you select the System Bridge server through the **Bridge** field instead of choosing an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Bridge:
+  description: The System Bridge server to talk to.
+  required: true
+URL:
+  description: The URL to open.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `system_bridge.open_url`. Store the result in a response variable so you can use it in later steps:
+
+{% example %}
+action: |
+  action: system_bridge.open_url
+  data:
+    bridge: 1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
+    url: "https://www.home-assistant.io"
+  response_variable: result
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+bridge:
+  description: The device ID of the System Bridge server to talk to.
+  required: true
+  type: string
+url:
+  description: The URL to open.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+## Response data
+
+The response confirms the URL that was opened and includes the following fields:
+
+- `id`: The ID of the request.
+- `type`: The result type, such as `OPENED`.
+- `data`: The data that was sent, such as the `url` that was opened.
+- `message`: A human-readable result message.
+
+An example of the response looks like this:
+
+```yaml
+id: abc123
+type: OPENED
+data:
+  url: https://www.home-assistant.io
+message: URL opened
+```
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/system_bridge.power_command.markdown
+++ b/source/_actions/system_bridge.power_command.markdown
@@ -1,0 +1,90 @@
+---
+title: "Power command"
+action: system_bridge.power_command
+domain: system_bridge
+description: "Sends a power command to a System Bridge server."
+related_actions:
+  - system_bridge.send_keypress
+  - system_bridge.send_text
+---
+
+The **Power command** action sends a power command to a System Bridge server, such as putting it to sleep, locking it, or shutting it down.
+
+This action returns its result in a response variable, which you can use in later steps of the same automation or script.
+
+{% include actions/ui_header.md %}
+
+To send a power command from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create** to start a new one.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **System Bridge: Power command**.
+6. Select the **Bridge** server and the **Command** to send.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you select the System Bridge server through the **Bridge** field instead of choosing an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Bridge:
+  description: The System Bridge server to talk to.
+  required: true
+Command:
+  description: The power command to send. One of hibernate, lock, logout, restart, shutdown, or sleep.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `system_bridge.power_command`. Store the result in a response variable so you can use it in later steps:
+
+{% example %}
+action: |
+  action: system_bridge.power_command
+  data:
+    bridge: 1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
+    command: sleep
+  response_variable: result
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+bridge:
+  description: The device ID of the System Bridge server to talk to.
+  required: true
+  type: string
+command:
+  description: >
+    The power command to send. One of `hibernate`, `lock`, `logout`,
+    `restart`, `shutdown`, or `sleep`.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+## Response data
+
+The response confirms the command that was sent and includes the following fields:
+
+- `id`: The ID of the request.
+- `type`: The result type, such as `POWER_SLEEPING`.
+- `data`: Any additional data returned with the result.
+- `message`: A human-readable result message.
+
+An example of the response looks like this:
+
+```yaml
+id: abc123
+type: POWER_SLEEPING
+data:
+message: Sleeping
+```
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/system_bridge.send_keypress.markdown
+++ b/source/_actions/system_bridge.send_keypress.markdown
@@ -1,0 +1,91 @@
+---
+title: "Send keyboard keypress"
+action: system_bridge.send_keypress
+domain: system_bridge
+description: "Sends a keyboard keypress to a System Bridge server."
+related_actions:
+  - system_bridge.send_text
+---
+
+The **Send keyboard keypress** action sends a single keyboard keypress to a System Bridge server, as if the key was pressed on the server's keyboard.
+
+This action returns its result in a response variable, which you can use in later steps of the same automation or script.
+
+{% include actions/ui_header.md %}
+
+To send a keypress from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create** to start a new one.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **System Bridge: Send keyboard keypress**.
+6. Select the **Bridge** server and select or enter the **Key** to press.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you select the System Bridge server through the **Bridge** field instead of choosing an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Bridge:
+  description: The System Bridge server to send the keypress to.
+  required: true
+Key:
+  description: The key to press, such as `a`, `enter`, or `audio_play`. You can pick a key from the list or enter your own.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `system_bridge.send_keypress`. Store the result in a response variable so you can use it in later steps:
+
+{% example %}
+action: |
+  action: system_bridge.send_keypress
+  data:
+    bridge: 1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
+    key: "a"
+  response_variable: result
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+bridge:
+  description: The device ID of the System Bridge server to send the keypress to.
+  required: true
+  type: string
+key:
+  description: >
+    The key to press, such as `a`, `enter`, or `audio_play`. For the full
+    list of supported keys, refer to the
+    [keys documentation](https://robotjs.dev/docs/syntax#keys).
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+## Response data
+
+The response confirms the key that was pressed and includes the following fields:
+
+- `id`: The ID of the request.
+- `type`: The result type, such as `KEYBOARD_KEY_PRESSED`.
+- `data`: The data that was sent, such as the `key` that was pressed.
+- `message`: A human-readable result message.
+
+An example of the response looks like this:
+
+```yaml
+id: abc123
+type: KEYBOARD_KEY_PRESSED
+data:
+  key: a
+message: Key pressed
+```
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/system_bridge.send_text.markdown
+++ b/source/_actions/system_bridge.send_text.markdown
@@ -1,0 +1,88 @@
+---
+title: "Send keyboard text"
+action: system_bridge.send_text
+domain: system_bridge
+description: "Sends text for a System Bridge server to type."
+related_actions:
+  - system_bridge.send_keypress
+---
+
+The **Send keyboard text** action sends text for a System Bridge server to type, as if it was typed on the server's keyboard.
+
+This action returns its result in a response variable, which you can use in later steps of the same automation or script.
+
+{% include actions/ui_header.md %}
+
+To send text from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create** to start a new one.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **System Bridge: Send keyboard text**.
+6. Select the **Bridge** server and enter the **Text** to type.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you select the System Bridge server through the **Bridge** field instead of choosing an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Bridge:
+  description: The System Bridge server to send the text to.
+  required: true
+Text:
+  description: The text to type.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `system_bridge.send_text`. Store the result in a response variable so you can use it in later steps:
+
+{% example %}
+action: |
+  action: system_bridge.send_text
+  data:
+    bridge: 1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
+    text: "Hello"
+  response_variable: result
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+bridge:
+  description: The device ID of the System Bridge server to send the text to.
+  required: true
+  type: string
+text:
+  description: The text to type.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+## Response data
+
+The response confirms the text that was sent and includes the following fields:
+
+- `id`: The ID of the request.
+- `type`: The result type, such as `KEYBOARD_TEXT_SENT`.
+- `data`: The data that was sent, such as the `text` that was typed.
+- `message`: A human-readable result message.
+
+An example of the response looks like this:
+
+```yaml
+id: abc123
+type: KEYBOARD_TEXT_SENT
+data:
+  text: Hello
+message: Text entered
+```
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/system_bridge.markdown
+++ b/source/_integrations/system_bridge.markdown
@@ -115,11 +115,9 @@ action: |
     message: "Have you considered frogs?"
 {% endexample %}
 
-## Actions
+## Notifications
 
-### Notifications `notify.system_bridge_hostname`
-
-You can send notifications to the device using the `notify` platform.
+You can send notifications to the device using the `notify.system_bridge_hostname` notify entity.
 
 ```yaml
 action: notify.system_bridge_hostname
@@ -142,26 +140,22 @@ data:
   message: "This is a message"
 ```
 
-#### Parameters
+### Parameters
 
-| Parameter | Description                                                  |
-| --------- | ------------------------------------------------------------ |
-| target    | The target to send the notification to. This can be ignored. |
-| title     | The title of the notification.                               |
-| message   | The message of the notification.                             |
-| data      | The data to send to the device. See below for info.          |
+- **target**: The target to send the notification to. This can be ignored.
+- **title**: The title of the notification.
+- **message**: The message of the notification.
+- **data**: The data to send to the device. See below for more information.
 
-##### Actions (`data` parameter)
+#### Actions (`data` parameter)
 
-This is an array of actions that can be sent to the device. These are buttons that show below the title, message and image.
+This is a list of actions that can be sent to the device. These are buttons that show below the title, message, and image.
 
-| Parameter | Description                                                                                                                |
-| --------- | -------------------------------------------------------------------------------------------------------------------------- |
-| command   | The command to send to the device. For example `api` will send a request to the System Bridge API.                         |
-| label     | The label of the button.                                                                                                   |
-| data      | The data to send to the device. The available parameters for the `api` command are: `endpoint`, `method` `body`, `params`. |
+- **command**: The command to send to the device. For example, `api` sends a request to the System Bridge API.
+- **label**: The label of the button.
+- **data**: The data to send to the device. The available parameters for the `api` command are `endpoint`, `method`, `body`, and `params`.
 
-Here is an example action that will open a URL in the device's browser:
+Here is an example action that opens a URL in the device's browser:
 
 ```yaml
 - command: api
@@ -173,185 +167,8 @@ Here is an example action that will open a URL in the device's browser:
       url: "http://homeassistant.local:8123/lovelace/cameras"
 ```
 
-##### Audio (`data` parameter)
+#### Audio (`data` parameter)
 
-This is an object containing the `source` and `volume` (0-100). The source must be a URL to a playable audio file (an MP3 for example).
+This is an object containing the `source` and `volume` (0-100). The source must be a URL to a playable audio file, such as an MP3.
 
-### Action: Get process by ID
-
-The `system_bridge.get_process_by_id` action returns a process by its PID.
-
-{% my developer_call_service service="system_bridge.get_process_by_id" title="Show action in your Home Assistant instance." %}
-
-```yaml
-action: system_bridge.get_process_by_id
-data:
-  bridge: "deviceid"
-  id: 17752
-```
-
-This returns [Response Data](/docs/scripts/perform-actions#use-templates-to-handle-response-data) like the following:
-
-```yaml
-id: 17752
-name: steam.exe
-cpu_usage: 0.9
-created: 1698951361.6117153
-memory_usage: 0.23782578821487121
-path: C:\Program Files (x86)\Steam\steam.exe
-status: running
-username: hostname\user
-working_directory: null
-```
-
-### Action: Get processes by name
-
-The `system_bridge.get_processes_by_name` action returns a count and a list of processes matching the name provided.
-
-{% my developer_call_service service="system_bridge.get_processes_by_name" title="Show action in your Home Assistant instance." %}
-
-```yaml
-action: system_bridge.get_processes_by_name
-data:
-  bridge: "deviceid"
-  name: discord
-```
-
-This returns [Response Data](/docs/scripts/perform-actions#use-templates-to-handle-response-data) like the following:
-
-```yaml
-count: 1
-processes:
-  - id: 11196
-    name: Discord.exe
-    cpu_usage: 0.3
-    created: 1698951365.770648
-    memory_usage: 0.07285296297215042
-    path: C:\Users\user\AppData\Local\Discord\app\Discord.exe
-    status: running
-    username: hostname\user
-    working_directory: null
-```
-
-### Action: Open path
-
-The `system_bridge.open_path` action opens a URL or file on the server using the default application.
-
-{% my developer_call_service service="system_bridge.open_path" title="Show action in your Home Assistant instance." %}
-
-```yaml
-action: system_bridge.open_path
-data:
-  bridge: "deviceid"
-  path: "C:\\image.jpg"
-```
-
-This returns [Response Data](/docs/scripts/perform-actions#use-templates-to-handle-response-data) like the following:
-
-```yaml
-id: abc123
-type: OPENED
-data:
-  path: C:\image.jpg
-message: Path opened
-```
-
-### Action: Open URL
-
-The `system_bridge.open_url` action opens a URL or file on the server using the default application.
-
-{% my developer_call_service service="system_bridge.open_url" title="Show action in your Home Assistant instance." %}
-
-```yaml
-action: system_bridge.open_url
-data:
-  bridge: "deviceid"
-  url: "https://home-assistant.io"
-```
-
-This returns [Response Data](/docs/scripts/perform-actions#use-templates-to-handle-response-data) like the following:
-
-```yaml
-id: abc123
-type: OPENED
-data:
-  url: https://home-assistant.io
-message: URL opened
-```
-
-### Action: Send keypress
-
-The `system_bridge.send_keypress` action sends a keypress to the server.
-
-{% my developer_call_service service="system_bridge.send_keypress" title="Show action in your Home Assistant instance." %}
-
-```yaml
-action: system_bridge.send_keypress
-data:
-  bridge: "deviceid"
-  key: "a"
-```
-
-This returns [Response Data](/docs/scripts/perform-actions#use-templates-to-handle-response-data) like the following:
-
-```yaml
-id: abc123
-type: KEYBOARD_KEY_PRESSED
-data:
-  key: a
-message: Key pressed
-```
-
-### Action: Send text
-
-The `system_bridge.send_text` action sends text for the server to type.
-
-{% my developer_call_service service="system_bridge.send_text" title="Show action in your Home Assistant instance." %}
-
-```yaml
-action: system_bridge.send_text
-data:
-  bridge: "deviceid"
-  text: "Hello"
-```
-
-This returns [Response Data](/docs/scripts/perform-actions#use-templates-to-handle-response-data) like the following:
-
-```yaml
-id: abc123
-type: KEYBOARD_TEXT_SENT
-data:
-  text: Hello
-message: Text entered
-```
-
-### Action: Power command
-
-The `system_bridge.power_command` action sends a power command to the system.
-
-Supported commands are:
-
-- `hibernate`
-- `lock`
-- `logout`
-- `restart`
-- `shutdown`
-- `sleep`
-
-{% my developer_call_service service="system_bridge.power_command" title="Show action in your Home Assistant instance." %}
-
-```yaml
-action: system_bridge.power_command
-data:
-  bridge: "device"
-  command: "sleep"
-```
-
-This returns [Response Data](/docs/scripts/perform-actions#use-templates-to-handle-response-data) like the following:
-
-```yaml
-id: abc123
-type: POWER_SLEEPING
-data: {}
-message: Sleeping
-```
+{% include integrations/actions.md %}


### PR DESCRIPTION
## Proposed change

Moves the System Bridge actions out of the integration page into dedicated action pages under `source/_actions/`, replacing the inline action documentation with `{% include integrations/actions.md %}`. The legacy `notify.system_bridge_hostname` notify entity stays documented in its own section, with its parameter tables converted to lists.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

