### PR TITLE
Conversation: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/conversation.process.markdown
+++ b/source/_actions/conversation.process.markdown
@@ -1,0 +1,131 @@
+---
+title: "Process conversation"
+action: conversation.process
+domain: conversation
+description: "Sends text to a conversation agent for processing."
+related_actions:
+  - conversation.reload
+---
+
+The **Process conversation** action sends a line of text to a conversation agent, which interprets it and acts on it, just like a spoken or typed command to your assistant.
+
+This is useful when another part of your setup produces text that you want Home Assistant to act on. For example, you can forward a message received from a chat integration to your assistant, or drive an automation from a sentence you build with a template.
+
+{% include actions/ui_header.md %}
+
+To send text to a conversation agent from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Conversation: Process conversation**.
+6. Enter the **Text** to process. Optionally, choose an **Agent**, a **Language**, and a **Conversation ID**.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Text:
+  description: The text to send to the conversation agent.
+  required: true
+Agent:
+  description: The conversation agent to process your request. The conversation agent is the brains of your assistant. It processes the incoming text. When left empty, the default agent is used.
+  required: false
+Language:
+  description: The language of the text. When left empty, the server language is used.
+  required: false
+Conversation ID:
+  description: The ID of a new or previous conversation. Provide a previous ID to continue that conversation, or a new one to start a fresh conversation.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `conversation.process`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: conversation.process
+  data:
+    text: "Turn on the kitchen lights"
+{% endexample %}
+
+This sends the text to the default conversation agent, which acts on it.
+
+### Options in YAML
+
+{% options_yaml %}
+text:
+  description: >
+    The text to send to the conversation agent.
+  required: true
+  type: string
+agent_id:
+  description: >
+    The conversation agent to process your request. The conversation agent is
+    the brains of your assistant. It processes the incoming text. When left
+    empty, the default agent is used.
+  required: false
+  type: string
+language:
+  description: >
+    The language of the text. When left empty, the server language is used.
+  required: false
+  type: string
+conversation_id:
+  description: >
+    The ID of a new or previous conversation. Provide a previous ID to continue
+    that conversation, or a new one to start a fresh conversation.
+  required: false
+  type: string
+{% endoptions_yaml %}
+
+## Response data
+
+When you store the result in a response variable, this action returns the conversation agent's response, including the spoken reply and the result of the intent. The response has the same structure as the [`/api/conversation/process` API](https://developers.home-assistant.io/docs/intent_conversation_api#conversation-response).
+
+You can read the spoken reply from the response, for example to send it on as a notification:
+
+{% example %}
+action: |
+  action: conversation.process
+  data:
+    text: "What time is it?"
+  response_variable: agent_response
+{% endexample %}
+
+The reply text is then available as `{{ agent_response.response.speech.plain.speech }}`.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: speak a chat message through your assistant
+
+When a message arrives from a chat integration, forward its text to the conversation agent so your assistant acts on it.
+
+- **Trigger**: A chat integration receives a new message
+- **Action**: Conversation: Process conversation, using the message text
+
+{% details "YAML example for processing a received message" %}
+
+{% example %}
+automation: |
+  alias: "Process received chat message"
+  triggers:
+    - trigger: event
+      event_type: chat_message_received
+  actions:
+    - action: conversation.process
+      data:
+        text: "{{ trigger.event.data.message }}"
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/conversation.process.markdown
+++ b/source/_actions/conversation.process.markdown
@@ -87,34 +87,25 @@ conversation_id:
 
 When you store the result in a response variable, this action returns the conversation agent's response, including the spoken reply and the result of the intent. The response has the same structure as the [`/api/conversation/process` API](https://developers.home-assistant.io/docs/intent_conversation_api#conversation-response).
 
-You can read the spoken reply from the response, for example to send it on as a notification:
-
-{% example %}
-action: |
-  action: conversation.process
-  data:
-    text: "What time is it?"
-  response_variable: agent_response
-{% endexample %}
-
-The reply text is then available as `{{ agent_response.response.speech.plain.speech }}`.
+The reply text is then available as `{{ agent_response.response.speech.plain.speech }}`. The automation below shows how to capture this reply and send it back to a chat.
 
 {% include actions/try_it.md %}
 
 {% include actions/more_examples.md %}
 
-### Automation: speak a chat message through your assistant
+### Automation: reply to a chat message with your assistant
 
-When a message arrives from a chat integration, forward its text to the conversation agent so your assistant acts on it.
+When a message arrives from a chat integration, forward its text to the conversation agent, then send the agent's spoken reply back to the chat. This processes the message and uses the response in a single automation.
 
 - **Trigger**: A chat integration receives a new message
-- **Action**: Conversation: Process conversation, using the message text
+- **Action**: Conversation: Process conversation, using the message text, and store the result in a response variable
+- **Action**: Send the agent's reply back to the chat
 
-{% details "YAML example for processing a received message" %}
+{% details "YAML example for replying to a received message" %}
 
 {% example %}
 automation: |
-  alias: "Process received chat message"
+  alias: "Reply to received chat message"
   triggers:
     - trigger: event
       event_type: chat_message_received
@@ -122,6 +113,12 @@ automation: |
     - action: conversation.process
       data:
         text: "{{ trigger.event.data.message }}"
+      response_variable: agent_response
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_chat
+      data:
+        message: "{{ agent_response.response.speech.plain.speech }}"
 {% endexample %}
 
 {% enddetails %}

