### PR TITLE
Philips Dynalite: migrate actions to dedicated pages

### DIFF
--- a/source/_actions/dynalite.request_area_preset.markdown
+++ b/source/_actions/dynalite.request_area_preset.markdown
@@ -1,0 +1,79 @@
+---
+title: "Request area preset"
+action: dynalite.request_area_preset
+domain: dynalite
+description: "Asks a Dynalite area to report its currently selected preset."
+related_actions:
+  - dynalite.request_channel_level
+---
+
+Use this action to send a command on the Dynalite network asking an area to report its currently selected preset. Normally, channel 1 is used, but some installations need a different channel for specific areas.
+
+{% note %}
+This action does not return the preset. It sends a network command asking the area to report its preset. When the area reports back, the system catches and handles that report.
+{% endnote %}
+
+{% include actions/ui_header.md %}
+
+To request an area preset from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Philips Dynalite: Request area preset**.
+6. Enter the **Area**, and optionally the **Host** and **Channel**.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Host:
+  description: The IP address of the gateway to send the command to. When left empty, the command is sent to all configured gateways.
+  required: false
+Area:
+  description: The Dynalite area to request the preset for.
+  required: true
+Channel:
+  description: The channel to request the preset from. When left empty, channel 1 is used.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `dynalite.request_area_preset`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: dynalite.request_area_preset
+  data:
+    area: 2
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+host:
+  description: >
+    The IP address of the gateway to send the command to. When left empty, the
+    command is sent to all configured gateways.
+  required: false
+  type: string
+area:
+  description: The Dynalite area to request the preset for.
+  required: true
+  type: integer
+channel:
+  description: >
+    The channel to request the preset from. When left empty, channel 1 is used.
+  required: false
+  type: integer
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/dynalite.request_area_preset.markdown
+++ b/source/_actions/dynalite.request_area_preset.markdown
@@ -25,7 +25,7 @@ To request an area preset from an automation or a script:
 6. Enter the **Area**, and optionally the **Host** and **Channel**.
 7. Select **Save**.
 
-This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+This action does not support targets. In the UI, you enter the Dynalite area number (and optionally a channel) instead of selecting an entity.
 
 ### Options in the UI
 

--- a/source/_actions/dynalite.request_channel_level.markdown
+++ b/source/_actions/dynalite.request_channel_level.markdown
@@ -25,7 +25,7 @@ To request a channel level from an automation or a script:
 6. Enter the **Area** and **Channel**, and optionally the **Host**.
 7. Select **Save**.
 
-This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+This action does not support targets. In the UI, you enter the Dynalite area and channel numbers instead of selecting an entity.
 
 ### Options in the UI
 

--- a/source/_actions/dynalite.request_channel_level.markdown
+++ b/source/_actions/dynalite.request_channel_level.markdown
@@ -1,0 +1,79 @@
+---
+title: "Request channel level"
+action: dynalite.request_channel_level
+domain: dynalite
+description: "Asks a Dynalite channel to report its current level."
+related_actions:
+  - dynalite.request_area_preset
+---
+
+Use this action to send a command on the Dynalite network asking a channel in an area to report its current level.
+
+{% note %}
+This action does not return the level. It sends a network command asking the channel to report its level. When the channel reports back, the system catches and handles that report.
+{% endnote %}
+
+{% include actions/ui_header.md %}
+
+To request a channel level from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Philips Dynalite: Request channel level**.
+6. Enter the **Area** and **Channel**, and optionally the **Host**.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Host:
+  description: The IP address of the gateway to send the command to. When left empty, the command is sent to all configured gateways.
+  required: false
+Area:
+  description: The Dynalite area that contains the channel.
+  required: true
+Channel:
+  description: The channel to request the level for.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `dynalite.request_channel_level`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: dynalite.request_channel_level
+  data:
+    area: 2
+    channel: 1
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+host:
+  description: >
+    The IP address of the gateway to send the command to. When left empty, the
+    command is sent to all configured gateways.
+  required: false
+  type: string
+area:
+  description: The Dynalite area that contains the channel.
+  required: true
+  type: integer
+channel:
+  description: The channel to request the level for.
+  required: true
+  type: integer
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/dynalite.markdown
+++ b/source/_integrations/dynalite.markdown
@@ -54,39 +54,7 @@ For example, you would go to your kitchen light and turn it on. Now you sign in 
 
 The initial process can be a bit time consuming and tedious, but it only has to be done once. Once you are done configuring, it is better to set `autodiscover` to `false`, since there are many "fake" channels and areas that the system uses for internal communication and you do not want to have visible.
 
-## Actions
-
-### Action: Request area preset
-
-The `dynalite.request_area_preset` action allows you to send a command on the Dynalite network asking an area to report its currently selected preset. Normally, channel 1 (default) is used, but in some implementation, specific areas will need other channels.
-
-{% note %}
-
-This does not return the area preset. It sends a network command asking the area to report its preset. Once it reports, that will be caught and handled by the system.
-
-{% endnote %}
-
-| Data attribute | Optional | Description                                                                               |
-| ---------------------- | -------- | ----------------------------------------------------------------------------------------- |
-| `host`                 | yes      | Which gateway to send the command to. If not specified, sends to all configured gateways. |
-| `area`                 | no       | Area for the requested channel.                                                           |
-| `channel`              | no       | Which channel to request.                                                                 |
-
-### Action: Request channel level
-
-The `dynalite.request_channel_level` action allows you to send a command on the Dynalite network asking a specific channel in an area to report its current level.
-
-{% note %}
-
-This does not return the channel level. It sends a network command asking the channel to report its level. Once it reports, that will be caught and handled by the system.
-
-{% endnote %}
-
-| Data attribute | Optional | Description                                                                               |
-| ---------------------- | -------- | ----------------------------------------------------------------------------------------- |
-| `host`                 | yes      | Which gateway to send the command to. If not specified, sends to all configured gateways. |
-| `area`                 | no       | Which area to request the preset for.                                                     |
-| `channel`              | yes      | Which channel to use. If not specified, uses the area configuration or system default.    |
+{% include integrations/actions.md %}
 
 ## Events
 


### PR DESCRIPTION
## Proposed change

Migrate the Philips Dynalite inline actions documentation to dedicated action pages under `source/_actions/` and replace the inline `## Actions` section with `{% include integrations/actions.md %}`.

While migrating, I corrected the documentation against Home Assistant core: the `channel` field is optional for `request_area_preset` (it defaults to channel 1) but required for `request_channel_level`. The previous tables had this reversed.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

