### PR TITLE
Renson: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/renson.set_breeze.markdown
+++ b/source/_actions/renson.set_breeze.markdown
@@ -77,6 +77,7 @@ activate:
   description: Whether to turn the Breeze function on or off.
   required: true
   type: boolean
+  default: false
 {% endoptions_yaml %}
 
 {% include actions/try_it.md %}

--- a/source/_actions/renson.set_breeze.markdown
+++ b/source/_actions/renson.set_breeze.markdown
@@ -1,0 +1,120 @@
+---
+title: "Set Breeze"
+action: renson.set_breeze
+domain: renson
+description: "Configures the Breeze function of the Renson ventilation unit."
+related_actions:
+  - renson.set_timer_level
+  - renson.set_pollution_settings
+---
+
+The **Set Breeze** action configures the Breeze function of your Renson ventilation unit. Breeze increases ventilation when the outdoor temperature rises above a set value, which helps cool your home naturally.
+
+You set the ventilation level to use, the temperature that activates Breeze, and whether the function is turned on.
+
+{% include actions/targets.md domain="fan" %}
+
+{% include actions/ui_header.md %}
+
+To configure Breeze from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Renson ventilation unit.
+6. From the actions shown for that target, select **Renson: Set Breeze**.
+7. Select the **Level** and **Temperature**, then turn **Activate** on or off.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Level:
+  description: "The ventilation level to use while Breeze is active. One of: Level 1, Level 2, Level 3, or Level 4."
+  required: true
+Temperature:
+  description: The outdoor temperature, in degrees Celsius, that activates Breeze, between 15 and 35.
+  required: true
+Activate:
+  description: Whether to turn the Breeze function on or off.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `renson.set_breeze`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: renson.set_breeze
+  target:
+    entity_id: fan.ventilation
+  data:
+    breeze_level: level3
+    temperature: 22
+    activate: true
+{% endexample %}
+
+This turns on Breeze at level 3 when the outdoor temperature rises above 22 °C.
+
+### Options in YAML
+
+{% options_yaml %}
+breeze_level:
+  description: >
+    The ventilation level to use while Breeze is active. One of `level1`,
+    `level2`, `level3`, or `level4`.
+  required: true
+  type: string
+temperature:
+  description: >
+    The outdoor temperature, in degrees Celsius, that activates Breeze,
+    between 15 and 35.
+  required: true
+  type: integer
+activate:
+  description: Whether to turn the Breeze function on or off.
+  required: true
+  type: boolean
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: Turn on Breeze in summer
+
+This automation enables the Breeze function at the start of summer so the unit ventilates more whenever it gets warm outside.
+
+- Trigger: an input boolean for summer mode turns on
+- Action: configure Breeze
+  - Target: the ventilation unit
+  - Level: `level3`
+  - Temperature: `24`
+  - Activate: on
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  alias: "Enable Breeze in summer"
+  triggers:
+    - trigger: state
+      entity_id: input_boolean.summer_mode
+      to: "on"
+  actions:
+    - action: renson.set_breeze
+      target:
+        entity_id: fan.ventilation
+      data:
+        breeze_level: level3
+        temperature: 24
+        activate: true
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/renson.set_breeze.markdown
+++ b/source/_actions/renson.set_breeze.markdown
@@ -88,12 +88,12 @@ activate:
 
 This automation enables the Breeze function at the start of summer so the unit ventilates more whenever it gets warm outside.
 
-- Trigger: an input boolean for summer mode turns on
-- Action: configure Breeze
-  - Target: the ventilation unit
-  - Level: `level3`
-  - Temperature: `24`
-  - Activate: on
+- **Trigger**: an input boolean for summer mode turns on
+- **Action**: Renson: Set Breeze
+  - **Target**: the ventilation unit
+  - **Level**: `level3`
+  - **Temperature**: `24`
+  - **Activate**: on
 
 {% details "Show example YAML" %}
 

--- a/source/_actions/renson.set_pollution_settings.markdown
+++ b/source/_actions/renson.set_pollution_settings.markdown
@@ -126,11 +126,11 @@ co2_hysteresis:
 
 This automation lowers the night pollution ventilation level every evening so the unit runs more quietly while you sleep.
 
-- Trigger: the time is 10:00 PM
-- Action: set the pollution settings
-  - Target: the ventilation unit
-  - Day pollution level: `level3`
-  - Night pollution level: `level1`
+- **Trigger**: the time is 10:00 PM
+- **Action**: Renson: Set pollution settings
+  - **Target**: the ventilation unit
+  - **Day pollution level**: `level3`
+  - **Night pollution level**: `level1`
 
 {% details "Show example YAML" %}
 

