### PR TITLE
Apple iCloud: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/icloud.display_message.markdown
+++ b/source/_actions/icloud.display_message.markdown
@@ -1,0 +1,122 @@
+---
+title: "Display message"
+action: icloud.display_message
+domain: icloud
+description: "Displays a message on an Apple device."
+related_actions:
+  - icloud.play_sound
+  - icloud.lost_device
+  - icloud.update
+---
+
+The **Display message** action shows a message on one of your Apple devices. It can also play a sound at the same time.
+
+This is useful for getting a note to a device, for example to leave instructions on a lost device or to alert whoever has it.
+
+{% include actions/ui_header.md %}
+
+To display a message from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Apple iCloud: Display message**.
+6. Enter the **Account**, the **Device name**, and the **Message** to show. Optionally, enable **Sound**.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Account:
+  description: The Apple Account username (email) the device belongs to.
+  required: true
+Device name:
+  description: The name of the Apple device to show the message on, as it appears in Find My.
+  required: true
+Message:
+  description: The content of the message to display.
+  required: true
+Sound:
+  description: Play a sound when the message is displayed.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `icloud.display_message`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: icloud.display_message
+  data:
+    account: "steve@apple.com"
+    device_name: "Bob's iPhone"
+    message: "Time to head home!"
+    sound: true
+{% endexample %}
+
+This shows the message on the device and plays a sound.
+
+### Options in YAML
+
+{% options_yaml %}
+account:
+  description: >
+    The Apple Account username (email) the device belongs to.
+  required: true
+  type: string
+device_name:
+  description: >
+    The name of the Apple device to show the message on, as it appears in
+    Find My.
+  required: true
+  type: string
+message:
+  description: >
+    The content of the message to display.
+  required: true
+  type: string
+sound:
+  description: >
+    Play a sound when the message is displayed.
+  required: false
+  type: boolean
+  default: false
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: remind a family member to come home for dinner
+
+When dinner time arrives, show a message on a family member's phone.
+
+- **Trigger**: A daily time trigger
+- **Action**: Apple iCloud: Display message
+
+{% details "YAML example for showing a dinner reminder" %}
+
+{% example %}
+automation: |
+  alias: "Dinner reminder"
+  triggers:
+    - trigger: time
+      at: "18:00:00"
+  actions:
+    - action: icloud.display_message
+      data:
+        account: "steve@apple.com"
+        device_name: "Bob's iPhone"
+        message: "Dinner is ready!"
+        sound: true
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/icloud.lost_device.markdown
+++ b/source/_actions/icloud.lost_device.markdown
@@ -37,7 +37,7 @@ Device name:
   description: The name of the Apple device to set to lost, as it appears in Find My.
   required: true
 Number:
-  description: The phone number to call from the lost device. Include the country code.
+  description: The phone number to call from the lost device. Include the country code. For example, +33450020100.
   required: true
 Message:
   description: The message to display on the lost device.
@@ -75,7 +75,7 @@ device_name:
   type: string
 number:
   description: >
-    The phone number to call from the lost device. Include the country code.
+    The phone number to call from the lost device. Include the country code. For example, +33450020100.
   required: true
   type: string
 message:

