### PR TITLE
Universal Powerline Bus (UPB): migrate actions to dedicated pages

### DIFF
--- a/source/_actions/upb.light_blink.markdown
+++ b/source/_actions/upb.light_blink.markdown
@@ -1,0 +1,65 @@
+---
+title: "Blink light"
+action: upb.light_blink
+domain: upb
+description: "Starts a UPB light blinking at a set rate."
+related_actions:
+  - upb.light_fade_start
+  - upb.light_fade_stop
+---
+
+Use this action to start a UPB light blinking. The blink rate sets how long the light stays on during each blink.
+
+{% include actions/ui_header.md %}
+
+To blink a light from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select your UPB light.
+6. From the actions shown for that target, select **Blink light**.
+7. Enter the blink rate, then select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Blink rate:
+  description: The time in seconds that the light stays on during each blink. Allowed values are between 0 and 4.25 seconds. The UPB system limits the blink rate to no faster than a third of a second.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `upb.light_blink`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: upb.light_blink
+  target:
+    entity_id: light.kitchen
+  data:
+    blink_rate: 1
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+blink_rate:
+  description: >
+    The time in seconds that the light stays on during each blink. Allowed
+    values are between 0 and 4.25 seconds. The UPB system limits the blink rate
+    to no faster than a third of a second.
+  required: false
+  type: float
+  default: 0.5
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="light" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/upb.light_fade_start.markdown
+++ b/source/_actions/upb.light_fade_start.markdown
@@ -1,0 +1,87 @@
+---
+title: "Start light fade"
+action: upb.light_fade_start
+domain: upb
+description: "Starts fading a UPB light up or down to a target brightness."
+related_actions:
+  - upb.light_fade_stop
+  - upb.light_blink
+---
+
+Use this action to start fading a UPB light up or down from its current brightness to a target level. Lights that are not dimmable ignore the fade.
+
+{% include actions/ui_header.md %}
+
+To start a light fade from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select your UPB light.
+6. From the actions shown for that target, select **Start light fade**.
+7. Enter the target brightness and the rate, then select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Brightness:
+  description: The target brightness, where 0 turns the light off, 1 is the minimum brightness, and 255 is the maximum brightness. Set either Brightness or Brightness percentage, but not both.
+  required: false
+Brightness percentage:
+  description: The target brightness as a percentage, where 0 turns the light off, 1 is the minimum brightness, and 100 is the maximum brightness. Set either Brightness or Brightness percentage, but not both.
+  required: false
+Rate:
+  description: The time in seconds for the light to transition to the new brightness. The UPB system rounds this to the nearest supported time. See [Rate transition time](/integrations/upb/#rate-transition-time) for how this value is interpreted. A value of -1 uses the device default rate.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `upb.light_fade_start`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: upb.light_fade_start
+  target:
+    entity_id: light.kitchen
+  data:
+    brightness_pct: 75
+    rate: 10
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+brightness:
+  description: >
+    The target brightness, where 0 turns the light off, 1 is the minimum
+    brightness, and 255 is the maximum brightness. Set either `brightness` or
+    `brightness_pct`, but not both.
+  required: false
+  type: integer
+brightness_pct:
+  description: >
+    The target brightness as a percentage, where 0 turns the light off, 1 is
+    the minimum brightness, and 100 is the maximum brightness. Set either
+    `brightness` or `brightness_pct`, but not both.
+  required: false
+  type: float
+rate:
+  description: >
+    The time in seconds for the light to transition to the new brightness. The
+    UPB system rounds this to the nearest supported time. See
+    [Rate transition time](/integrations/upb/#rate-transition-time) for how
+    this value is interpreted. A value of -1 uses the device default rate.
+  required: false
+  type: float
+  default: -1
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="light" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/upb.light_fade_stop.markdown
+++ b/source/_actions/upb.light_fade_stop.markdown
@@ -1,0 +1,46 @@
+---
+title: "Stop light fade"
+action: upb.light_fade_stop
+domain: upb
+description: "Stops a running fade or transition on a UPB light."
+related_actions:
+  - upb.light_fade_start
+  - upb.light_blink
+---
+
+Use this action to stop a UPB light while it transitions from one brightness to another. It stops either a fade or a transition started by turning the light on or off.
+
+{% include actions/ui_header.md %}
+
+To stop a light fade from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select your UPB light.
+6. From the actions shown for that target, select **Stop light fade**.
+7. Select **Save**.
+
+### Options in the UI
+
+This action has no additional options in the UI.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `upb.light_fade_stop`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: upb.light_fade_stop
+  target:
+    entity_id: light.kitchen
+{% endexample %}
+
+{% include actions/targets.md domain="light" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/upb.link_blink.markdown
+++ b/source/_actions/upb.link_blink.markdown
@@ -1,0 +1,65 @@
+---
+title: "Blink link"
+action: upb.link_blink
+domain: upb
+description: "Starts a UPB scene blinking at a set rate."
+related_actions:
+  - upb.link_deactivate
+  - upb.link_goto
+---
+
+Use this action to start a UPB scene blinking. The blink rate sets how long the lights stay on during each blink.
+
+{% include actions/ui_header.md %}
+
+To blink a scene from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select your UPB scene.
+6. From the actions shown for that target, select **Blink link**.
+7. Enter the blink rate, then select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Blink rate:
+  description: The time in seconds that the lights stay on during each blink. Allowed values are between 0 and 4.25 seconds. The UPB system limits the blink rate to no faster than a third of a second.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `upb.link_blink`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: upb.link_blink
+  target:
+    entity_id: scene.interior_lights
+  data:
+    blink_rate: 1
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+blink_rate:
+  description: >
+    The time in seconds that the lights stay on during each blink. Allowed
+    values are between 0 and 4.25 seconds. The UPB system limits the blink rate
+    to no faster than a third of a second.
+  required: false
+  type: float
+  default: 0.5
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="scene" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/upb.link_deactivate.markdown
+++ b/source/_actions/upb.link_deactivate.markdown
@@ -1,0 +1,48 @@
+---
+title: "Deactivate link"
+action: upb.link_deactivate
+domain: upb
+description: "Deactivates a UPB scene."
+related_actions:
+  - upb.link_goto
+  - upb.link_fade_start
+  - upb.link_fade_stop
+  - upb.link_blink
+---
+
+Use this action to deactivate a UPB scene. Deactivate is a general UPB term that usually means turning to the off state, but each device manufacturer can define it differently for their device.
+
+{% include actions/ui_header.md %}
+
+To deactivate a scene from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select your UPB scene.
+6. From the actions shown for that target, select **Deactivate link**.
+7. Select **Save**.
+
+### Options in the UI
+
+This action has no additional options in the UI.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `upb.link_deactivate`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: upb.link_deactivate
+  target:
+    entity_id: scene.interior_lights
+{% endexample %}
+
+{% include actions/targets.md domain="scene" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/upb.link_fade_start.markdown
+++ b/source/_actions/upb.link_fade_start.markdown
@@ -1,0 +1,88 @@
+---
+title: "Start link fade"
+action: upb.link_fade_start
+domain: upb
+description: "Starts fading a UPB scene up or down to a target brightness."
+related_actions:
+  - upb.link_fade_stop
+  - upb.link_goto
+  - upb.link_deactivate
+---
+
+Use this action to start fading a UPB scene up or down from its current brightness to a target level. Lights within the scene that are not dimmable ignore the fade.
+
+{% include actions/ui_header.md %}
+
+To start a scene fade from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select your UPB scene.
+6. From the actions shown for that target, select **Start link fade**.
+7. Enter the target brightness and the rate, then select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Brightness:
+  description: The target brightness, where 0 turns the scene off, 1 is the minimum brightness, and 255 is the maximum brightness. Set either Brightness or Brightness percentage, but not both.
+  required: false
+Brightness percentage:
+  description: The target brightness as a percentage, where 0 turns the scene off, 1 is the minimum brightness, and 100 is the maximum brightness. Set either Brightness or Brightness percentage, but not both.
+  required: false
+Rate:
+  description: The time in seconds for the scene to transition to the new brightness. The UPB system rounds this to the nearest supported time. See [Rate transition time](/integrations/upb/#rate-transition-time) for how this value is interpreted. A value of -1 uses the device default rate.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `upb.link_fade_start`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: upb.link_fade_start
+  target:
+    entity_id: scene.interior_lights
+  data:
+    brightness_pct: 75
+    rate: 10
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+brightness:
+  description: >
+    The target brightness, where 0 turns the scene off, 1 is the minimum
+    brightness, and 255 is the maximum brightness. Set either `brightness` or
+    `brightness_pct`, but not both.
+  required: false
+  type: integer
+brightness_pct:
+  description: >
+    The target brightness as a percentage, where 0 turns the scene off, 1 is
+    the minimum brightness, and 100 is the maximum brightness. Set either
+    `brightness` or `brightness_pct`, but not both.
+  required: false
+  type: float
+rate:
+  description: >
+    The time in seconds for the scene to transition to the new brightness. The
+    UPB system rounds this to the nearest supported time. See
+    [Rate transition time](/integrations/upb/#rate-transition-time) for how
+    this value is interpreted. A value of -1 uses the device default rate.
+  required: false
+  type: float
+  default: -1
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="scene" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/upb.link_fade_stop.markdown
+++ b/source/_actions/upb.link_fade_stop.markdown
@@ -1,0 +1,47 @@
+---
+title: "Stop link fade"
+action: upb.link_fade_stop
+domain: upb
+description: "Stops a running fade or transition on a UPB scene."
+related_actions:
+  - upb.link_fade_start
+  - upb.link_goto
+  - upb.link_deactivate
+---
+
+Use this action to stop a UPB scene while it transitions from one brightness to another. It stops either a fade or a transition.
+
+{% include actions/ui_header.md %}
+
+To stop a scene fade from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select your UPB scene.
+6. From the actions shown for that target, select **Stop link fade**.
+7. Select **Save**.
+
+### Options in the UI
+
+This action has no additional options in the UI.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `upb.link_fade_stop`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: upb.link_fade_stop
+  target:
+    entity_id: scene.interior_lights
+{% endexample %}
+
+{% include actions/targets.md domain="scene" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/upb.link_goto.markdown
+++ b/source/_actions/upb.link_goto.markdown
@@ -1,0 +1,88 @@
+---
+title: "Go to link"
+action: upb.link_goto
+domain: upb
+description: "Sets a UPB scene to a target brightness."
+related_actions:
+  - upb.link_fade_start
+  - upb.link_fade_stop
+  - upb.link_deactivate
+---
+
+Use this action to set a UPB scene to a target brightness. Lights within the scene that are not dimmable ignore the brightness.
+
+{% include actions/ui_header.md %}
+
+To set a scene to a target brightness from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select your UPB scene.
+6. From the actions shown for that target, select **Go to link**.
+7. Enter the target brightness and the rate, then select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Brightness:
+  description: The target brightness, where 0 turns the scene off, 1 is the minimum brightness, and 255 is the maximum brightness. Set either Brightness or Brightness percentage, but not both.
+  required: false
+Brightness percentage:
+  description: The target brightness as a percentage, where 0 turns the scene off, 1 is the minimum brightness, and 100 is the maximum brightness. Set either Brightness or Brightness percentage, but not both.
+  required: false
+Rate:
+  description: The time in seconds for the scene to transition to the new brightness. The UPB system rounds this to the nearest supported time. See [Rate transition time](/integrations/upb/#rate-transition-time) for how this value is interpreted. A value of -1 uses the device default rate.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `upb.link_goto`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: upb.link_goto
+  target:
+    entity_id: scene.interior_lights
+  data:
+    brightness_pct: 50
+    rate: 5
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+brightness:
+  description: >
+    The target brightness, where 0 turns the scene off, 1 is the minimum
+    brightness, and 255 is the maximum brightness. Set either `brightness` or
+    `brightness_pct`, but not both.
+  required: false
+  type: integer
+brightness_pct:
+  description: >
+    The target brightness as a percentage, where 0 turns the scene off, 1 is
+    the minimum brightness, and 100 is the maximum brightness. Set either
+    `brightness` or `brightness_pct`, but not both.
+  required: false
+  type: float
+rate:
+  description: >
+    The time in seconds for the scene to transition to the new brightness. The
+    UPB system rounds this to the nearest supported time. See
+    [Rate transition time](/integrations/upb/#rate-transition-time) for how
+    this value is interpreted. A value of -1 uses the device default rate.
+  required: false
+  type: float
+  default: -1
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="scene" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/upb.markdown
+++ b/source/_integrations/upb.markdown
@@ -58,118 +58,30 @@ The `event_data` contains the following:
 - `rate`: The rate for link to transition to the new level. `rate` is
   -1 for the default transition rate.
 
-## Actions
+{% include integrations/actions.md %}
 
-Besides the standard actions provided by the Home Assistant [Light](/integrations/light/) and [Scene](/integrations/scene) integrations, the following extra actions are provided by the UPB integration:
+Besides these actions, UPB lights and scenes also support the standard actions provided by the Home Assistant [Light](/integrations/light/) and [Scene](/integrations/scene/) integrations.
 
-- `upb.light_fade_start`
-- `upb.light_fade_stop`
-- `upb.light_blink`
-- `upb.scene_deactivate`
-- `upb.scene_goto`
-- `upb.scene_fade_start`
-- `upb.scene_fade_stop`
-- `upb.scene_blink`
+## Rate transition time
 
-### Rate transition time
+Both the standard actions and the UPB actions that take a `transition` or a `rate` for changing brightness levels use a time in seconds. The UPB system only offers a discrete set of transition times, so the requested time is rounded to the closest supported value, based on the list below. This rounding does not apply to blink rates, only to brightness transition times.
 
-Both standard and custom actions that take a `transition` or a `rate` for changing brightness levels take time in seconds. The UPB
-system only offers a discrete set of transition times. As such, the transition time requested is changed to the closest time based on
-the table below. Note that this table does not apply to blink rates, only to brightness transition times.
-
-| Request rate >= | Requested rate < | Rate Used |
-| --------------- | ---------------- | --------- |
-| 0 seconds       | 0.4 seconds      | 0 seconds
-| 0.4 seconds     | 1.2 seconds      | 0.8 seconds
-| 1.2 seconds     | 2.45 seconds     | 1.6 seconds
-| 2.45 seconds    | 4.15 seconds     | 3.3 seconds
-| 4.15 seconds    | 5.8 seconds      | 5.0 seconds
-| 5.8 seconds     | 8.3 seconds      | 6.6 seconds
-| 8.3 seconds     | 15 seconds       | 10 seconds
-| 15 seconds      | 25 seconds       | 20 seconds
-| 25 seconds      | 45 seconds       | 30 seconds
-| 45 seconds      | 90 seconds       | 60 seconds
-| 1.5 minute      | 3.5 minutes      | 2 minutes
-| 3.5 minutes     | 7.5 minutes      | 5 minutes
-| 7.5 minutes     | 12.5 minutes     | 10 minutes
-| 12.5 minutes    | 22.5 minutes     | 15 minutes
-| 22.5 minutes    | 45 minutes       | 30 minutes
-| 45 minutes      | ∞                | 1 hour
-
-### Action: Light fade start
-
-The `upb.light_fade_start` action starts a transition of a light to the specified level. Lights that are not dimmable ignore the fade start command.
-
-| Data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `entity_id` | yes | UPB light which to start fading operation.
-| `brightness` | no* | Integer between 0 and 255 for how bright the light should be, where 0 means the light is off, 1 is the minimum brightness and 255 is the maximum brightness. *Only one of `brightness` and `brightness_pct` may be used.
-| `brightness_pct`| no* | Number between 0 and 100 in percentage that specifies how bright the light should be, where 0 means the light is off, 1 is the minimum brightness and 100 is the maximum brightness. *Only one of `brightness` and `brightness_pct` may be used.
-| `rate` | yes | Number that represents the time (in seconds) the light should take to transition to the new state. See section on "Rate Transition Time" for how this time value is interpreted.
-
-### Action: Light fade stop
-
-The `upb.light_fade_stop` action stops a light when transitioning from one light level to another. Stops either a fade or a goto (goto occurs when using a `light.turn_on` or `light.turn_off`).
-
-| Data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `entity_id` | yes | UPB light which to stop fading operation.
-
-### Action: Light blink
-
-The `upb.light_blink` action starts a light blinking.
-
-| Data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `entity_id` | yes | UPB light which to blink.
-| `rate` | no | Number between 0 and 4.25 that represents the time (in seconds) the rate the light blinks. Note the UPB implementation limits the blink rate to no faster than 1/3 of a second.
-
-### Action: Scene deactivate
-
-The `upb.scene_deactivate` action deactivates a scene. The term "deactivate" is a general UPB term that usually means to turn to the OFF state, but each individual device manufacturer can define it differently for their device.
-
-| Data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `entity_id` | yes | UPB scene to deactivate.
-
-### Action: Scene goto
-
-The `upb.scene_goto` action starts a transition of a scene to the specified level.
-
-| Data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `entity_id` | yes | UPB scene to transition.
-| `brightness` | no* | Integer between 0 and 255 for how bright the scene should be, where 0 means the scene is off, 1 is the minimum brightness and 255 is the maximum brightness. *Only one of `brightness` and `brightness_pct` may be used.
-| `brightness_pct`| no* | Number between 0 and 100 in percentage that specifies how bright the scene should be, where 0 means the scene is off, 1 is the minimum brightness and 100 is the maximum brightness. *Only one of `brightness` and `brightness_pct` may be used.
-| `rate` | yes | Number that represents the time (in seconds) the light should take to transition to the new state. See section on "Rate Transition Time" for how this time value is interpreted.
-
-### Action: Scene fade start
-
-The `upb.scene_fade_start` action starts a transition of a scene to the specified level. Lights within the scene that are not dimmable ignore the fade start command.
-
-| Data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `entity_id` | yes | UPB scene to transition.
-| `brightness` | no* | Integer between 0 and 255 for how bright the scene should be, where 0 means the scene is off, 1 is the minimum brightness and 255 is the maximum brightness. *Only one of `brightness` and `brightness_pct` may be used.
-| `brightness_pct`| no* | Number between 0 and 100 in percentage that specifies how bright the scene should be, where 0 means the scene is off, 1 is the minimum brightness and 100 is the maximum brightness. *Only one of `brightness` and `brightness_pct` may be used.
-| `rate` | yes | Number that represents the time (in seconds) the light should take to transition to the new state. See section on "Rate Transition Time" for how this time value is interpreted.
-
-### Action: Scene fade stop
-
-The `upb.scene_fade_stop` action stops a scene when transitioning from one light level to another. Stops either a fade or a goto.
-
-| Data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `entity_id` | yes | UPB scene which to stop fading operation.
-
-### Action: Scene blink
-
-The `upb.scene_blink` action starts a scene blinking.
-
-| Data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `entity_id` | yes | UPB scene which to blink.
-| `rate` | no | Number between 0 and 4.25 that represents the time (in seconds) the rate the scene blinks. Note the UPB implementation limits the blink rate to no faster than 1/3 of a second.
+- Up to 0.4 seconds: 0 seconds
+- 0.4 up to 1.2 seconds: 0.8 seconds
+- 1.2 up to 2.45 seconds: 1.6 seconds
+- 2.45 up to 4.15 seconds: 3.3 seconds
+- 4.15 up to 5.8 seconds: 5 seconds
+- 5.8 up to 8.3 seconds: 6.6 seconds
+- 8.3 up to 15 seconds: 10 seconds
+- 15 up to 25 seconds: 20 seconds
+- 25 up to 45 seconds: 30 seconds
+- 45 up to 90 seconds: 60 seconds
+- 1.5 up to 3.5 minutes: 2 minutes
+- 3.5 up to 7.5 minutes: 5 minutes
+- 7.5 up to 12.5 minutes: 10 minutes
+- 12.5 up to 22.5 minutes: 15 minutes
+- 22.5 up to 45 minutes: 30 minutes
+- 45 minutes or more: 1 hour
 
 ## Examples
 
@@ -210,7 +122,7 @@ all_lights_off:
   alias: "All Lights Off"
   description: "Deactivate two UPB scenes named interior_lights and exterior_lights"
   sequence:
-    - action: upb.scene_deactivate
+    - action: upb.link_deactivate
       target:
         entity_id: 
           - scene.interior_lights


### PR DESCRIPTION
## Proposed change

Migrate the inline actions documentation on the Universal Powerline Bus (UPB) integration page to dedicated action pages under `source/_actions/`, and replace the inline section with `{% include integrations/actions.md %}`.

While migrating, I corrected the documentation against Home Assistant core. The five scene actions are registered as `upb.link_deactivate`, `upb.link_goto`, `upb.link_fade_start`, `upb.link_fade_stop`, and `upb.link_blink`, not `upb.scene_*`. The blink rate field is `blink_rate`, not `rate`. I also fixed the deactivate example, which used the wrong action name, and moved the rate transition reference into its own section as a list.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

