### PR TITLE
Browser: migrate browse_url action to dedicated page

### DIFF
--- a/source/_actions/browser.browse_url.markdown
+++ b/source/_actions/browser.browse_url.markdown
@@ -1,0 +1,58 @@
+---
+title: "Browse URL"
+action: browser.browse_url
+domain: browser
+description: "Opens a URL in the default browser on the machine running Home Assistant."
+---
+
+Use this action to open a web page in the default browser on the machine that runs Home Assistant. This is useful for setups where Home Assistant runs on a computer connected to a screen, for example a wall-mounted dashboard or a kiosk, and you want an automation to bring up a specific page.
+
+The URL opens on the host machine, not on the device you are using to view Home Assistant.
+
+{% include actions/ui_header.md %}
+
+To open a URL from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Browser: Browse URL**.
+6. In the **URL** field, enter the web address you want to open.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+URL:
+  description: The web address to open in the default browser on the machine running Home Assistant.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `browser.browse_url`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: browser.browse_url
+  data:
+    url: "https://www.home-assistant.io"
+{% endexample %}
+
+This opens the Home Assistant website in the default browser on the host machine.
+
+### Options in YAML
+
+{% options_yaml %}
+url:
+  description: The web address to open in the default browser on the machine running Home Assistant.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}

--- a/source/_actions/browser.browse_url.markdown
+++ b/source/_actions/browser.browse_url.markdown
@@ -56,3 +56,5 @@ url:
 {% include actions/try_it.md %}
 
 {% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/browser.markdown
+++ b/source/_integrations/browser.markdown
@@ -25,22 +25,4 @@ To load this integration, add the following lines to your {% term "`configuratio
 browser:
 ```
 
-### Actions
-
-Once loaded, the `browser` platform will expose {% term actions %} that can be called to perform various {% term actions %}.
-
-Available actions: `browser/browse_url`.
-
-| Data attribute | Optional | Description      |
-| ---------------------- | -------- | ---------------- |
-| `url`                  | no       | The URL to open. |
-
-### Usage
-
-To use this {% term action %}, go to {% my developer_services title="**Settings** > **Developer tools** > **Actions**" %}. Choose the action *browser/browse_url* from the list of **Actions:** and enter the URL into the **data** field and select **Perform action**.
-
-```json
-{"url": "http://www.google.com"}
-```
-
-This will open the given URL on the host machine.
+{% include integrations/actions.md %}


### PR DESCRIPTION
## Proposed change

Migrates the inline documentation for the `browser.browse_url` action into a dedicated page under `source/_actions/`, and replaces the inline action and usage sections on the Browser integration page with the standard `{% include integrations/actions.md %}` include.

The new page follows the established action-page structure, with a UI walkthrough and a YAML reference. It also updates the action reference from the old `browser/browse_url` slash notation to the current `browser.browse_url` form, and clarifies that the URL opens on the machine running Home Assistant.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