--- a/source/_actions/icloud.lost_device.markdown
+++ b/source/_actions/icloud.lost_device.markdown
@@ -1,0 +1,123 @@
+---
+title: "Lost device"
+action: icloud.lost_device
+domain: icloud
+description: "Puts an Apple device into Lost Mode."
+related_actions:
+  - icloud.play_sound
+  - icloud.display_message
+  - icloud.update
+---
+
+The **Lost device** action puts a compatible Apple device into Lost Mode. The device shows a message and a phone number so that whoever finds it can reach you.
+
+This is useful when a device goes missing and you want to lock it and display a way to contact you.
+
+{% include actions/ui_header.md %}
+
+To put a device into Lost Mode from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Apple iCloud: Lost device**.
+6. Enter the **Account**, the **Device name**, the **Number** to call, and the **Message** to display.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Account:
+  description: The Apple Account username (email) the device belongs to.
+  required: true
+Device name:
+  description: The name of the Apple device to set to lost, as it appears in Find My.
+  required: true
+Number:
+  description: The phone number to call from the lost device. Include the country code.
+  required: true
+Message:
+  description: The message to display on the lost device.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `icloud.lost_device`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: icloud.lost_device
+  data:
+    account: "steve@apple.com"
+    device_name: "Bob's iPhone"
+    number: "+33450020100"
+    message: "Please call me to return this phone."
+{% endexample %}
+
+This puts the device into Lost Mode with the given message and phone number.
+
+### Options in YAML
+
+{% options_yaml %}
+account:
+  description: >
+    The Apple Account username (email) the device belongs to.
+  required: true
+  type: string
+device_name:
+  description: >
+    The name of the Apple device to set to lost, as it appears in Find My.
+  required: true
+  type: string
+number:
+  description: >
+    The phone number to call from the lost device. Include the country code.
+  required: true
+  type: string
+message:
+  description: >
+    The message to display on the lost device.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: set a tablet to lost when it leaves home
+
+When a device has not been home for a while, put it into Lost Mode with your contact details.
+
+- **Trigger**: A device stays away from home for an hour
+- **Action**: Apple iCloud: Lost device
+
+{% details "YAML example for setting a device to lost" %}
+
+{% example %}
+automation: |
+  alias: "Mark tablet as lost"
+  triggers:
+    - trigger: state
+      entity_id: device_tracker.family_ipad
+      to: "not_home"
+      for:
+        hours: 1
+  actions:
+    - action: icloud.lost_device
+      data:
+        account: "steve@apple.com"
+        device_name: "Family iPad"
+        number: "+33450020100"
+        message: "Please call me to return this iPad."
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/icloud.play_sound.markdown
+++ b/source/_actions/icloud.play_sound.markdown
@@ -1,0 +1,100 @@
+---
+title: "Play sound"
+action: icloud.play_sound
+domain: icloud
+description: "Plays the Lost device sound on an Apple device."
+related_actions:
+  - icloud.display_message
+  - icloud.lost_device
+  - icloud.update
+---
+
+The **Play sound** action plays the Lost device sound on one of your Apple devices.
+
+This is useful for finding a misplaced device. The device rings even when it is set to **Mute** or **Do not disturb**.
+
+{% include actions/ui_header.md %}
+
+To play the sound from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Apple iCloud: Play sound**.
+6. Enter the **Account** and the **Device name** of the device to ring.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Account:
+  description: The Apple Account username (email) the device belongs to.
+  required: true
+Device name:
+  description: The name of the Apple device to ring, as it appears in Find My.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `icloud.play_sound`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: icloud.play_sound
+  data:
+    account: "steve@apple.com"
+    device_name: "Bob's iPhone"
+{% endexample %}
+
+This rings the given device.
+
+### Options in YAML
+
+{% options_yaml %}
+account:
+  description: >
+    The Apple Account username (email) the device belongs to.
+  required: true
+  type: string
+device_name:
+  description: >
+    The name of the Apple device to ring, as it appears in Find My.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: ring your phone when you press a button
+
+Use a button helper to ring your phone whenever you misplace it around the house.
+
+- **Trigger**: A button helper is pressed
+- **Action**: Apple iCloud: Play sound
+
+{% details "YAML example for ringing a phone from a button" %}
+
+{% example %}
+automation: |
+  alias: "Find my phone"
+  triggers:
+    - trigger: state
+      entity_id: input_button.find_my_phone
+  actions:
+    - action: icloud.play_sound
+      data:
+        account: "steve@apple.com"
+        device_name: "Bob's iPhone"
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/icloud.update.markdown
+++ b/source/_actions/icloud.update.markdown
@@ -1,0 +1,92 @@
+---
+title: "Update"
+action: icloud.update
+domain: icloud
+description: "Requests a location and state update for the devices on an Apple Account."
+related_actions:
+  - icloud.play_sound
+  - icloud.display_message
+  - icloud.lost_device
+---
+
+The **Update** action requests a fresh location and state update for the devices linked to an Apple Account.
+
+To save battery, Home Assistant polls your devices on a dynamic interval. This action is useful when you need an up to date location right away, for example to check whether anyone is home when a door opens.
+
+{% include actions/ui_header.md %}
+
+To request an update from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Apple iCloud: Update**.
+6. Optionally, enter the **Account** to update. Leave it empty to update every configured Apple Account.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Account:
+  description: The Apple Account username (email) to update. Leave empty to update every configured account.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `icloud.update`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: icloud.update
+  data:
+    account: "steve@apple.com"
+{% endexample %}
+
+This requests an update for all devices on the given account.
+
+### Options in YAML
+
+{% options_yaml %}
+account:
+  description: >
+    The Apple Account username (email) to update. Leave empty to update every
+    configured account.
+  required: false
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: check presence when the front door opens
+
+When the front door opens, request a location update so the presence detection reflects the latest position.
+
+- **Trigger**: The front door opens
+- **Action**: Apple iCloud: Update
+
+{% details "YAML example for requesting an update on door open" %}
+
+{% example %}
+automation: |
+  alias: "Update iCloud location on door open"
+  triggers:
+    - trigger: state
+      entity_id: binary_sensor.front_door
+      to: "on"
+  actions:
+    - action: icloud.update
+      data:
+        account: "steve@apple.com"
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/icloud.update.markdown
+++ b/source/_actions/icloud.update.markdown
@@ -11,7 +11,7 @@ related_actions:
 
 The **Update** action requests a fresh location and state update for the devices linked to an Apple Account.
 