--- a/source/_actions/renson.set_pollution_settings.markdown
+++ b/source/_actions/renson.set_pollution_settings.markdown
@@ -1,0 +1,156 @@
+---
+title: "Set pollution settings"
+action: renson.set_pollution_settings
+domain: renson
+description: "Configures the pollution settings of the Renson ventilation unit."
+related_actions:
+  - renson.set_timer_level
+  - renson.set_breeze
+---
+
+The **Set pollution settings** action configures how your Renson ventilation unit responds to pollution. You set the ventilation levels used during the day and night, choose which sensors trigger extra ventilation, and tune the CO2 thresholds.
+
+This is useful when you want an automation to change how aggressively the unit ventilates, for example a quieter program at night.
+
+{% include actions/targets.md domain="fan" %}
+
+{% include actions/ui_header.md %}
+
+To configure the pollution settings from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Renson ventilation unit.
+6. From the actions shown for that target, select **Renson: Set pollution settings**.
+7. Set the **Day pollution level** and **Night pollution level**, then adjust the control and CO2 options as needed.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Day pollution level:
+  description: "The ventilation level used when pollution is detected during the day. One of: Level 1, Level 2, Level 3, or Level 4."
+  required: true
+Night pollution level:
+  description: "The ventilation level used when pollution is detected during the night. One of: Level 1, Level 2, Level 3, or Level 4."
+  required: true
+Enable humidity control:
+  description: Whether the unit increases ventilation when it detects high humidity.
+  required: false
+Enable air quality control:
+  description: Whether the unit increases ventilation when it detects poor air quality.
+  required: false
+Enable CO2 control:
+  description: Whether the unit increases ventilation when it detects high CO2 levels.
+  required: false
+CO2 threshold:
+  description: The CO2 level, in parts per million, above which the unit increases ventilation, between 400 and 2000.
+  required: false
+CO2 hysteresis:
+  description: How far the CO2 level, in parts per million, must drop below the threshold before ventilation returns to normal, between 50 and 400.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `renson.set_pollution_settings`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: renson.set_pollution_settings
+  target:
+    entity_id: fan.ventilation
+  data:
+    day_pollution_level: level3
+    night_pollution_level: level2
+{% endexample %}
+
+This sets the day ventilation level to level 3 and the night ventilation level to level 2.
+
+### Options in YAML
+
+{% options_yaml %}
+day_pollution_level:
+  description: >
+    The ventilation level used when pollution is detected during the day.
+    One of `level1`, `level2`, `level3`, or `level4`.
+  required: true
+  type: string
+night_pollution_level:
+  description: >
+    The ventilation level used when pollution is detected during the night.
+    One of `level1`, `level2`, `level3`, or `level4`.
+  required: true
+  type: string
+humidity_control:
+  description: >
+    Whether the unit increases ventilation when it detects high humidity.
+  required: false
+  type: boolean
+  default: true
+airquality_control:
+  description: >
+    Whether the unit increases ventilation when it detects poor air quality.
+  required: false
+  type: boolean
+  default: true
+co2_control:
+  description: >
+    Whether the unit increases ventilation when it detects high CO2 levels.
+  required: false
+  type: boolean
+  default: true
+co2_threshold:
+  description: >
+    The CO2 level, in parts per million, above which the unit increases
+    ventilation, between 400 and 2000.
+  required: false
+  type: integer
+  default: 600
+co2_hysteresis:
+  description: >
+    How far the CO2 level, in parts per million, must drop below the threshold
+    before ventilation returns to normal, between 50 and 400.
+  required: false
+  type: integer
+  default: 100
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: Use a quieter program at night
+
+This automation lowers the night pollution ventilation level every evening so the unit runs more quietly while you sleep.
+
+- Trigger: the time is 10:00 PM
+- Action: set the pollution settings
+  - Target: the ventilation unit
+  - Day pollution level: `level3`
+  - Night pollution level: `level1`
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  alias: "Quieter ventilation at night"
+  triggers:
+    - trigger: time
+      at: "22:00:00"
+  actions:
+    - action: renson.set_pollution_settings
+      target:
+        entity_id: fan.ventilation
+      data:
+        day_pollution_level: level3
+        night_pollution_level: level1
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/renson.set_timer_level.markdown
+++ b/source/_actions/renson.set_timer_level.markdown
@@ -1,0 +1,110 @@
+---
+title: "Set timer"
+action: renson.set_timer_level
+domain: renson
+description: "Runs the Renson ventilation unit at a chosen level for a set time."
+related_actions:
+  - renson.set_breeze
+  - renson.set_pollution_settings
+---
+
+The **Set timer** action runs your Renson ventilation unit at a chosen ventilation level for a set number of minutes. When the timer ends, the unit returns to its normal program.
+
+This is useful when you want an automation to boost ventilation for a while, for example after a shower or while cooking.
+
+{% include actions/targets.md domain="fan" %}
+
+{% include actions/ui_header.md %}
+
+To set a timer from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Renson ventilation unit.
+6. From the actions shown for that target, select **Renson: Set timer**.
+7. Select the **Level** and enter the **Time** in minutes.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Level:
+  description: "The ventilation level to run while the timer is active. One of: Level 1, Level 2, Level 3, Level 4, Holiday, or Breeze."
+  required: true
+Time:
+  description: The number of minutes to run at the chosen level, between 0 and 1440. Set to 0 to disable the timer.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `renson.set_timer_level`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: renson.set_timer_level
+  target:
+    entity_id: fan.ventilation
+  data:
+    timer_level: level3
+    minutes: 30
+{% endexample %}
+
+This runs the ventilation unit at level 3 for 30 minutes.
+
+### Options in YAML
+
+{% options_yaml %}
+timer_level:
+  description: >
+    The ventilation level to run while the timer is active. One of `level1`,
+    `level2`, `level3`, `level4`, `holiday`, or `breeze`.
+  required: true
+  type: string
+minutes:
+  description: >
+    The number of minutes to run at the chosen level, between 0 and 1440.
+    Set to 0 to disable the timer.
+  required: true
+  type: integer
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: Boost ventilation after a shower
+
+This automation runs your ventilation unit at its highest level for 30 minutes whenever the bathroom humidity rises above 70%.
+
+- Trigger: the bathroom humidity goes above 70%
+- Action: set a ventilation timer
+  - Target: the ventilation unit
+  - Level: `level4`
+  - Time: `30`
+
+{% details "Show example YAML" %}
+
+{% example %}
+automation: |
+  alias: "Boost ventilation after a shower"
+  triggers:
+    - trigger: numeric_state
+      entity_id: sensor.bathroom_humidity
+      above: 70
+  actions:
+    - action: renson.set_timer_level
+      target:
+        entity_id: fan.ventilation
+      data:
+        timer_level: level4
+        minutes: 30
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/renson.set_timer_level.markdown
+++ b/source/_actions/renson.set_timer_level.markdown
@@ -79,11 +79,11 @@ minutes:
 
 This automation runs your ventilation unit at its highest level for 30 minutes whenever the bathroom humidity rises above 70%.
 
