### PR TITLE
Blackbird: migrate set_all_zones action to dedicated page

### DIFF
--- a/source/_actions/blackbird.set_all_zones.markdown
+++ b/source/_actions/blackbird.set_all_zones.markdown
@@ -1,0 +1,60 @@
+---
+title: "Set all zones"
+action: blackbird.set_all_zones
+domain: blackbird
+description: "Sets every zone on the Blackbird matrix switch to the same input source at once."
+---
+
+Use this action to switch every zone on your Monoprice Blackbird matrix switch to the same input source in one step. This is handy when you want all the TVs in your home to show the same source, for example to play one video feed everywhere.
+
+This action always updates every zone. Any entity or target you select is ignored, so there is no need to pick a specific zone.
+
+{% include actions/ui_header.md %}
+
+To set all zones to the same source from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Monoprice Blackbird Matrix Switch: Set all zones**.
+6. In the **Source** field, enter the name of the source to activate. This is one of the source names you defined in your configuration.
+7. Select **Save**.
+
+This action does not support targets. In the UI, even if you are prompted to choose an entity, the action always updates every zone.
+
+### Options in the UI
+
+{% options_ui %}
+Source:
+  description: The name of the source to switch all zones to. This must match one of the source names you defined in your configuration.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `blackbird.set_all_zones`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: blackbird.set_all_zones
+  data:
+    source: BluRay
+{% endexample %}
+
+This switches every zone to the source named `BluRay`.
+
+### Options in YAML
+
+{% options_yaml %}
+source:
+  description: >
+    The name of the source to switch all zones to. This must match one of
+    the source names you defined in your configuration.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}

--- a/source/_actions/blackbird.set_all_zones.markdown
+++ b/source/_actions/blackbird.set_all_zones.markdown
@@ -58,3 +58,5 @@ source:
 {% include actions/try_it.md %}
 
 {% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/blackbird.markdown
+++ b/source/_integrations/blackbird.markdown
@@ -60,11 +60,4 @@ sources:
       type: string
 {% endconfiguration %}
 
-### Action `blackbird.set_all_zones`
-
-Set all zones to the same input source. This action allows you to immediately synchronize all the TVs in your home. Regardless of `entity_id` provided, all zones will be updated.
-
-| Data attribute | Optional | Description                                     |
-| ---------------------- | -------- | ----------------------------------------------- |
-| `entity_id`            | yes      | String that points at an `entity_id` of a zone. |
-| `source`               | no       | String of source name to activate.              |
+{% include integrations/actions.md %}


### PR DESCRIPTION
## Proposed change

Migrates the inline documentation for the `blackbird.set_all_zones` action into a dedicated page under `source/_actions/`, and replaces the inline action section on the Monoprice Blackbird Matrix Switch integration page with the standard `{% include integrations/actions.md %}` include.

The new page follows the established action-page structure, with a UI walkthrough and a YAML reference. It also corrects the documentation to match Home Assistant core: the `entity_id` field is optional and ignored, since the action always updates every zone.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
