### PR TITLE
Minio: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/minio.get.markdown
+++ b/source/_actions/minio.get.markdown
@@ -1,5 +1,5 @@
 ---
-title: "Get"
+title: "Get file"
 action: minio.get
 domain: minio
 description: "Downloads a file from a MinIO bucket to the local file system."
@@ -13,6 +13,10 @@ The **Get** action downloads an object from a MinIO bucket and saves it to a fil
 This is useful when another part of your setup needs a file that is stored in MinIO, for example to retrieve a camera snapshot or a backup that was uploaded earlier.
 
 {% include actions/ui_header.md %}
+
+### Prerequisites
+
+- The file path must be added to [`allowlist_external_dirs`](/integrations/homeassistant/#allowlist_external_dirs) in {% term "`configuration.yaml`" %}.
 
 To download a file from an automation or a script:
 

--- a/source/_actions/minio.get.markdown
+++ b/source/_actions/minio.get.markdown
@@ -1,0 +1,109 @@
+---
+title: "Get"
+action: minio.get
+domain: minio
+description: "Downloads a file from a MinIO bucket to the local file system."
+related_actions:
+  - minio.put
+  - minio.remove
+---
+
+The **Get** action downloads an object from a MinIO bucket and saves it to a file on the local file system.
+
+This is useful when another part of your setup needs a file that is stored in MinIO, for example to retrieve a camera snapshot or a backup that was uploaded earlier.
+
+{% include actions/ui_header.md %}
+
+To download a file from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Minio: Get**.
+6. Enter the **Bucket**, the **Key** of the object, and the **File path** to save it to.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Bucket:
+  description: The name of the bucket to download from.
+  required: true
+Key:
+  description: The object key of the file in the bucket.
+  required: true
+File path:
+  description: The path on the local file system to save the file to.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `minio.get`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: minio.get
+  data:
+    bucket: "camera-files"
+    key: "front_camera/snapshot.jpg"
+    file_path: "/data/camera_files/snapshot.jpg"
+{% endexample %}
+
+This downloads the object to the given path on the local file system.
+
+### Options in YAML
+
+{% options_yaml %}
+bucket:
+  description: >
+    The name of the bucket to download from.
+  required: true
+  type: string
+key:
+  description: >
+    The object key of the file in the bucket.
+  required: true
+  type: string
+file_path:
+  description: >
+    The path on the local file system to save the file to.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: download a file when it is added to a bucket
+
+When MinIO reports that an object was created, download it to the local file system.
+
+- **Trigger**: A MinIO bucket event for a created object
+- **Action**: Minio: Get
+
+{% details "YAML example for downloading a newly added object" %}
+
+{% example %}
+automation: |
+  alias: "Download new MinIO object"
+  triggers:
+    - trigger: event
+      event_type: minio
+  actions:
+    - action: minio.get
+      data:
+        bucket: "{{ trigger.event.data.bucket }}"
+        key: "{{ trigger.event.data.key }}"
+        file_path: "/tmp/{{ trigger.event.data.key | basename }}"
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/minio.put.markdown
+++ b/source/_actions/minio.put.markdown
@@ -1,0 +1,115 @@
+---
+title: "Put"
+action: minio.put
+domain: minio
+description: "Uploads a file from the local file system to a MinIO bucket."
+related_actions:
+  - minio.get
+  - minio.remove
+---
+
+The **Put** action uploads a file from the local file system to a MinIO bucket.
+
+This is useful when you want to store a file in MinIO, for example to keep a camera snapshot or a generated report in object storage.
+
+{% include actions/ui_header.md %}
+
+To upload a file from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Minio: Put**.
+6. Enter the **Bucket**, the **Key** to store the object under, and the **File path** of the local file.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Bucket:
+  description: The name of the bucket to upload to.
+  required: true
+Key:
+  description: The object key to store the file under in the bucket.
+  required: true
+File path:
+  description: The path of the file on the local file system to upload.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `minio.put`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: minio.put
+  data:
+    bucket: "camera-files"
+    key: "front_camera/snapshot.jpg"
+    file_path: "/data/camera_files/snapshot.jpg"
+{% endexample %}
+
+This uploads the local file to the bucket under the given key.
+
+### Options in YAML
+
+{% options_yaml %}
+bucket:
+  description: >
+    The name of the bucket to upload to.
+  required: true
+  type: string
+key:
+  description: >
+    The object key to store the file under in the bucket.
+  required: true
+  type: string
+file_path:
+  description: >
+    The path of the file on the local file system to upload.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: upload a camera snapshot to MinIO
+
+When motion is detected, take a snapshot and upload it to a MinIO bucket for storage.
+
+- **Trigger**: A motion sensor turns on
+- **Action**: Camera: Take snapshot, followed by Minio: Put
+
+{% details "YAML example for uploading a snapshot" %}
+
+{% example %}
+automation: |
+  alias: "Store snapshot in MinIO"
+  triggers:
+    - trigger: state
+      entity_id: binary_sensor.front_door_motion
+      to: "on"
+  actions:
+    - action: camera.snapshot
+      target:
+        entity_id: camera.front_door
+      data:
+        filename: "/data/camera_files/snapshot.jpg"
+    - action: minio.put
+      data:
+        bucket: "camera-files"
+        key: "front_door/snapshot.jpg"
+        file_path: "/data/camera_files/snapshot.jpg"
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/minio.put.markdown
+++ b/source/_actions/minio.put.markdown
@@ -1,5 +1,5 @@
 ---
-title: "Put"
+title: "Put file"
 action: minio.put
 domain: minio
 description: "Uploads a file from the local file system to a MinIO bucket."
@@ -13,6 +13,10 @@ The **Put** action uploads a file from the local file system to a MinIO bucket.
 This is useful when you want to store a file in MinIO, for example to keep a camera snapshot or a generated report in object storage.
 
 {% include actions/ui_header.md %}
+
+### Prerequisites
+
+- The file path must be added to [`allowlist_external_dirs`](/integrations/homeassistant/#allowlist_external_dirs) in {% term "`configuration.yaml`" %}.
 
 To upload a file from an automation or a script:
 

--- a/source/_actions/minio.remove.markdown
+++ b/source/_actions/minio.remove.markdown
@@ -1,5 +1,5 @@
 ---
-title: "Remove"
+title: "Remove file"
 action: minio.remove
 domain: minio
 description: "Deletes a file from a MinIO bucket."
@@ -10,7 +10,7 @@ related_actions:
 
 The **Remove** action deletes an object from a MinIO bucket.
 
-This is useful for cleaning up files you no longer need, for example removing an old snapshot after you have processed it.
+This is useful for cleaning up files you no longer need, for example, removing an old snapshot after you have processed it.
 
 {% include actions/ui_header.md %}
 

--- a/source/_actions/minio.remove.markdown
+++ b/source/_actions/minio.remove.markdown
@@ -1,0 +1,99 @@
+---
+title: "Remove"
+action: minio.remove
+domain: minio
+description: "Deletes a file from a MinIO bucket."
+related_actions:
+  - minio.get
+  - minio.put
+---
+
+The **Remove** action deletes an object from a MinIO bucket.
+
+This is useful for cleaning up files you no longer need, for example removing an old snapshot after you have processed it.
+
+{% include actions/ui_header.md %}
+
+To delete a file from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Minio: Remove**.
+6. Enter the **Bucket** and the **Key** of the object to delete.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Bucket:
+  description: The name of the bucket to delete from.
+  required: true
+Key:
+  description: The object key of the file to delete.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `minio.remove`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: minio.remove
+  data:
+    bucket: "camera-files"
+    key: "front_camera/snapshot.jpg"
+{% endexample %}
+
+This deletes the object with the given key from the bucket.
+
+### Options in YAML
+
+{% options_yaml %}
+bucket:
+  description: >
+    The name of the bucket to delete from.
+  required: true
+  type: string
+key:
+  description: >
+    The object key of the file to delete.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: remove a snapshot after a week
+
+Once a day, delete last week's snapshot from the bucket to keep storage tidy.
+
+- **Trigger**: A daily time trigger
+- **Action**: Minio: Remove
+
+{% details "YAML example for removing an old snapshot" %}
+
+{% example %}
+automation: |
+  alias: "Clean up old MinIO snapshot"
+  triggers:
+    - trigger: time
+      at: "03:00:00"
+  actions:
+    - action: minio.remove
+      data:
+        bucket: "camera-files"
+        key: "front_door/snapshot.jpg"
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/minio.markdown
+++ b/source/_integrations/minio.markdown
@@ -118,39 +118,4 @@ automation:
         file_path: "/tmp/{{ trigger.event.data.file_name }}"
 ```
 
-## Actions
-
-These actions are provided:
-
-- `get`
-- `put`
-- `remove`
-
-### Action: Get
-
-The `minio.get` action downloads a file from Minio storage.
-
-| Data attribute | Required | Description                        |
-| ---------------------- | -------- | ---------------------------------- |
-| `bucket`               | yes      | Bucket to use                      |
-| `key`                  | yes      | Object key of the file             |
-| `file_path`            | yes      | File path on the local file system |
-
-### Action: Put
-
-The `minio.put` action uploads a file to Minio storage.
-
-| Data attribute | Required | Description                        |
-| ---------------------- | -------- | ---------------------------------- |
-| `bucket`               | yes      | Bucket to use                      |
-| `key`                  | yes      | Object key of the file             |
-| `file_path`            | yes      | File path on the local file system |
-
-### Action: Remove
-
-The `minio.remove` action deletes a file from Minio storage.
-
-| Data attribute | Required | Description            |
-| ---------------------- | -------- | ---------------------- |
-| `bucket`               | yes      | Bucket to use          |
-| `key`                  | yes      | Object key of the file |
+{% include integrations/actions.md %}


### PR DESCRIPTION
## Proposed change

Migrates the Minio integration's action documentation into dedicated action pages under `source/_actions/` (`minio.get`, `minio.put`, and `minio.remove`), and replaces the inline action block on the integration page with `{% include integrations/actions.md %}`.

This is part of the ongoing effort to move inline action documentation to dedicated, consistently structured action pages.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

