### PR TITLE
Keba Charging Station: migrate actions to dedicated pages

### DIFF
--- a/source/_actions/keba.authorize.markdown
+++ b/source/_actions/keba.authorize.markdown
@@ -1,0 +1,43 @@
+---
+title: "Authorize"
+action: keba.authorize
+domain: keba
+description: "Authorizes a charging process on a Keba charging station."
+related_actions:
+  - keba.deauthorize
+  - keba.enable
+---
+
+Use this action to authorize a charging process on a Keba charging station. It uses the RFID tag defined in your configuration.
+
+{% include actions/ui_header.md %}
+
+To authorize a charging process from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Keba Charging Station: Authorize**.
+6. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+This action has no additional options in the UI.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `keba.authorize`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: keba.authorize
+{% endexample %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/keba.authorize.markdown
+++ b/source/_actions/keba.authorize.markdown
@@ -10,6 +10,10 @@ related_actions:
 
 Use this action to authorize a charging process on a Keba charging station. It uses the RFID tag defined in your configuration.
 
+{% caution %}
+Using this action changes the state of your charging station. Use it with care.
+{% endcaution %}
+
 {% include actions/ui_header.md %}
 
 To authorize a charging process from an automation or a script:

--- a/source/_actions/keba.deauthorize.markdown
+++ b/source/_actions/keba.deauthorize.markdown
@@ -10,6 +10,10 @@ related_actions:
 
 Use this action to deauthorize the running charging process on a Keba charging station. It uses the RFID tag defined in your configuration.
 
+{% caution %}
+Using this action changes the state of your charging station. Use it with care.
+{% endcaution %}
+
 {% include actions/ui_header.md %}
 
 To deauthorize a charging process from an automation or a script:

--- a/source/_actions/keba.deauthorize.markdown
+++ b/source/_actions/keba.deauthorize.markdown
@@ -1,0 +1,43 @@
+---
+title: "Deauthorize"
+action: keba.deauthorize
+domain: keba
+description: "Deauthorizes the running charging process on a Keba charging station."
+related_actions:
+  - keba.authorize
+  - keba.disable
+---
+
+Use this action to deauthorize the running charging process on a Keba charging station. It uses the RFID tag defined in your configuration.
+
+{% include actions/ui_header.md %}
+
+To deauthorize a charging process from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Keba Charging Station: Deauthorize**.
+6. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+This action has no additional options in the UI.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `keba.deauthorize`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: keba.deauthorize
+{% endexample %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/keba.disable.markdown
+++ b/source/_actions/keba.disable.markdown
@@ -1,0 +1,43 @@
+---
+title: "Disable"
+action: keba.disable
+domain: keba
+description: "Stops the charging process on an authorized Keba charging station."
+related_actions:
+  - keba.enable
+  - keba.deauthorize
+---
+
+Use this action to stop the charging process on a Keba charging station. The charging station must already be authorized.
+
+{% include actions/ui_header.md %}
+
+To stop a charging process from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Keba Charging Station: Disable**.
+6. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+This action has no additional options in the UI.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `keba.disable`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: keba.disable
+{% endexample %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/keba.disable.markdown
+++ b/source/_actions/keba.disable.markdown
@@ -10,6 +10,10 @@ related_actions:
 
 Use this action to stop the charging process on a Keba charging station. The charging station must already be authorized.
 
+{% caution %}
+Using this action changes the state of your charging station. Use it with care.
+{% endcaution %}
+
 {% include actions/ui_header.md %}
 
 To stop a charging process from an automation or a script:

--- a/source/_actions/keba.enable.markdown
+++ b/source/_actions/keba.enable.markdown
@@ -10,6 +10,10 @@ related_actions:
 
 Use this action to start a charging process on a Keba charging station. The charging station must already be authorized.
 
+{% caution %}
+Using this action changes the state of your charging station. Use it with care.
+{% endcaution %}
+
 {% include actions/ui_header.md %}
 
 To start a charging process from an automation or a script:

--- a/source/_actions/keba.enable.markdown
+++ b/source/_actions/keba.enable.markdown
@@ -1,0 +1,43 @@
+---
+title: "Enable"
+action: keba.enable
+domain: keba
+description: "Starts a charging process on an authorized Keba charging station."
+related_actions:
+  - keba.disable
+  - keba.authorize
+---
+
+Use this action to start a charging process on a Keba charging station. The charging station must already be authorized.
+
+{% include actions/ui_header.md %}
+
+To start a charging process from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Keba Charging Station: Enable**.
+6. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+This action has no additional options in the UI.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `keba.enable`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: keba.enable
+{% endexample %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/keba.request_data.markdown
+++ b/source/_actions/keba.request_data.markdown
@@ -9,6 +9,10 @@ related_actions:
 
 Use this action to request new data from a Keba charging station. The charging station sends an update so the related entities reflect its latest state.
 
+{% caution %}
+Using this action changes the state of your charging station. Use it with care.
+{% endcaution %}
+
 {% include actions/ui_header.md %}
 
 To request new data from an automation or a script:

--- a/source/_actions/keba.request_data.markdown
+++ b/source/_actions/keba.request_data.markdown
@@ -1,0 +1,42 @@
+---
+title: "Request data"
+action: keba.request_data
+domain: keba
+description: "Requests new data from a Keba charging station."
+related_actions:
+  - keba.set_current
+---
+
+Use this action to request new data from a Keba charging station. The charging station sends an update so the related entities reflect its latest state.
+
+{% include actions/ui_header.md %}
+
+To request new data from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Keba Charging Station: Request data**.
+6. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+This action has no additional options in the UI.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `keba.request_data`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: keba.request_data
+{% endexample %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/keba.set_current.markdown
+++ b/source/_actions/keba.set_current.markdown
@@ -1,0 +1,86 @@
+---
+title: "Set current"
+action: keba.set_current
+domain: keba
+description: "Sets the maximum charging current on a Keba charging station."
+related_actions:
+  - keba.set_energy
+  - keba.set_failsafe
+---
+
+Use this action to set the maximum charging current of a Keba charging station, in amperes. This lets you limit how fast a connected car charges, for example to match the available solar power or to stay within the limits of your electrical installation.
+
+{% include actions/ui_header.md %}
+
+To set the maximum current from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Keba Charging Station: Set current**.
+6. Enter the **Current** in amperes.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Current:
+  description: The maximum charging current in amperes. Allowed values are between 6 A and 63 A. A value of 0 stops the running charging process.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `keba.set_current`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: keba.set_current
+  data:
+    current: 16
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+current:
+  description: >
+    The maximum charging current in amperes. Allowed values are between
+    6 A and 63 A. A value of 0 stops the running charging process.
+  required: true
+  type: float
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: limit charging current at night
+
+Lower the maximum charging current during off-peak hours so the car charges gently overnight.
+
+- **Trigger**: Time, 23:00
+- **Action**: Keba Charging Station: Set current
+
+{% details "YAML example for limiting the current at night" %}
+
+{% example %}
+automation: |
+  alias: "Limit charging current at night"
+  triggers:
+    - trigger: time
+      at: "23:00:00"
+  actions:
+    - action: keba.set_current
+      data:
+        current: 10
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/keba.set_current.markdown
+++ b/source/_actions/keba.set_current.markdown
@@ -10,6 +10,10 @@ related_actions:
 
 Use this action to set the maximum charging current of a Keba charging station, in amperes. This lets you limit how fast a connected car charges, for example to match the available solar power or to stay within the limits of your electrical installation.
 
+{% caution %}
+Using this action changes the state of your charging station. Use it with care.
+{% endcaution %}
+
 {% include actions/ui_header.md %}
 
 To set the maximum current from an automation or a script:

--- a/source/_actions/keba.set_energy.markdown
+++ b/source/_actions/keba.set_energy.markdown
@@ -1,0 +1,87 @@
+---
+title: "Set energy"
+action: keba.set_energy
+domain: keba
+description: "Sets the target energy for the current charging session on a Keba charging station."
+related_actions:
+  - keba.set_current
+---
+
+Use this action to set the target energy for the current charging session on a Keba charging station, in kilowatt-hours. Once the session reaches this amount, the charging station stops charging. This is useful when you want to add a fixed amount of energy to a car rather than charging it fully.
+
+{% include actions/ui_header.md %}
+
+To set the target energy from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Keba Charging Station: Set energy**.
+6. Enter the **Energy** in kilowatt-hours.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Energy:
+  description: The target energy for the current charging session in kilowatt-hours. Allowed values are between 0 kWh and 100 kWh. A value of 0 disables the energy limit.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `keba.set_energy`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: keba.set_energy
+  data:
+    energy: 10
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+energy:
+  description: >
+    The target energy for the current charging session in kilowatt-hours.
+    Allowed values are between 0 kWh and 100 kWh. A value of 0 disables the
+    energy limit.
+  required: true
+  type: float
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: add a fixed amount of energy when plugged in
+
+Top up the car with a set amount of energy whenever it is plugged in.
+
+- **Trigger**: State, the plug sensor changes to plugged in
+- **Action**: Keba Charging Station: Set energy
+
+{% details "YAML example for adding a fixed amount of energy" %}
+
+{% example %}
+automation: |
+  alias: "Add fixed energy when plugged in"
+  triggers:
+    - trigger: state
+      entity_id: binary_sensor.keba_charging_station_plug
+      to: "on"
+  actions:
+    - action: keba.set_energy
+      data:
+        energy: 15
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/keba.set_energy.markdown
+++ b/source/_actions/keba.set_energy.markdown
@@ -9,6 +9,10 @@ related_actions:
 
 Use this action to set the target energy for the current charging session on a Keba charging station, in kilowatt-hours. Once the session reaches this amount, the charging station stops charging. This is useful when you want to add a fixed amount of energy to a car rather than charging it fully.
 
+{% caution %}
+Using this action changes the state of your charging station. Use it with care.
+{% endcaution %}
+
 {% include actions/ui_header.md %}
 
 To set the target energy from an automation or a script:

--- a/source/_actions/keba.set_failsafe.markdown
+++ b/source/_actions/keba.set_failsafe.markdown
@@ -1,0 +1,85 @@
+---
+title: "Set failsafe"
+action: keba.set_failsafe
+domain: keba
+description: "Configures the failsafe mode of a Keba charging station."
+related_actions:
+  - keba.set_current
+---
+
+Use this action to configure the failsafe mode of a Keba charging station. Failsafe mode protects the charging process if Home Assistant stops sending updates. When enabled, the charging station falls back to a defined current after a timeout, so charging continues safely without supervision.
+
+If you enable failsafe mode, make sure to call [Set current](/actions/keba.set_current/) regularly within the configured timeout. Otherwise, the charging station applies the fallback current.
+
+{% include actions/ui_header.md %}
+
+To configure the failsafe mode from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Keba Charging Station: Set failsafe**.
+6. Enter the **Failsafe timeout**, **Failsafe fallback**, and **Failsafe persist** values.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Failsafe timeout:
+  description: The timeout in seconds after which the fallback current is applied if no new current is set. Allowed values are between 1 second and 3600 seconds. A value of 0 disables failsafe mode.
+  required: true
+Failsafe fallback:
+  description: The fallback current in amperes that is applied when the timeout is reached. Allowed values are between 6 A and 63 A. A value of 0 stops the running charging process.
+  required: true
+Failsafe persist:
+  description: Whether to save the failsafe configuration to the charging station. Use 0 to keep it until the next restart of the charging station, or 1 to store it permanently.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `keba.set_failsafe`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: keba.set_failsafe
+  data:
+    failsafe_timeout: 30
+    failsafe_fallback: 6
+    failsafe_persist: 0
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+failsafe_timeout:
+  description: >
+    The timeout in seconds after which the fallback current is applied if no
+    new current is set. Allowed values are between 1 second and 3600 seconds.
+    A value of 0 disables failsafe mode.
+  required: true
+  type: integer
+failsafe_fallback:
+  description: >
+    The fallback current in amperes that is applied when the timeout is
+    reached. Allowed values are between 6 A and 63 A. A value of 0 stops the
+    running charging process.
+  required: true
+  type: float
+failsafe_persist:
+  description: >
+    Whether to save the failsafe configuration to the charging station. Use 0
+    to keep it until the next restart of the charging station, or 1 to store
+    it permanently.
+  required: true
+  type: integer
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/keba.set_failsafe.markdown
+++ b/source/_actions/keba.set_failsafe.markdown
@@ -11,6 +11,10 @@ Use this action to configure the failsafe mode of a Keba charging station. Fails
 
 If you enable failsafe mode, make sure to call [Set current](/actions/keba.set_current/) regularly within the configured timeout. Otherwise, the charging station applies the fallback current.
 
+{% caution %}
+Using this action changes the state of your charging station. Use it with care.
+{% endcaution %}
+
 {% include actions/ui_header.md %}
 
 To configure the failsafe mode from an automation or a script:

--- a/source/_integrations/keba.markdown
+++ b/source/_integrations/keba.markdown
@@ -30,7 +30,7 @@ This {% term integration %} provides the following platforms:
 - Binary sensors: Online state, plug state, charging state and failsafe mode state.
 - Lock: Authorization (like with the RFID card).
 - Sensors: current set by the user, target energy set by the user, charging power, charged energy of the current session and total energy charged.
-- Actions: authorize, deauthorize, set energy target, set the maximum allowed current and manually update the states. More details can be found in the [actions](#actions) section.
+- Actions: authorize, deauthorize, set energy target, set the maximum allowed current and manually update the states. More details can be found in the [actions](#list-of-actions) section.
 - Notify: Show a text on chargers with a built-in LED display.
 
 ## Configuration
@@ -86,53 +86,11 @@ keba:
       default: 5
 {% endconfiguration %}
 
-## Actions
+{% include integrations/actions.md %}
 
-The Keba integration offers several actions. Using these actions will change the state of your charging station. So use these actions with care!
-
-### Authorizing and Deauthorizing `keba.authorize` and `keba.deauthorize`
-
-The charging station can be authorized and deauthorized using actions (`keba.authorize` and `keba.deauthorize`) or via the lock integration that is created automatically for the charging station. In both cases the RFID tag from the configuration is used.
-
-### Start and Stop `keba.start` and `keba.stop`
-
-The `keba.start` and `keba.stop` actions control the charging process if the car is already authorized. Technically it sends `ena 1` or `ena 0` commands to the charging station.
-
-### Set Target Energy `keba.set_energy`
-
-The action `keba.set_energy` sets the target energy for the current session to the given energy attribute in kWh. Payload example:
-
-```json
-{
-  "energy": 10.0
-}
-```
-
-### Maximum Current `keba.set_curr`
-
-The `keba.set_curr` action sets the maximum current to the given current attribute in Ampere. Payload example:
-
-```json
-{
-  "current": 16.0
-}
-```
-
-### Request New Data `keba.request_data`
-
-The `keba.request_data` action sends data update requests to the charging station.
-
-### Request New Data `keba.set_failsafe`
-
-The `keba.set_failsafe` action sets the failsafe mode of the charging station. Payload example:
-
-```json
-{
-  "failsafe_timeout": 30,
-  "failsafe_fallback": 6,
-  "failsafe_persist": 0
-}
-```
+{% caution %}
+Using these actions changes the state of your charging station. Use them with care.
+{% endcaution %}
 
 ## Notifications
 


### PR DESCRIPTION
## Proposed change

Migrate the inline actions documentation on the Keba Charging Station integration page to dedicated action pages under `source/_actions/`, and replace the inline section with `{% include integrations/actions.md %}`.

While migrating, I corrected the action names to match Home Assistant core: the page documented `keba.start`/`keba.stop` and `keba.set_curr`, but the integration registers these as `keba.enable`/`keba.disable` and `keba.set_current`.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

