### PR TITLE
Python Scripts: migrate reload to a dedicated action page

### DIFF
--- a/source/_actions/python_script.reload.markdown
+++ b/source/_actions/python_script.reload.markdown
@@ -1,8 +1,8 @@
 ---
-title: "Reload"
+title: "Reload Python scripts"
 action: python_script.reload
 domain: python_script
-description: "Reloads the available Python scripts from the configuration folder."
+description: "Reloads the available Python scripts from the `<config>/python_scripts` folder."
 ---
 
 The **Reload** action reloads all Python scripts from the `<config>/python_scripts` folder. It is a quicker alternative to restarting Home Assistant.
@@ -20,7 +20,11 @@ To reload your Python scripts from an automation or a script:
 5. From the search box, search for and select **Python Scripts: Reload**.
 6. Select **Save**.
 
-This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label. It has no additional options.
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+This action has no additional options in the UI.
 
 {% include actions/yaml_header.md %}
 
@@ -32,6 +36,10 @@ action: |
 {% endexample %}
 
 This reloads all Python scripts from the `<config>/python_scripts` folder.
+
+### Options in YAML
+
+This action has no options.
 
 {% include actions/try_it.md %}
 

--- a/source/_actions/python_script.reload.markdown
+++ b/source/_actions/python_script.reload.markdown
@@ -1,0 +1,60 @@
+---
+title: "Reload"
+action: python_script.reload
+domain: python_script
+description: "Reloads the available Python scripts from the configuration folder."
+---
+
+The **Reload** action reloads all Python scripts from the `<config>/python_scripts` folder. It is a quicker alternative to restarting Home Assistant.
+
+Use this after you add a new Python script, or after you update the `<config>/python_scripts/services.yaml` file. You don't need to reload when you change an existing Python script, because the latest version runs each time the script is called.
+
+{% include actions/ui_header.md %}
+
+To reload your Python scripts from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Python Scripts: Reload**.
+6. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label. It has no additional options.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `python_script.reload`. It takes no options:
+
+{% example %}
+action: |
+  action: python_script.reload
+{% endexample %}
+
+This reloads all Python scripts from the `<config>/python_scripts` folder.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Script: reload Python scripts on demand
+
+While working on your Python scripts, run a script that reloads them so a newly added script or an updated `services.yaml` file becomes available right away.
+
+- **Action**: Python Scripts: Reload
+
+{% details "YAML example for reloading Python scripts" %}
+
+{% example %}
+script: |
+  reload_python_scripts:
+    alias: "Reload Python scripts"
+    sequence:
+      - action: python_script.reload
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/python_script.markdown
+++ b/source/_integrations/python_script.markdown
@@ -177,16 +177,4 @@ turn_on_light:
 
 For more examples, visit the [Scripts section](https://community.home-assistant.io/c/26) in our forum.
 
-## Actions
-
-Available actions: `reload`.
-
-### Action: Reload
-
-The `python_script.reload` action reloads all available python_scripts from the `<config>/python_scripts` folder, as a quicker alternative to restarting Home Assistant.
-
-Use this when creating a new Python script, or after updating the `<config>/python_scripts/services.yaml` file. 
-
-You don't have to call this service when you change an existing Python script.
-
-This service takes no data attributes.
+{% include integrations/actions.md %}


### PR DESCRIPTION
## Proposed change

Moves the inline `python_script.reload` documentation off the Python Scripts integration page into a dedicated action page under `source/_actions/`, and replaces the inline block with the standard `{% include integrations/actions.md %}`. This follows the action documentation structure and gives the action its own UI-first page.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