-To save battery, Home Assistant polls your devices on a dynamic interval. This action is useful when you need an up to date location right away, for example to check whether anyone is home when a door opens.
+To save battery, Home Assistant polls your devices on a dynamic interval. This action is useful when you need an up-to-date location right away, for example to check whether anyone is home when a door opens.
 
 {% include actions/ui_header.md %}
 

--- a/source/_integrations/icloud.markdown
+++ b/source/_integrations/icloud.markdown
@@ -56,27 +56,4 @@ The iCloud integration will track available devices on your iCloud account.
 
 The iCloud integration will add a battery sensor for each iCloud devices available on your iCloud account.
 
-## Actions
-
-4 actions are available:
-
-### Action: Update
-
-The `icloud.update` action requests an update of a certain iDevice or all devices linked to an iCloud account. The request will result in a new Home Assistant [state_changed](/docs/configuration/events/#event-state_changed) event describing the current iPhone location. It can be used in automations when a manual location update is needed, for example, to check if anyone is home when a door has been opened.
-
-### Action: Play sound
-
-The `icloud.play_sound` action plays the Lost iPhone sound on your iDevice. It will still ring if you are on "Mute" or "Do not disturb" mode.
-
-| Data attribute    | Optional | Description                                             |
-|---------------------------|----------|---------------------------------------------------------|
-| `account`                 |       no | Email address of the iCloud account                    |
-| `device_name`             |       no | Human Friendly device name like Bob's iPhone            |
-
-### Action: Display message
-
-The `icloud.display_message` action displays a message on your iDevice. It can also ring your device.
-
-### Action: Lost device
-
-The `icloud.lost_device` action puts your iDevice on "lost" mode (compatible devices only). You have to provide a phone number with a suffixed [country code](https://en.wikipedia.org/wiki/List_of_country_calling_codes) and a message.
+{% include integrations/actions.md %}


### PR DESCRIPTION
## Proposed change

Migrates the Apple iCloud integration's action documentation into dedicated action pages under `source/_actions/` (`icloud.update`, `icloud.play_sound`, `icloud.display_message`, and `icloud.lost_device`), and replaces the inline action block on the integration page with `{% include integrations/actions.md %}`.

This is part of the ongoing effort to move inline action documentation to dedicated, consistently structured action pages.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

