### PR TITLE
Modern Forms: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/modern_forms.clear_fan_sleep_timer.markdown
+++ b/source/_actions/modern_forms.clear_fan_sleep_timer.markdown
@@ -1,0 +1,46 @@
+---
+title: "Clear fan sleep timer"
+action: modern_forms.clear_fan_sleep_timer
+domain: modern_forms
+description: "Clears the sleep timer on a Modern Forms fan."
+related_actions:
+  - modern_forms.set_fan_sleep_timer
+  - modern_forms.clear_light_sleep_timer
+---
+
+Use this action to clear the sleep timer on a Modern Forms fan. Clearing the timer does not turn the fan off, it only cancels the pending timer.
+
+{% include actions/ui_header.md %}
+
+To clear a fan sleep timer from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select your Modern Forms fan.
+6. From the actions shown for that target, select **Clear fan sleep timer**.
+7. Select **Save**.
+
+### Options in the UI
+
+This action has no additional options in the UI.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `modern_forms.clear_fan_sleep_timer`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: modern_forms.clear_fan_sleep_timer
+  target:
+    entity_id: fan.bedroom
+{% endexample %}
+
+{% include actions/targets.md domain="fan" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/modern_forms.clear_fan_sleep_timer.markdown
+++ b/source/_actions/modern_forms.clear_fan_sleep_timer.markdown
@@ -19,7 +19,7 @@ To clear a fan sleep timer from an automation or a script:
 3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
 4. In the **Then do** section, select **Add action**.
 5. Select what you want to control. Under **By target** (see [Targets](#targets)), select your Modern Forms fan.
-6. From the actions shown for that target, select **Clear fan sleep timer**.
+6. From the actions shown for that target, select **Modern Forms: Clear fan sleep timer**.
 7. Select **Save**.
 
 ### Options in the UI

--- a/source/_actions/modern_forms.clear_fan_sleep_timer.markdown
+++ b/source/_actions/modern_forms.clear_fan_sleep_timer.markdown
@@ -8,7 +8,7 @@ related_actions:
   - modern_forms.clear_light_sleep_timer
 ---
 
-Use this action to clear the sleep timer on a Modern Forms fan. Clearing the timer does not turn the fan off, it only cancels the pending timer.
+Use this action to clear the sleep timer on a Modern Forms fan. Clearing the timer does not turn the fan off. It only cancels the pending timer.
 
 {% include actions/ui_header.md %}
 

--- a/source/_actions/modern_forms.clear_light_sleep_timer.markdown
+++ b/source/_actions/modern_forms.clear_light_sleep_timer.markdown
@@ -1,0 +1,46 @@
+---
+title: "Clear light sleep timer"
+action: modern_forms.clear_light_sleep_timer
+domain: modern_forms
+description: "Clears the sleep timer on a Modern Forms fan light."
+related_actions:
+  - modern_forms.set_light_sleep_timer
+  - modern_forms.clear_fan_sleep_timer
+---
+
+Use this action to clear the sleep timer on a Modern Forms fan light. Clearing the timer does not turn the light off, it only cancels the pending timer.
+
+{% include actions/ui_header.md %}
+
+To clear a light sleep timer from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select your Modern Forms fan light.
+6. From the actions shown for that target, select **Clear light sleep timer**.
+7. Select **Save**.
+
+### Options in the UI
+
+This action has no additional options in the UI.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `modern_forms.clear_light_sleep_timer`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: modern_forms.clear_light_sleep_timer
+  target:
+    entity_id: light.bedroom
+{% endexample %}
+
+{% include actions/targets.md domain="light" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/modern_forms.clear_light_sleep_timer.markdown
+++ b/source/_actions/modern_forms.clear_light_sleep_timer.markdown
@@ -19,7 +19,7 @@ To clear a light sleep timer from an automation or a script:
 3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
 4. In the **Then do** section, select **Add action**.
 5. Select what you want to control. Under **By target** (see [Targets](#targets)), select your Modern Forms fan light.
-6. From the actions shown for that target, select **Clear light sleep timer**.
+6. From the actions shown for that target, select **Modern Forms: Clear light sleep timer**.
 7. Select **Save**.
 
 ### Options in the UI

--- a/source/_actions/modern_forms.clear_light_sleep_timer.markdown
+++ b/source/_actions/modern_forms.clear_light_sleep_timer.markdown
@@ -8,7 +8,7 @@ related_actions:
   - modern_forms.clear_fan_sleep_timer
 ---
 
-Use this action to clear the sleep timer on a Modern Forms fan light. Clearing the timer does not turn the light off, it only cancels the pending timer.
+Use this action to clear the sleep timer on a Modern Forms fan light. Clearing the timer does not turn the light off. It only cancels the pending timer.
 
 {% include actions/ui_header.md %}
 

--- a/source/_actions/modern_forms.set_fan_sleep_timer.markdown
+++ b/source/_actions/modern_forms.set_fan_sleep_timer.markdown
@@ -19,7 +19,7 @@ To set a fan sleep timer from an automation or a script:
 3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
 4. In the **Then do** section, select **Add action**.
 5. Select what you want to control. Under **By target** (see [Targets](#targets)), select your Modern Forms fan.
-6. From the actions shown for that target, select **Set fan sleep timer**.
+6. From the actions shown for that target, select **Modern Forms: Set fan sleep timer**.
 7. Enter the **Sleep time** in minutes.
 8. Select **Save**.
 

--- a/source/_actions/modern_forms.set_fan_sleep_timer.markdown
+++ b/source/_actions/modern_forms.set_fan_sleep_timer.markdown
@@ -1,0 +1,92 @@
+---
+title: "Set fan sleep timer"
+action: modern_forms.set_fan_sleep_timer
+domain: modern_forms
+description: "Sets a sleep timer on a Modern Forms fan."
+related_actions:
+  - modern_forms.clear_fan_sleep_timer
+  - modern_forms.set_light_sleep_timer
+---
+
+Use this action to set a sleep timer on a Modern Forms fan. When the timer expires, the fan turns off.
+
+{% include actions/ui_header.md %}
+
+To set a fan sleep timer from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select your Modern Forms fan.
+6. From the actions shown for that target, select **Set fan sleep timer**.
+7. Enter the **Sleep time** in minutes.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Sleep time:
+  description: The number of minutes to set the timer for, from 1 to 1440 (one day).
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `modern_forms.set_fan_sleep_timer`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: modern_forms.set_fan_sleep_timer
+  target:
+    entity_id: fan.bedroom
+  data:
+    sleep_time: 60
+{% endexample %}
+
+This turns the fan off after one hour.
+
+### Options in YAML
+
+{% options_yaml %}
+sleep_time:
+  description: >
+    The number of minutes to set the timer for, from 1 to 1440 (one day).
+  required: true
+  type: integer
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="fan" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: run the bedroom fan for an hour at bedtime
+
+This automation sets a one-hour sleep timer on the bedroom fan every night, so it runs while you fall asleep and then turns itself off.
+
+- **Trigger**: A scheduled time
+- **Action**: Modern Forms: Set fan sleep timer
+
+{% details "YAML example for a nightly fan sleep timer" %}
+
+{% example %}
+automation: |
+  alias: "Bedroom fan sleep timer"
+  triggers:
+    - trigger: time
+      at: "22:30:00"
+  actions:
+    - action: modern_forms.set_fan_sleep_timer
+      target:
+        entity_id: fan.bedroom
+      data:
+        sleep_time: 60
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/modern_forms.set_light_sleep_timer.markdown
+++ b/source/_actions/modern_forms.set_light_sleep_timer.markdown
@@ -1,0 +1,92 @@
+---
+title: "Set light sleep timer"
+action: modern_forms.set_light_sleep_timer
+domain: modern_forms
+description: "Sets a sleep timer on a Modern Forms fan light."
+related_actions:
+  - modern_forms.clear_light_sleep_timer
+  - modern_forms.set_fan_sleep_timer
+---
+
+Use this action to set a sleep timer on a Modern Forms fan light. When the timer expires, the light turns off.
+
+{% include actions/ui_header.md %}
+
+To set a light sleep timer from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select your Modern Forms fan light.
+6. From the actions shown for that target, select **Set light sleep timer**.
+7. Enter the **Sleep time** in minutes.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Sleep time:
+  description: The number of minutes to set the timer for, from 1 to 1440 (one day).
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `modern_forms.set_light_sleep_timer`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: modern_forms.set_light_sleep_timer
+  target:
+    entity_id: light.bedroom
+  data:
+    sleep_time: 30
+{% endexample %}
+
+This turns the light off after 30 minutes.
+
+### Options in YAML
+
+{% options_yaml %}
+sleep_time:
+  description: >
+    The number of minutes to set the timer for, from 1 to 1440 (one day).
+  required: true
+  type: integer
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="light" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: dim-then-off reading light at bedtime
+
+This automation sets a 30-minute sleep timer on the bedroom fan light every night, so you can read for a while before it turns itself off.
+
+- **Trigger**: A scheduled time
+- **Action**: Modern Forms: Set light sleep timer
+
+{% details "YAML example for a nightly light sleep timer" %}
+
+{% example %}
+automation: |
+  alias: "Bedroom reading light sleep timer"
+  triggers:
+    - trigger: time
+      at: "22:30:00"
+  actions:
+    - action: modern_forms.set_light_sleep_timer
+      target:
+        entity_id: light.bedroom
+      data:
+        sleep_time: 30
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/modern_forms.set_light_sleep_timer.markdown
+++ b/source/_actions/modern_forms.set_light_sleep_timer.markdown
@@ -19,7 +19,7 @@ To set a light sleep timer from an automation or a script:
 3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
 4. In the **Then do** section, select **Add action**.
 5. Select what you want to control. Under **By target** (see [Targets](#targets)), select your Modern Forms fan light.
-6. From the actions shown for that target, select **Set light sleep timer**.
+6. From the actions shown for that target, select **Modern Forms: Set light sleep timer**.
 7. Enter the **Sleep time** in minutes.
 8. Select **Save**.
 

--- a/source/_integrations/modern_forms.markdown
+++ b/source/_integrations/modern_forms.markdown
@@ -61,32 +61,8 @@ The Modern Forms integration provides support for the following toggleable attri
 - Away mode - to allow the fan simulate someone being home.
 - Adaptive learning - for allow learning for away mode.
 
-## Actions
-
-### Action `modern_forms.clear_fan_sleep_timer`
-
-This action will clear the sleep timer for the fan if it has been set. It will not turn off the fan when the timer is cleared.
-
-### Action `modern_forms.clear_light_sleep_timer`
-
-This action will clear the sleep timer for the light if it has been set. It will not turn off the light when the timer is cleared.
-
-### Action `modern_forms.set_fan_sleep_timer`
-
-This action will set a sleep timer for the fan. When the sleep timer is expired it will turn off the fan.
-
-| Data attribute | Required | Description                                        |
-| ---------------------- | -------- | -------------------------------------------------- |
-| `sleep_time`           | yes      | The amount of time in minutes to set the sleep timer for. This is time in minutes from 1 to 1440 (1 day). |
-
-### Action `modern_forms.set_light_sleep_timer`
-
-This action will set a sleep timer for the light. When the sleep timer is expired it will turn off the light.
-
-| Data attribute | Required | Description                                        |
-| ---------------------- | -------- | -------------------------------------------------- |
-| `sleep_time`           | yes      | The amount of time in minutes to set the sleep timer for. This is time in minutes from 1 to 1440 (1 day).|
+{% include integrations/actions.md %}
 
 {% note %}
-Modern Forms Fans use NTP to pool.ntp.org to set its internal clock and check of sleep timers have expired. Sleep timers will only work if the Modern Forms Fans have internet NTP access. You can block off cloud access for the fan and only leave NTP (UDP port 123) outbound working for the sleep timers.
+Modern Forms fans use NTP to pool.ntp.org to set their internal clock and check whether sleep timers have expired. Sleep timers only work if the fan has internet NTP access. You can block cloud access for the fan and leave only NTP (UDP port 123) outbound working for the sleep timers.
 {% endnote %}

--- a/source/_integrations/modern_forms.markdown
+++ b/source/_integrations/modern_forms.markdown
@@ -64,5 +64,5 @@ The Modern Forms integration provides support for the following toggleable attri
 {% include integrations/actions.md %}
 
 {% note %}
-Modern Forms fans use NTP to pool.ntp.org to set their internal clock and check whether sleep timers have expired. Sleep timers only work if the fan has internet NTP access. You can block cloud access for the fan and leave only NTP (UDP port 123) outbound working for the sleep timers.
+Modern Forms fans use NTP (via `pool.ntp.org`) to set their internal clock and check whether sleep timers have expired. Sleep timers only work if your fan can reach an NTP server on the internet. You can block cloud access for the fan and allow only outbound NTP (UDP port 123) so sleep timers keep working.
 {% endnote %}


### PR DESCRIPTION
## Proposed change

Migrates the Modern Forms inline action documentation into dedicated action pages under `source/_actions/`, one per action (`set_fan_sleep_timer`, `clear_fan_sleep_timer`, `set_light_sleep_timer`, `clear_light_sleep_timer`), and replaces the inline `## Actions` block with the standard `{% include integrations/actions.md %}`. The NTP note about sleep timer expiry is preserved.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