--- a/source/_actions/conversation.reload.markdown
+++ b/source/_actions/conversation.reload.markdown
@@ -7,9 +7,9 @@ related_actions:
   - conversation.process
 ---
 
-The **Reload conversation agents** action reloads the intent configuration of your conversation agents and clears their cached intents.
+The **Reload conversation agents** action reloads the intent configuration of the default conversation agent and clears its cached intents.
 
-This is useful while you are working on custom sentences or intents. After you change your configuration, reload the conversation agents to apply your changes without restarting Home Assistant.
+This is useful while you are working on custom sentences or intents. After you change your configuration, reload the conversation agent to apply your changes without restarting Home Assistant.
 
 {% include actions/ui_header.md %}
 
@@ -20,7 +20,7 @@ To reload conversation agents from an automation or a script:
 3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
 4. In the **Then do** section, select **Add action**.
 5. From the search box, search for and select **Conversation: Reload conversation agents**.
-6. Optionally, choose an **Agent** and a **Language** to limit what gets reloaded.
+6. Optionally, choose a **Language** to limit what gets reloaded.
 7. Select **Save**.
 
 This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
@@ -29,7 +29,7 @@ This action does not support targets. In the UI, you are not prompted to choose 
 
 {% options_ui %}
 Agent:
-  description: The conversation agent to reload. When left empty, all agents are reloaded.
+  description: This action reloads the default conversation agent, regardless of which agent you select.
   required: false
 Language:
   description: The language to clear cached intents for. When left empty, all languages are cleared.
@@ -45,14 +45,14 @@ action: |
   action: conversation.reload
 {% endexample %}
 
-This reloads all conversation agents and clears their cached intents.
+This reloads the default conversation agent and clears its cached intents.
 
 ### Options in YAML
 
 {% options_yaml %}
 agent_id:
   description: >
-    The conversation agent to reload. When left empty, all agents are reloaded.
+    This action reloads the default conversation agent, regardless of which agent you set here.
   required: false
   type: string
 language:

--- a/source/_actions/conversation.reload.markdown
+++ b/source/_actions/conversation.reload.markdown
@@ -1,0 +1,90 @@
+---
+title: "Reload conversation agents"
+action: conversation.reload
+domain: conversation
+description: "Reloads the intent configuration of conversation agents."
+related_actions:
+  - conversation.process
+---
+
+The **Reload conversation agents** action reloads the intent configuration of your conversation agents and clears their cached intents.
+
+This is useful while you are working on custom sentences or intents. After you change your configuration, reload the conversation agents to apply your changes without restarting Home Assistant.
+
+{% include actions/ui_header.md %}
+
+To reload conversation agents from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Conversation: Reload conversation agents**.
+6. Optionally, choose an **Agent** and a **Language** to limit what gets reloaded.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Agent:
+  description: The conversation agent to reload. When left empty, all agents are reloaded.
+  required: false
+Language:
+  description: The language to clear cached intents for. When left empty, all languages are cleared.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `conversation.reload`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: conversation.reload
+{% endexample %}
+
+This reloads all conversation agents and clears their cached intents.
+
+### Options in YAML
+
+{% options_yaml %}
+agent_id:
+  description: >
+    The conversation agent to reload. When left empty, all agents are reloaded.
+  required: false
+  type: string
+language:
+  description: >
+    The language to clear cached intents for. When left empty, all languages
+    are cleared.
+  required: false
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Script: apply new custom sentences
+
+While iterating on custom sentences, run a script that reloads the conversation agents so your changes take effect right away.
+
+- **Action**: Conversation: Reload conversation agents
+
+{% details "YAML example for reloading after editing sentences" %}
+
+{% example %}
+script: |
+  reload_conversation_agents:
+    alias: "Reload conversation agents"
+    sequence:
+      - action: conversation.reload
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/conversation.markdown
+++ b/source/_integrations/conversation.markdown
@@ -145,24 +145,4 @@ intents:
 
 It's now possible to say "engage all lights in the bedroom", which will turn on every light in the area named "bedroom".
 
-
-## Action `conversation.process`
-
-Send a message to a conversation agent for processing.
-
-| Data attribute | Optional | Description                                                                                                               |
-| ---------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------- |
-| `text`                 | no       | Transcribed text input                                                                                                    |
-| `language`             | yes      | Language of the text                                                                                                      |
-| `agent_id`             | yes      | ID of conversation agent. The conversation agent is the brains of the assistant. It processes the incoming text commands. |
-| `conversation_id`      | yes      | ID of a new or previous conversation. Will continue an old conversation or start a new one.                               |
-
-This action can return [response data](/docs/scripts/perform-actions/#use-templates-to-handle-response-data). The response is the same response as for the
-[`/api/conversation/process` API](https://developers.home-assistant.io/docs/intent_conversation_api#conversation-response).
-
-## Action `conversation.reload`
-
-| Data attribute | Optional | Description                                                              |
-| ---------------------- | -------- | ------------------------------------------------------------------------ |
-| `language`             | yes      | Language to clear intent cache for. No value clears all languages        |
-| `agent_id`             | yes      | ID of conversation agent. Defaults to the built-in Home Assistant agent. |
+{% include integrations/actions.md %}


### PR DESCRIPTION
## Proposed change

Moves the inline `conversation.process` and `conversation.reload` documentation off the Conversation integration page into dedicated action pages under `source/_actions/`, and replaces the inline blocks with the standard `{% include integrations/actions.md %}`. This follows the action documentation structure and gives each action its own UI-first page, including the response data details for `conversation.process`.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
