### PR TITLE
Weather: migrate get_forecasts to a dedicated action page

### DIFF
--- a/source/_actions/weather.get_forecasts.markdown
+++ b/source/_actions/weather.get_forecasts.markdown
@@ -26,9 +26,8 @@ To get weather forecasts from an automation or a script:
 
 {% options_ui %}
 Forecast type:
-  description: The scope of the forecast to retrieve. One of daily, hourly, or twice daily.
-  required: true
-{% endoptions_ui %}
+  description: The scope of the forecast to retrieve. One of daily, hourly, or twice daily. When not set, defaults to daily.
+  required: false
 
 {% include actions/yaml_header.md %}
 

--- a/source/_actions/weather.get_forecasts.markdown
+++ b/source/_actions/weather.get_forecasts.markdown
@@ -1,0 +1,123 @@
+---
+title: "Get weather forecasts"
+action: weather.get_forecasts
+domain: weather
+description: "Retrieves the forecasts from one or more weather entities."
+---
+
+Use this action to retrieve the forecast from one or more weather entities, for example to read out tomorrow's weather or to drive an automation based on the chance of rain.
+
+This action returns its result in a response variable, which you can use in later steps of the same automation or script.
+
+{% include actions/ui_header.md %}
+
+To get weather forecasts from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the weather entities you want to read.
+6. From the actions shown for that target, select **Get weather forecasts**.
+7. Select the **Forecast type** to retrieve.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Forecast type:
+  description: The scope of the forecast to retrieve. One of daily, hourly, or twice daily.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `weather.get_forecasts`. Store the result in a response variable so you can use it in later steps:
+
+{% example %}
+action: |
+  action: weather.get_forecasts
+  target:
+    entity_id:
+      - weather.home
+      - weather.toronto_forecast
+  data:
+    type: hourly
+  response_variable: weather_forecast
+{% endexample %}
+
+This returns the hourly forecast for both weather entities.
+
+### Options in YAML
+
+{% options_yaml %}
+type:
+  description: The scope of the forecast to retrieve. One of `daily`, `hourly`, or `twice_daily`.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/targets.md %}
+
+## Response data
+
+The response is keyed by each weather entity you targeted, with a `forecast` list. Each entry in the list describes the forecasted conditions at a given point in time and includes the following fields:
+
+- `datetime`: The time of the forecasted conditions.
+- `is_daytime`: Whether the forecast period is during the day. Only set for `twice_daily` forecasts.
+- `condition`: The weather condition.
+- `apparent_temperature`: The apparent (feels-like) temperature, in the unit indicated by the `temperature_unit` state attribute.
+- `temperature`: The temperature, in the unit indicated by the `temperature_unit` state attribute. When `templow` is also provided, this is the higher temperature.
+- `templow`: The lower temperature, in the unit indicated by the `temperature_unit` state attribute.
+- `dew_point`: The dew point temperature, in the unit indicated by the `temperature_unit` state attribute.
+- `humidity`: The relative humidity, in percent.
+- `cloud_coverage`: The cloud coverage, in percent.
+- `precipitation`: The precipitation amount, in the unit indicated by the `precipitation_unit` state attribute.
+- `precipitation_probability`: The probability of precipitation, in percent.
+- `pressure`: The air pressure, in the unit indicated by the `pressure_unit` state attribute.
+- `uv_index`: The UV index.
+- `wind_bearing`: The wind bearing, as an azimuth angle in degrees or a cardinal direction.
+- `wind_gust_speed`: The wind gust speed, in the unit indicated by the `wind_speed_unit` state attribute.
+- `wind_speed`: The wind speed, in the unit indicated by the `wind_speed_unit` state attribute.
+
+A shortened example of the response looks like this:
+
+```yaml
+weather.home:
+  forecast:
+    - datetime: "2023-12-07T13:00:00+00:00"
+      condition: cloudy
+      temperature: 0.1
+      dew_point: -1.9
+      humidity: 86
+      precipitation: 0
+      precipitation_probability: 0
+      wind_bearing: 241.19
+      wind_speed: 16.88
+    - datetime: "2023-12-07T14:00:00+00:00"
+      condition: cloudy
+      temperature: 0.8
+      dew_point: -2.8
+      humidity: 77
+      precipitation: 0
+      precipitation_probability: 0
+      wind_bearing: 232.41
+      wind_speed: 17.82
+weather.toronto_forecast:
+  forecast:
+    - datetime: "2023-12-07T14:00:00+00:00"
+      condition: snowy
+      temperature: 0
+      precipitation_probability: 40
+```
+
+## Good to know
+
+- A weather entity may not provide every field. Fields that aren't available are omitted from the forecast.
+- A weather entity only supports the forecast types it provides, such as daily, hourly, or twice daily. Make sure the entity supports the type you request.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/weather.get_forecasts.markdown
+++ b/source/_actions/weather.get_forecasts.markdown
@@ -17,10 +17,11 @@ To get weather forecasts from an automation or a script:
 2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
 3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
 4. In the **Then do** section, select **Add action**.
