### PR TITLE
Add Yoto display brightness and maximum volume numbers documentation

### DIFF
--- a/source/_integrations/yoto.markdown
+++ b/source/_integrations/yoto.markdown
@@ -4,6 +4,7 @@ description: Instructions on how to integrate Yoto players with Home Assistant.
 ha_category:
   - Binary Sensor
   - Media Player
+  - Number
   - Sensor
   - Time
 ha_iot_class: Cloud Push
@@ -17,6 +18,7 @@ ha_domain: yoto
 ha_platforms:
   - binary_sensor
   - media_player
+  - number
   - sensor
   - time
 ha_integration_type: hub
@@ -108,6 +110,15 @@ Yoto players can switch between a day display and a night display. Each player p
 
 - **Day mode start**: The time the player switches to day mode.
 - **Night mode start**: The time the player switches to night mode.
+
+### Numbers
+
+Set the display brightness and volume limit for each mode:
+
+- **Day mode brightness**: The display brightness in day mode, from 0% to 100%. Unavailable while day mode uses automatic brightness.
+- **Night mode brightness**: The display brightness in night mode, from 0% to 100%. Unavailable while night mode uses automatic brightness.
+- **Day mode maximum volume**: The highest volume the player can reach in day mode, from 0 to 16.
+- **Night mode maximum volume**: The highest volume the player can reach in night mode, from 0 to 16.
 
 ### Binary sensors
 


### PR DESCRIPTION
## Proposed change

Document the `number` config entities added in [home-assistant/core#173968](https://github.com/home-assistant/core/pull/173968): per-mode display brightness and maximum volume, in a `Numbers` section.

The brightness numbers are unavailable while a mode uses automatic brightness, since there is no manual value to set then.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/173968
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