-- Trigger: the bathroom humidity goes above 70%
-- Action: set a ventilation timer
-  - Target: the ventilation unit
-  - Level: `level4`
-  - Time: `30`
+- **Trigger**: the bathroom humidity goes above 70%
+- **Action**: Renson: Set timer
+  - **Target**: the ventilation unit
+  - **Level**: `level4`
+  - **Time**: `30`
 
 {% details "Show example YAML" %}
 

--- a/source/_integrations/renson.markdown
+++ b/source/_integrations/renson.markdown
@@ -29,37 +29,4 @@ The **Renson** {% term integration %} pulls in data from the Renson Endura delta
 
 {% include integrations/config_flow.md %}
 
-## Actions
-
-### Action: Set timer level
-
-The `renson.set_timer_level` action sets the ventilation timer.
-
-  | Data attribute | Required | Description | Example |
-  | ---------------------- | -------- | ----------- | ------- |
-  | `timer_level`| yes | Level setting | |
-  | `minutes` | yes | Time of the timer (0 will disable the timer) | |
-
-### Action: Set breeze
-
-The `renson.set_breeze` action sets the breeze function of the ventilation system.
-
-  | Data attribute | Required | Description | Example |
-  | ---------------------- | -------- | ----------- | ------- |
-  | `breeze_level`| no | Ventilation level when breeze function is activated | |
-  | `temperature` | no | Temperature when the breeze function should be activated in °C | |
-  | `activate` | yes | Activate or disable the breeze feature | `2020-05-01T17:45:00` |
-
-### Action: Set pollution settings
-
-The `renson.set_pollution_settings` action sets all the pollution settings of the ventilation system.
-
-  | Data attribute | Required | Description | Example |
-  | ---------------------- | -------- | ----------- | ------- |
-  | `day_pollution_level`| no | Ventilation level when pollution is detected in the day | |
-  | `night_pollution_level` | no | Ventilation level when pollution is detected in the night | |
-  | `humidity_control` | no | Activate or disable the humidity control | |
-  | `airquality_control` | no | Activate or disable the air quality control | |
-  | `co2_control` | no | Activate or disable the CO2 control | `2020-05-01T17:45:00` |
-  | `co2_threshold` | no | Sets the CO2 pollution threshold level in ppm | `2020-05-01T17:45:00` |
-  | `co2_hysteresis` | no | Sets the CO2 pollution threshold hysteresis level in ppm | `2020-05-01T17:45:00` |
+{% include integrations/actions.md %}


### PR DESCRIPTION
## Proposed change

Migrates the inline Renson action documentation into dedicated action pages under `source/_actions/` (`renson.set_timer_level`, `renson.set_breeze`, and `renson.set_pollution_settings`), and replaces the inline `## Actions` section on the integration page with `{% include integrations/actions.md %}`.

While migrating, I verified each field against the integration's voluptuous schema in core. The inline tables marked `breeze_level`, `temperature`, `day_pollution_level`, and `night_pollution_level` as optional, but the schema marks all of them as required, so the new pages document them correctly. Each page also documents the value ranges, units, and defaults, and includes a realistic automation example.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

