### PR TITLE
Local file: migrate update_file_path action to dedicated page

### DIFF
--- a/source/_actions/local_file.update_file_path.markdown
+++ b/source/_actions/local_file.update_file_path.markdown
@@ -67,3 +67,5 @@ file_path:
 {% include actions/try_it.md %}
 
 {% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/local_file.update_file_path.markdown
+++ b/source/_actions/local_file.update_file_path.markdown
@@ -1,0 +1,69 @@
+---
+title: "Update file path"
+action: local_file.update_file_path
+domain: local_file
+description: "Changes the image file that a local file camera displays."
+---
+
+Use this action to change which image file a local file camera shows. This is useful when another process saves a new image, for example a snapshot from another camera or a graph you render periodically, and you want the camera to start displaying that file.
+
+{% important %}
+The new file path must be added to [`allowlist_external_dirs`](/integrations/homeassistant/#allowlist_external_dirs). Without this, Home Assistant cannot read the file and the action returns an error.
+{% endimportant %}
+
+{% include actions/ui_header.md %}
+
+To change the displayed file from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the local file camera entity you want to update.
+6. From the actions shown for that target, select **Local file: Update file path**.
+7. In the **File path** field, enter the full path to the new image file.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+File path:
+  description: The full path to the new image file to display. The path must be allowed in `allowlist_external_dirs`.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `local_file.update_file_path`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: local_file.update_file_path
+  target:
+    entity_id: camera.front_door
+  data:
+    file_path: /config/www/images/front_door.jpg
+{% endexample %}
+
+This makes the `camera.front_door` local file camera display the image at the given path.
+
+### Options in YAML
+
+{% options_yaml %}
+file_path:
+  description: >
+    The full path to the new image file to display. The path must be allowed
+    in `allowlist_external_dirs`.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="camera" %}
+
+## Good to know
+
+- The new file path must be added to [`allowlist_external_dirs`](/integrations/homeassistant/#allowlist_external_dirs). Otherwise, the action cannot read the file and returns an error.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}

--- a/source/_integrations/local_file.markdown
+++ b/source/_integrations/local_file.markdown
@@ -25,11 +25,4 @@ The file path must be added to [allowlist_external_dirs](/integrations/homeassis
 
 {% include integrations/config_flow.md %}
 
-### Action: Update file path
-
-The `local_file.update_file_path` action changes the file displayed by the camera.
-
-| Data attribute | Description                                          |
-| ---------------------- | ---------------------------------------------------- |
-| `entity_id`            | String of the `entity_id` of the camera to update.   |
-| `file_path`            | The full path to the new image file to be displayed. |
+{% include integrations/actions.md %}


### PR DESCRIPTION
## Proposed change

Migrates the inline documentation for the `local_file.update_file_path` action into a dedicated page under `source/_actions/`, and replaces the inline action section on the Local file integration page with the standard `{% include integrations/actions.md %}` include.

The new page follows the established action-page structure, with a UI walkthrough and a YAML reference, and keeps the note about adding the file path to `allowlist_external_dirs`.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
