### PR TITLE
Add Yoto config switches documentation

### DIFF
--- a/source/_integrations/yoto.markdown
+++ b/source/_integrations/yoto.markdown
@@ -5,6 +5,7 @@ ha_category:
   - Binary Sensor
   - Media Player
   - Sensor
+  - Switch
   - Time
 ha_iot_class: Cloud Push
 ha_release: 2026.6
@@ -18,6 +19,7 @@ ha_platforms:
   - binary_sensor
   - media_player
   - sensor
+  - switch
   - time
 ha_integration_type: hub
 ha_dhcp: true
@@ -108,6 +110,12 @@ Yoto players can switch between a day display and a night display. Each player p
 
 - **Day mode start**: The time the player switches to day mode.
 - **Night mode start**: The time the player switches to night mode.
+
+### Switches
+
+- **Automatic brightness**: Lets the display set its own brightness. Available for day and night mode, on players with a light sensor.
+- **Bluetooth pairing**: Turns on the player's Bluetooth to pair with audio devices.
+- **Maximum headphone volume**: Limits the volume when headphones are connected.
 
 ### Binary sensors
 

--- a/source/_integrations/yoto.markdown
+++ b/source/_integrations/yoto.markdown
@@ -113,6 +113,8 @@ Yoto players can switch between a day display and a night display. Each player p
 
 ### Switches
 
+Turn the following player settings on or off:
+
 - **Bluetooth pairing**: Enables Bluetooth so you can pair an audio device.
 - **Maximum headphone volume**: Limits the volume when headphones are connected.
 - **Day mode automatic brightness**: Automatically adjusts the display brightness in day mode (only available on players with a light sensor). Turning this off sets the brightness to 100%.

--- a/source/_integrations/yoto.markdown
+++ b/source/_integrations/yoto.markdown
@@ -113,9 +113,10 @@ Yoto players can switch between a day display and a night display. Each player p
 
 ### Switches
 
-- **Automatic brightness**: Lets the display set its own brightness. Available for day and night mode, on players with a light sensor.
-- **Bluetooth pairing**: Turns on the player's Bluetooth to pair with audio devices.
+- **Bluetooth pairing**: Enables Bluetooth so you can pair an audio device.
 - **Maximum headphone volume**: Limits the volume when headphones are connected.
+- **Day mode automatic brightness**: Automatically adjusts the display brightness in day mode (only available on players with a light sensor). Turning this off sets the brightness to 100%.
+- **Night mode automatic brightness**: Automatically adjusts the display brightness in night mode (only available on players with a light sensor). Turning this off sets the brightness to 100%.
 
 ### Binary sensors
 


### PR DESCRIPTION
## Proposed change

Document the `switch` config entities added in [home-assistant/core#173973](https://github.com/home-assistant/core/pull/173973) in a `### Switches` section:

- **Automatic brightness** (per mode), available on players with a light sensor.
- **Bluetooth pairing** and **Maximum headphone volume**.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/173973
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
