### PR TITLE
Bang & Olufsen: migrate Beolink actions to dedicated action pages

### DIFF
--- a/source/_actions/bang_olufsen.beolink_allstandby.markdown
+++ b/source/_actions/bang_olufsen.beolink_allstandby.markdown
@@ -21,7 +21,7 @@ To set all Beolink devices to standby from an automation or a script:
 2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
 3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
 4. In the **Then do** section, select **Add action**.
-5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Bang & Olufsen device you want to control.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Bang & Olufsen device you want to control. You can also select an area, a device, or a label.
 6. From the actions shown for that target, select **Beolink all standby**.
 7. Select **Save**.
 

--- a/source/_actions/bang_olufsen.beolink_allstandby.markdown
+++ b/source/_actions/bang_olufsen.beolink_allstandby.markdown
@@ -1,0 +1,49 @@
+---
+title: "Beolink all standby"
+action: bang_olufsen.beolink_allstandby
+domain: bang_olufsen
+description: "Sets all connected Beolink devices to standby."
+related_actions:
+  - bang_olufsen.beolink_leave
+  - bang_olufsen.beolink_join
+  - bang_olufsen.beolink_expand
+---
+
+The **Beolink all standby** action sets all devices connected to the [Beolink](https://support.bang-olufsen.com/hc/en-us/articles/4411572883089-What-is-Beolink-Multiroom) experience to standby.
+
+This is useful for turning off a whole multiroom group at once, for example when you leave the house.
+
+{% include actions/ui_header.md %}
+
+To set all Beolink devices to standby from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Bang & Olufsen device you want to control.
+6. From the actions shown for that target, select **Beolink all standby**.
+7. Select **Save**.
+
+This action has no additional options in the UI.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `bang_olufsen.beolink_allstandby`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: bang_olufsen.beolink_allstandby
+  target:
+    entity_id: media_player.beosound_balance_12345678
+{% endexample %}
+
+This action has no additional options.
+
+{% include actions/targets.md domain="media_player" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/bang_olufsen.beolink_expand.markdown
+++ b/source/_actions/bang_olufsen.beolink_expand.markdown
@@ -21,7 +21,7 @@ To expand a Beolink experience from an automation or a script:
 2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
 3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
 4. In the **Then do** section, select **Add action**.
-5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Bang & Olufsen device you want to control.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Bang & Olufsen device you want to control. You can also select an area, a device, or a label.
 6. From the actions shown for that target, select **Beolink expand**.
 7. Enable **All discovered**, or enter the **Beolink JIDs** to add. Set only one of the two.
 8. Select **Save**.

--- a/source/_actions/bang_olufsen.beolink_expand.markdown
+++ b/source/_actions/bang_olufsen.beolink_expand.markdown
@@ -1,0 +1,100 @@
+---
+title: "Beolink expand"
+action: bang_olufsen.beolink_expand
+domain: bang_olufsen
+description: "Adds devices to the current Beolink experience."
+related_actions:
+  - bang_olufsen.beolink_unexpand
+  - bang_olufsen.beolink_join
+  - bang_olufsen.beolink_leave
+---
+
+The **Beolink expand** action adds one or more devices to the [Beolink](https://support.bang-olufsen.com/hc/en-us/articles/4411572883089-What-is-Beolink-Multiroom) experience that the target device is hosting.
+
+This is useful for extending the audio that is already playing on a device to other rooms.
+
+{% include actions/ui_header.md %}
+
+To expand a Beolink experience from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Bang & Olufsen device you want to control.
+6. From the actions shown for that target, select **Beolink expand**.
+7. Enable **All discovered**, or enter the **Beolink JIDs** to add. Set only one of the two.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+All discovered:
+  description: Expand the experience to all devices discovered by the target device.
+  required: false
+Beolink JIDs:
+  description: The Beolink JIDs of the devices to add to the experience.
+  required: false
+{% endoptions_ui %}
+
+Set either **All discovered** or **Beolink JIDs**, not both.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `bang_olufsen.beolink_expand`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: bang_olufsen.beolink_expand
+  target:
+    entity_id: media_player.beosound_balance_12345678
+  data:
+    all_discovered: true
+{% endexample %}
+
+This expands the experience to every device the target device has discovered.
+
+### Options in YAML
+
+{% options_yaml %}
+all_discovered:
+  description: >
+    Expand the experience to all devices discovered by the target device. Set
+    either this or beolink_jids, not both.
+  required: false
+  type: boolean
+  default: false
+beolink_jids:
+  description: >
+    The Beolink JIDs of the devices to add to the experience. Set either this
+    or all_discovered, not both.
+  required: false
+  type: list
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="media_player" %}
+
+## Good to know
+
+- Calling the `media_player.join` action with the entity IDs of other Bang & Olufsen media players in `group_members` has the same effect.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Expand to specific devices
+
+{% example %}
+action: |
+  action: bang_olufsen.beolink_expand
+  target:
+    entity_id: media_player.beosound_balance_12345678
+  data:
+    beolink_jids:
+      - 1111.2222222.33333333@products.bang-olufsen.com
+      - 4444.5555555.66666666@products.bang-olufsen.com
+{% endexample %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/bang_olufsen.beolink_join.markdown
+++ b/source/_actions/bang_olufsen.beolink_join.markdown
@@ -1,0 +1,111 @@
+---
+title: "Beolink join"
+action: bang_olufsen.beolink_join
+domain: bang_olufsen
+description: "Joins a Beolink experience."
+related_actions:
+  - bang_olufsen.beolink_expand
+  - bang_olufsen.beolink_leave
+  - bang_olufsen.beolink_allstandby
+---
+
+The **Beolink join** action makes a Bang & Olufsen device join an active [Beolink](https://support.bang-olufsen.com/hc/en-us/articles/4411572883089-What-is-Beolink-Multiroom) multiroom experience.
+
+This is useful for grouping a device with others that are already playing, so the same audio plays in another room.
+
+{% include actions/ui_header.md %}
+
+To join a Beolink experience from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Bang & Olufsen device you want to control.
+6. From the actions shown for that target, select **Beolink join**.
+7. Optionally, set the **Beolink JID** and **Source** to join a specific experience or source.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Beolink JID:
+  description: The Beolink JID of the experience to join. Leave empty to join the closest active experience.
+  required: false
+Source:
+  description: The source to join. Behavior varies between hardware platforms. A Beolink JID is required when you set a source.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `bang_olufsen.beolink_join`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: bang_olufsen.beolink_join
+  target:
+    entity_id: media_player.beosound_balance_12345678
+{% endexample %}
+
+Without any data, this joins the closest active Beolink experience. Calling it repeatedly cycles through the available devices.
+
+### Options in YAML
+
+{% options_yaml %}
+beolink_jid:
+  description: >
+    The Beolink JID of the experience to join. Leave empty to join the closest
+    active experience.
+  required: false
+  type: string
+source_id:
+  description: >
+    The source to join. Behavior varies between hardware platforms. A Beolink
+    JID is required when you set a source. One of: beoradio, deezer, spotify,
+    tidal, radio, tp1, tp2, cd, aux_a, or ph.
+  required: false
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="media_player" %}
+
+## Good to know
+
+- Calling this action with an empty list of `group_members` on the `media_player.join` action has the same effect.
+- The available sources depend on the hardware platform of the device you join:
+  - ASE: `beoradio`
+  - ASE and Mozart: `deezer`, `spotify`
+  - Mozart: `tidal`
+  - Beolink Converter NL/ML: `radio`, `tp1`, `tp2`, `cd`, `aux_a`, `ph`
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Join a specific Beolink experience
+
+{% example %}
+action: |
+  action: bang_olufsen.beolink_join
+  target:
+    entity_id: media_player.beosound_balance_12345678
+  data:
+    beolink_jid: 1111.2222222.33333333@products.bang-olufsen.com
+{% endexample %}
+
+### Join the radio source on a Beolink Converter NL/ML
+
+{% example %}
+action: |
+  action: bang_olufsen.beolink_join
+  target:
+    entity_id: media_player.beosound_balance_12345678
+  data:
+    beolink_jid: 1111.2222222.33333333@products.bang-olufsen.com
+    source_id: radio
+{% endexample %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/bang_olufsen.beolink_join.markdown
+++ b/source/_actions/bang_olufsen.beolink_join.markdown
@@ -21,7 +21,7 @@ To join a Beolink experience from an automation or a script:
 2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
 3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
 4. In the **Then do** section, select **Add action**.
-5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Bang & Olufsen device you want to control.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Bang & Olufsen device you want to control. You can also select an area, a device, or a label.
 6. From the actions shown for that target, select **Beolink join**.
 7. Optionally, set the **Beolink JID** and **Source** to join a specific experience or source.
 8. Select **Save**.

--- a/source/_actions/bang_olufsen.beolink_leave.markdown
+++ b/source/_actions/bang_olufsen.beolink_leave.markdown
@@ -1,0 +1,53 @@
+---
+title: "Beolink leave"
+action: bang_olufsen.beolink_leave
+domain: bang_olufsen
+description: "Leaves a Beolink experience."
+related_actions:
+  - bang_olufsen.beolink_join
+  - bang_olufsen.beolink_allstandby
+  - bang_olufsen.beolink_unexpand
+---
+
+The **Beolink leave** action makes the target Bang & Olufsen device leave the [Beolink](https://support.bang-olufsen.com/hc/en-us/articles/4411572883089-What-is-Beolink-Multiroom) experience it is part of.
+
+This is useful for taking a single device out of a multiroom group.
+
+{% include actions/ui_header.md %}
+
+To leave a Beolink experience from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Bang & Olufsen device you want to control.
+6. From the actions shown for that target, select **Beolink leave**.
+7. Select **Save**.
+
+This action has no additional options in the UI.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `bang_olufsen.beolink_leave`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: bang_olufsen.beolink_leave
+  target:
+    entity_id: media_player.beosound_balance_12345678
+{% endexample %}
+
+This action has no additional options.
+
+{% include actions/targets.md domain="media_player" %}
+
+## Good to know
+
+- Calling the `media_player.unjoin` action on the device has the same effect.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/bang_olufsen.beolink_leave.markdown
+++ b/source/_actions/bang_olufsen.beolink_leave.markdown
@@ -21,7 +21,7 @@ To leave a Beolink experience from an automation or a script:
 2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
 3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
 4. In the **Then do** section, select **Add action**.
-5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Bang & Olufsen device you want to control.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Bang & Olufsen device you want to control. You can also select an area, a device, or a label.
 6. From the actions shown for that target, select **Beolink leave**.
 7. Select **Save**.
 

--- a/source/_actions/bang_olufsen.beolink_unexpand.markdown
+++ b/source/_actions/bang_olufsen.beolink_unexpand.markdown
@@ -1,0 +1,84 @@
+---
+title: "Beolink unexpand"
+action: bang_olufsen.beolink_unexpand
+domain: bang_olufsen
+description: "Removes devices from the current Beolink experience."
+related_actions:
+  - bang_olufsen.beolink_expand
+  - bang_olufsen.beolink_leave
+  - bang_olufsen.beolink_join
+---
+
+The **Beolink unexpand** action removes one or more devices from the [Beolink](https://support.bang-olufsen.com/hc/en-us/articles/4411572883089-What-is-Beolink-Multiroom) experience that the target device is hosting.
+
+This is useful for dropping a specific room from a multiroom group while keeping the rest playing.
+
+{% include actions/ui_header.md %}
+
+To remove devices from a Beolink experience from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Bang & Olufsen device you want to control.
+6. From the actions shown for that target, select **Beolink unexpand**.
+7. Enter the **Beolink JIDs** to remove.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Beolink JIDs:
+  description: The Beolink JIDs of the devices to remove from the experience.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `bang_olufsen.beolink_unexpand`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: bang_olufsen.beolink_unexpand
+  target:
+    entity_id: media_player.beosound_balance_12345678
+  data:
+    beolink_jids:
+      - 1111.2222222.33333333@products.bang-olufsen.com
+{% endexample %}
+
+This removes the given device from the experience.
+
+### Options in YAML
+
+{% options_yaml %}
+beolink_jids:
+  description: >
+    The Beolink JIDs of the devices to remove from the experience.
+  required: true
+  type: list
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="media_player" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Remove multiple devices
+
+{% example %}
+action: |
+  action: bang_olufsen.beolink_unexpand
+  target:
+    entity_id: media_player.beosound_balance_12345678
+  data:
+    beolink_jids:
+      - 1111.2222222.33333333@products.bang-olufsen.com
+      - 4444.5555555.66666666@products.bang-olufsen.com
+{% endexample %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/bang_olufsen.beolink_unexpand.markdown
+++ b/source/_actions/bang_olufsen.beolink_unexpand.markdown
@@ -21,7 +21,7 @@ To remove devices from a Beolink experience from an automation or a script:
 2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
 3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
 4. In the **Then do** section, select **Add action**.
-5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Bang & Olufsen device you want to control.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Bang & Olufsen device you want to control. You can also select an area, a device, or a label.
 6. From the actions shown for that target, select **Beolink unexpand**.
 7. Enter the **Beolink JIDs** to remove.
 8. Select **Save**.

--- a/source/_integrations/bang_olufsen.markdown
+++ b/source/_integrations/bang_olufsen.markdown
@@ -189,6 +189,8 @@ Several remote controls can be paired to the same Mozart device and are still cr
 
 This has the benefit of being able to trigger automations mapped to remote A with remote B, but also means that each Mozart device _only_ supports the 90 Event entities that a single remote provides.
 
+{% include integrations/actions.md %}
+
 ## Playing media
 
 The Bang & Olufsen integration supports different playback types in the `media_player.play_media` action: playback from URL, activating a favorite, playback from a local file, playing a radio station, activating a Deezer flow and Deezer playlists, albums, tracks, and playing files and text-to-speech (TTS) as an overlay.
@@ -389,7 +391,6 @@ data:
 
 Attempting to run an invalid Beolink action results in either a Home Assistant error or an audible error indication from your device.
 
-{% include integrations/actions.md %}
 
 ## Automations
 

--- a/source/_integrations/bang_olufsen.markdown
+++ b/source/_integrations/bang_olufsen.markdown
@@ -66,11 +66,11 @@ Several features are available through the media player entity:
 
 - See current metadata, progress, volume, and more.
 - Control next/previous, play/pause, shuffle/repeat settings, volume, sound mode, audio and video sources, and more.
-- Play various media through [play_media actions](#play_media-actions).
+- Play various media through the [media player play media action](#playing-media).
 - Control multiroom audio through [Beolink](https://support.bang-olufsen.com/hc/en-us/articles/4411572883089-What-is-Beolink-Multiroom):
   - Control with Home Assistant media_player grouping.
   - Monitor current [Beolink state](#beolink) through media player properties.
-  - For more advanced usage, [custom Beolink services](#custom-actions) have been defined:
+  - For more advanced usage, dedicated [Beolink actions](#beolink-multiroom) have been defined:
      - Connect or expand to [ASE](https://support.bang-olufsen.com/hc/en-us/articles/24766979863441-Which-platform-is-my-Connected-Audio-product-based-on) products not available in Home Assistant.
      - Expand sessions to all discovered devices.
      - Connect to, expand to or unexpand devices.
@@ -189,13 +189,11 @@ Several remote controls can be paired to the same Mozart device and are still cr
 
 This has the benefit of being able to trigger automations mapped to remote A with remote B, but also means that each Mozart device _only_ supports the 90 Event entities that a single remote provides.
 
-## Actions
-
-### play_media actions
+## Playing media
 
 The Bang & Olufsen integration supports different playback types in the `media_player.play_media` action: playback from URL, activating a favorite, playback from a local file, playing a radio station, activating a Deezer flow and Deezer playlists, albums, tracks, and playing files and text-to-speech (TTS) as an overlay.
 
-#### play_media examples
+### Playback examples
 
 Playing [DR P1](https://www.dr.dk/lyd/p1) from a URL:
 
@@ -328,7 +326,7 @@ data:
   media_content_id: 123456789
 ```
 
-##### Overlay
+#### Overlay
 
 Interrupts currently playing media to play an audio message.
 
@@ -337,13 +335,11 @@ Bang & Olufsen Cloud TTS messages are limited to 100 unique messages a day and a
 
 Extra keys available:
 
-| Data attribute            | Optional | Description                                                                                       |
-| ------------------------- | -------- | ------------------------------------------------------------------------------------------------- |
-| `overlay_absolute_volume` | yes      | Specify an absolute volume for the overlay.                                                       |
-| `overlay_offset_volume`   | yes      | Specify a volume offset to be added to the current volume level.                                  |
-| `overlay_tts_language`    | yes      | Specify the language used for text-to-speech. Uses the BCP 47 standard. Default value is "en-us". |
+- `overlay_absolute_volume`: Specify an absolute volume for the overlay.
+- `overlay_offset_volume`: Specify a volume offset to be added to the current volume level.
+- `overlay_tts_language`: Specify the language used for text-to-speech. Uses the BCP 47 standard. The default is `en-us`.
 
-###### Examples:
+##### Examples
 
 Playing a local file with an absolute volume as an overlay:
 
@@ -387,200 +383,13 @@ data:
     overlay_tts_language: da-dk
 ```
 
-### Custom actions
+## Beolink multiroom
 
-The Bang & Olufsen integration additionally supports different custom actions for Beolink.
+[Beolink](https://support.bang-olufsen.com/hc/en-us/articles/4411572883089-What-is-Beolink-Multiroom) is Bang & Olufsen's multiroom audio solution. This integration supports Home Assistant's `media_player` grouping, but to fully benefit from Beolink, such as joining legacy devices that are not added to Home Assistant, the integration provides dedicated actions.
 
-[Beolink](https://support.bang-olufsen.com/hc/en-us/articles/4411572883089-What-is-Beolink-Multiroom) is Bang & Olufsen's advanced multiroom audio solution. This integration supports Home Assistant's `media_player` grouping, but to fully benefit from Beolink, such as being able to join legacy devices not added in Home Assistant, custom actions have been defined.
+Attempting to run an invalid Beolink action results in either a Home Assistant error or an audible error indication from your device.
 
-Attempting to execute an invalid Beolink action will result in either a Home Assistant error or an audible error indication from your device.
-
-#### `bang_olufsen.beolink_join`
-
-Join a Beolink experience.
-
-| Action data attribute | Optional | Description                                                                                                                                                                                                                                                                                                                                          |
-| --------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `beolink_jid`         | yes      | Manually specify Beolink JID to join.                                                                                                                                                                                                                                                                                                                |
-| `source_id`           | yes      | Specify which source to join, behavior varies between hardware platforms. Source names prefaced by a platform name can only be used when connecting to that platform. For example "ASE Beoradio" can only be used when joining an ASE device, while ”ASE / Mozart Deezer” can be used with ASE or Mozart devices. A defined Beolink JID is required. |
-
-##### Join a currently active beolink experience or device playing compatible source
-
-```yaml
-action: bang_olufsen.beolink_join
-target:
-  entity_id: media_player.beosound_balance_12345678
-```
-
-Repeatedly calling this will cycle through available devices.
-
-Will also be triggered by calling the `media_player.join` action with an empty list of `group_members`:
-
-```yaml
-action: media_player.join
-target:
-  entity_id: media_player.beosound_balance_12345678
-data:
-  group_members:
-```
-
-##### Join a specific active beolink experience
-
-```yaml
-action: bang_olufsen.beolink_join
-target:
-  entity_id: media_player.beosound_balance_12345678
-data:
-  beolink_jid: 1111.2222222.33333333@products.bang-olufsen.com
-```
-
-##### Join the "radio" source on a Beolink Converter NL/ML
-
-```yaml
-action: bang_olufsen.beolink_join
-target:
-  entity_id: media_player.beosound_balance_12345678
-data:
-  beolink_jid: 1111.2222222.33333333@products.bang-olufsen.com
-  source_id: radio
-```
-
-A limited selection of `source_id`s are available. The below table shows which `source_id` can be joined on which hardware platform:
-
-| Hardware platform       | Compatible source_ids                      |
-| ----------------------- | ------------------------------------------ |
-| ASE                     | `beoradio`                                 |
-| ASE and Mozart          | `deezer`, `spotify`                        |
-| Mozart                  | `tidal`                                    |
-| Beolink Converter NL/ML | `radio`, `tp1`, `tp2`, `cd`, `aux_a`, `ph` |
-
-#### `bang_olufsen.beolink_expand`
-
-Expand current Beolink experience.
-
-| Action data attribute | Optional | Description                                                      |
-| --------------------- | -------- | ---------------------------------------------------------------- |
-| `all_discovered`      | yes      | Expand Beolink experience to all discovered devices.             |
-| `beolink_jids`        | yes      | Specify which Beolink JIDs will join current Beolink experience. |
-
-##### Expand an active Beolink experience to all other devices discovered by the defined device
-
-```yaml
-action: bang_olufsen.beolink_expand
-target:
-  entity_id: media_player.beosound_balance_12345678
-data:
-  all_discovered: true
-```
-
-##### Expand an active Beolink experience to a specific device
-
-```yaml
-action: bang_olufsen.beolink_expand
-target:
-  entity_id: media_player.beosound_balance_12345678
-data:
-  beolink_jids:
-    - 1111.2222222.33333333@products.bang-olufsen.com
-```
-
-Will also be triggered by calling the `media_player.join` action, with the entity_id of a `media_player` entity from this integration in `group_members`:
-
-```yaml
-action: media_player.join
-target:
-  entity_id: media_player.beosound_balance_12345678
-data:
-  group_members:
-    - media_player.beosound_balance_33333333
-```
-
-##### Expand an active Beolink experience to specific devices
-
-```yaml
-action: bang_olufsen.beolink_expand
-target:
-  entity_id: media_player.beosound_balance_12345678
-data:
-  beolink_jids:
-    - 1111.2222222.33333333@products.bang-olufsen.com
-    - 4444.5555555.66666666@products.bang-olufsen.com
-```
-
-Will also be triggered by calling the `media_player.join` action, with the entity_ids of `media_player` entities from this integration in `group_members`:
-
-```yaml
-action: media_player.join
-target:
-  entity_id: media_player.beosound_balance_12345678
-data:
-  group_members:
-    - media_player.beosound_balance_33333333
-    - media_player.beosound_balance_66666666
-```
-
-#### `bang_olufsen.beolink_unexpand`
-
-Unexpand from current Beolink experience.
-
-| Action data attribute | Optional | Description                                                            |
-| --------------------- | -------- | ---------------------------------------------------------------------- |
-| `beolink_jids`        | no       | Specify which Beolink JIDs will leave from current Beolink experience. |
-
-##### Remove a device from an active Beolink experience
-
-```yaml
-action: bang_olufsen.beolink_unexpand
-target:
-  entity_id: media_player.beosound_balance_12345678
-data:
-  beolink_jids:
-    - 1111.2222222.33333333@products.bang-olufsen.com
-```
-
-##### Remove devices from an active Beolink experience
-
-```yaml
-action: bang_olufsen.beolink_unexpand
-target:
-  entity_id: media_player.beosound_balance_12345678
-data:
-  beolink_jids:
-    - 1111.2222222.33333333@products.bang-olufsen.com
-    - 4444.5555555.66666666@products.bang-olufsen.com
-```
-
-#### `bang_olufsen.beolink_leave`
-
-Leave a Beolink experience.
-
-##### Action usage example
-
-```yaml
-action: bang_olufsen.beolink_leave
-target:
-  entity_id: media_player.beosound_balance_12345678
-```
-
-Same behavior as calling the `media_player.unjoin` action:
-
-```yaml
-action: media_player.unjoin
-target:
-  entity_id: media_player.beosound_balance_12345678
-```
-
-#### `bang_olufsen.beolink_allstandby`
-
-Set all connected Beolink devices to standby.
-
-##### Action usage example
-
-```yaml
-action: bang_olufsen.beolink_allstandby
-target:
-  entity_id: media_player.beosound_balance_12345678
-```
+{% include integrations/actions.md %}
 
 ## Automations
 


### PR DESCRIPTION
## Proposed change

Migrates the inline Beolink action documentation on the Bang & Olufsen integration page into dedicated action pages under `source/_actions/`, one per action (`beolink_join`, `beolink_expand`, `beolink_unexpand`, `beolink_leave`, `beolink_allstandby`), and replaces the inline block with `{% include integrations/actions.md %}`.

The generic `media_player.play_media` usage documentation stays on the integration page, since it documents a core action rather than a Bang & Olufsen-specific one.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

