### PR TITLE
Google Gemini: remove docs for removed generate_content action

### DIFF
--- a/source/_integrations/google_generative_ai_conversation.markdown
+++ b/source/_integrations/google_generative_ai_conversation.markdown
@@ -139,49 +139,6 @@ The tutorial is using OpenAI, but this could also be done with the Google Gemini
 
 ## Actions
 
-### Generate content
-
-{% tip %}
-This action isn't tied to any integration entry, so it won't use the model, prompt, or any of the other settings in your options. If you only want to pass text, you should use the `conversation.process` action.
-{% endtip %}
-
-Allows you to ask Gemini Pro or Gemini Pro Vision to generate content from a prompt consisting of text and optionally attachments (such as images or PDFs).
-This action populates [response data](/docs/scripts/perform-actions#use-templates-to-handle-response-data) with the generated content.
-
-| Data attribute | Optional | Description                                          | Example             |
-| -------------- | -------- | ---------------------------------------------------- | ------------------- |
-| `prompt`       | no       | The prompt for generating the content.               | Describe this image |
-| `filenames`    | yes      | File names for attachments to include in the prompt. | /tmp/image.jpg      |
-
-```yaml
-action: google_generative_ai_conversation.generate_content
-data:
-  prompt: >-
-    Very briefly describe what you see in this image from my doorbell camera.
-    Your message needs to be short to fit in a phone notification. Don't
-    describe stationary objects or buildings.
-  filenames: /tmp/doorbell_snapshot.jpg
-response_variable: generated_content
-```
-
-The response data field `text` will contain the generated content.
-
-Another example with multiple images:
-
-```yaml
-action: google_generative_ai_conversation.generate_content
-data:
-  prompt: >-
-    Briefly describe what happened in the following sequence of images
-    from my driveway camera.
-  filenames:
-    - /tmp/driveway_snapshot1.jpg
-    - /tmp/driveway_snapshot2.jpg
-    - /tmp/driveway_snapshot3.jpg
-    - /tmp/driveway_snapshot4.jpg
-response_variable: generated_content
-```
-
 ### Speak
 
 The `tts.speak` action is the modern way to use TTS. Add the `speak` action, select the Google Gemini TTS entity, select the media player entity or group to send the TTS audio to, and enter the message to speak.


### PR DESCRIPTION
## Proposed change

The `google_generative_ai_conversation.generate_content` action was deprecated and then removed from Home Assistant core (core #169255). The integration no longer registers the service, so its inline documentation is removed. The remaining TTS `speak` guidance is kept.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
