### PR TITLE
Agent DVR: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/agent_dvr.disable_alerts.markdown
+++ b/source/_actions/agent_dvr.disable_alerts.markdown
@@ -1,0 +1,45 @@
+---
+title: "Disable alerts"
+action: agent_dvr.disable_alerts
+domain: agent_dvr
+description: "Disables alert events for an Agent DVR camera."
+related_actions:
+  - agent_dvr.enable_alerts
+---
+
+Use this action to disable alert events for an Agent DVR camera. When alerts are disabled, Agent DVR stops generating alert events for that camera.
+
+{% include actions/ui_header.md %}
+
+To disable alerts from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select your Agent DVR camera.
+6. From the actions shown for that target, select **Disable alerts**.
+7. Select **Save**.
+
+### Options in the UI
+
+This action has no additional options in the UI.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `agent_dvr.disable_alerts`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: agent_dvr.disable_alerts
+  target:
+    entity_id: camera.living_room
+{% endexample %}
+
+{% include actions/targets.md domain="camera" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/agent_dvr.enable_alerts.markdown
+++ b/source/_actions/agent_dvr.enable_alerts.markdown
@@ -1,0 +1,45 @@
+---
+title: "Enable alerts"
+action: agent_dvr.enable_alerts
+domain: agent_dvr
+description: "Enables alert events for an Agent DVR camera."
+related_actions:
+  - agent_dvr.disable_alerts
+---
+
+Use this action to enable alert events for an Agent DVR camera. When alerts are enabled, Agent DVR generates alert events for that camera, for example when it detects motion.
+
+{% include actions/ui_header.md %}
+
+To enable alerts from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select your Agent DVR camera.
+6. From the actions shown for that target, select **Enable alerts**.
+7. Select **Save**.
+
+### Options in the UI
+
+This action has no additional options in the UI.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `agent_dvr.enable_alerts`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: agent_dvr.enable_alerts
+  target:
+    entity_id: camera.living_room
+{% endexample %}
+
+{% include actions/targets.md domain="camera" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/agent_dvr.snapshot.markdown
+++ b/source/_actions/agent_dvr.snapshot.markdown
@@ -1,0 +1,45 @@
+---
+title: "Snapshot"
+action: agent_dvr.snapshot
+domain: agent_dvr
+description: "Takes a photo on an Agent DVR camera."
+related_actions:
+  - agent_dvr.start_recording
+---
+
+Use this action to take a photo on an Agent DVR camera. The snapshot is captured and stored by Agent DVR.
+
+{% include actions/ui_header.md %}
+
+To take a snapshot from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select your Agent DVR camera.
+6. From the actions shown for that target, select **Snapshot**.
+7. Select **Save**.
+
+### Options in the UI
+
+This action has no additional options in the UI.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `agent_dvr.snapshot`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: agent_dvr.snapshot
+  target:
+    entity_id: camera.living_room
+{% endexample %}
+
+{% include actions/targets.md domain="camera" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/agent_dvr.start_recording.markdown
+++ b/source/_actions/agent_dvr.start_recording.markdown
@@ -1,0 +1,46 @@
+---
+title: "Start recording"
+action: agent_dvr.start_recording
+domain: agent_dvr
+description: "Starts continuous recording on an Agent DVR camera."
+related_actions:
+  - agent_dvr.stop_recording
+  - agent_dvr.snapshot
+---
+
+Use this action to start continuous recording on an Agent DVR camera. Recording continues until you stop it with the [Stop recording](/actions/agent_dvr.stop_recording/) action.
+
+{% include actions/ui_header.md %}
+
+To start recording from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select your Agent DVR camera.
+6. From the actions shown for that target, select **Start recording**.
+7. Select **Save**.
+
+### Options in the UI
+
+This action has no additional options in the UI.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `agent_dvr.start_recording`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: agent_dvr.start_recording
+  target:
+    entity_id: camera.living_room
+{% endexample %}
+
+{% include actions/targets.md domain="camera" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/agent_dvr.stop_recording.markdown
+++ b/source/_actions/agent_dvr.stop_recording.markdown
@@ -1,0 +1,45 @@
+---
+title: "Stop recording"
+action: agent_dvr.stop_recording
+domain: agent_dvr
+description: "Stops continuous recording on an Agent DVR camera."
+related_actions:
+  - agent_dvr.start_recording
+---
+
+Use this action to stop continuous recording on an Agent DVR camera that you previously started with the [Start recording](/actions/agent_dvr.start_recording/) action.
+
+{% include actions/ui_header.md %}
+
+To stop recording from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select your Agent DVR camera.
+6. From the actions shown for that target, select **Stop recording**.
+7. Select **Save**.
+
+### Options in the UI
+
+This action has no additional options in the UI.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `agent_dvr.stop_recording`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: agent_dvr.stop_recording
+  target:
+    entity_id: camera.living_room
+{% endexample %}
+
+{% include actions/targets.md domain="camera" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/agent_dvr.markdown
+++ b/source/_integrations/agent_dvr.markdown
@@ -30,38 +30,9 @@ Please ensure you are using Agent DVR v2.6.1.0 +
 
 Reports on the current alarm status and can be used to arm and disarm the system.
 
-## Actions
+{% include integrations/actions.md %}
 
-Once loaded, the `agent_dvr` integration will expose actions that can be used. The `entity_id` action attribute can specify one or more specific cameras.
-
-Available actions:
-`enable_alerts`, `disable_alerts`,
-`start_recording`, `stop_recording`,
-`turn_on`, `turn_off`, `toggle`, `enable_motion_detection`,`disable_motion_detection`
-
-### Action: Enable alerts / disable alerts
-
-The `agent_dvr.enable_alerts` and `agent_dvr.disable_alerts` actions are used to enable or disable the device's alert events within Agent DVR.
-
-Data attribute | Optional | Description
--|-|-
-`entity_id` | no | Name(s) of entities, e.g., `camera.living_room_camera`.
-
-### Action: Start recording / stop recording
-
-The `agent_dvr.start_recording` and `agent_dvr.stop_recording` actions are used to start or stop the device recording.
-
-Data attribute | Optional | Description
--|-|-
-`entity_id` | no | Name(s) of entities, e.g., `camera.living_room_camera`.
-
-### Action: Turn on / turn off / toggle
-
-The `agent_dvr.turn_on`, `agent_dvr.turn_off`, and `agent_dvr.toggle` actions are used to turn on, off or toggle the device enabled state within Agent DVR.
-
-Data attribute | Optional | Description
--|-|-
-`entity_id` | no | Name(s) of entities, e.g., `camera.living_room_camera`.
+The Agent DVR cameras also support the standard [camera actions](/integrations/camera/#list-of-actions), such as turning the camera on or off and toggling motion detection.
 
 ## Iframe
 


### PR DESCRIPTION
## Proposed change

Migrates the Agent DVR inline action documentation into dedicated action pages under `source/_actions/`, one per action (`enable_alerts`, `disable_alerts`, `start_recording`, `stop_recording`, `snapshot`), and replaces the inline `## Actions` block with the standard `{% include integrations/actions.md %}`.

While migrating, this also documents the previously missing `snapshot` action and drops the `turn_on`, `turn_off`, `toggle`, `enable_motion_detection`, and `disable_motion_detection` entries, which are standard camera actions and were incorrectly listed under the `agent_dvr` domain. A short note now points to the standard camera actions instead.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