-5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the weather entities you want to read.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), pick the weather entity you want to read. You can also select an area, a device, or a label.
 6. From the actions shown for that target, select **Get weather forecasts**.
 7. Select the **Forecast type** to retrieve.
-8. Select **Save**.
+8. In the **Response variable** field, enter a name to store the forecast data in. Choose a short, descriptive name that reflects what it holds, such as `berlin_forecast`. You'll use this name to read the forecast in later steps.
+9. Select **Save**.
 
 ### Options in the UI
 

--- a/source/_actions/weather.get_forecasts.markdown
+++ b/source/_actions/weather.get_forecasts.markdown
@@ -28,6 +28,7 @@ To get weather forecasts from an automation or a script:
 Forecast type:
   description: The scope of the forecast to retrieve. One of daily, hourly, or twice daily. When not set, defaults to daily.
   required: false
+{% endoptions_ui %}
 
 {% include actions/yaml_header.md %}
 

--- a/source/_integrations/weather.markdown
+++ b/source/_integrations/weather.markdown
@@ -68,47 +68,7 @@ wind_speed: 35.17
 wind_speed_unit: km/h
 ```
 
-## Action `weather.get_forecasts`
-
-This action populates [response data](/docs/scripts/perform-actions#use-templates-to-handle-response-data)
-with a mapping of weather services and their associated forecasts.
-
-| Data attribute | Optional | Description                                                                                       | Example |
-| -------------- | -------- | ------------------------------------------------------------------------------------------------- | ------- |
-| `type`         | no       | The type of forecast, must be one of `daily`, `twice_daily`, or `hourly`. The default is `daily`. | daily   |
-
-```yaml
-action: weather.get_forecasts
-target:
-  entity_id:
-    - weather.tomorrow_io_home_nowcast
-    - weather.toronto_forecast
-data:
-  type: hourly
-response_variable: weather_forecast
-```
-
-The response data field is a mapping of called target entities, each containing the `forecast` field.
-`forecast` is a list of forecasted conditions at a given point in time:
-
-| Response data               | Description                                                                                                                                     | Example                   |
-| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------- |
-| `datetime`                  | The time of the forecasted conditions.                                                                                                          | 2023-02-17T14:00:00+00:00 |
-| `is_daytime`                | Only set for `twice_daily` forecasts.                                                                                                           | False                     |
-| `apparent_temperature`      | The apparent (feels-like) temperature in the unit indicated by the `temperature_unit` state attribute.                                          | 10.2                      |
-| `cloud_coverage`            | The cloud coverage in %.                                                                                                                        | 15                        |
-| `condition`                 | The weather condition.                                                                                                                          | Sunny                     |
-| `dew_point`                 | The dew point temperature in the unit indicated by the `temperature_unit` state attribute.                                                      | 6.0                       |
-| `humidity`                  | The relative humidity in %.                                                                                                                     | 82                        |
-| `precipitation_probability` | The probability of precipitation in %.                                                                                                          | 0                         |
-| `precipitation`             | The precipitation amount in the unit indicated by the `precipitation_unit` state attribute.                                                     | 0                         |
-| `pressure`                  | The air pressure in the unit indicated by the `pressure_unit` state attribute.                                                                  | 1019                      |
-| `temperature`               | The temperature in the unit indicated by the `temperature_unit` state attribute. If `templow` is also provided, this is the higher temperature. | 14.2                      |
-| `templow`                   | The lower temperature in the unit indicated by the `temperature_unit` state attribute.                                                          | 5.0                       |
-| `uv_index`                  | The UV index.                                                                                                                                   | 3                         |
-| `wind_bearing`              | The wind bearing in azimuth angle (degrees) or 1-3 letter cardinal direction.                                                                   | 268                       |
-| `wind_gust_speed`           | The wind gust speed in the unit indicated by the `wind_speed_unit` state attribute.                                                             | 34.41                     |
-| `wind_speed`                | The wind speed in the unit indicated by the `wind_speed_unit` state attribute.                                                                  | 24.41                     |
+{% include integrations/actions.md %}
 
 ## Examples
 


### PR DESCRIPTION
## Proposed change

Moves the inline `weather.get_forecasts` documentation off the Weather integration page into a dedicated action page under `source/_actions/`, and replaces the inline block with the standard `{% include integrations/actions.md %}`. This follows the action documentation structure and gives the action its own UI-first page with response data details.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
