### PR TITLE
Keymitt BLE: migrate calibrate action to dedicated page

### DIFF
--- a/source/_actions/keymitt_ble.calibrate.markdown
+++ b/source/_actions/keymitt_ble.calibrate.markdown
@@ -49,7 +49,7 @@ action: |
     mode: normal
 {% endexample %}
 
-This calibrates the `switch.microbot_push` device to extend the arm halfway, hold for one second, and operate in normal mode.
+This calibrates the `switch.microbot_push` entity to extend the arm halfway, hold for one second, and operate in normal mode.
 
 ### Options in YAML
 
@@ -80,3 +80,5 @@ mode:
 {% include actions/try_it.md %}
 
 {% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/keymitt_ble.calibrate.markdown
+++ b/source/_actions/keymitt_ble.calibrate.markdown
@@ -1,0 +1,82 @@
+---
+title: "Calibrate"
+action: keymitt_ble.calibrate
+domain: keymitt_ble
+description: "Sets the push depth, hold duration, and mode of a MicroBot Push."
+---
+
+Use this action to calibrate a MicroBot Push. You set how far the push arm extends, how long it stays extended, and the mode it operates in. The settings are stored on the device, so they apply to later presses as well.
+
+{% include actions/ui_header.md %}
+
+To calibrate a MicroBot Push from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the MicroBot Push switch entity you want to calibrate.
+6. From the actions shown for that target, select **MicroBot Push: Calibrate**.
+7. Set the **Depth**, **Duration**, and **Mode**.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Depth:
+  description: How far the push arm extends, as a percentage from 0 to 100.
+  required: true
+Duration:
+  description: How long, in seconds, the push arm stays extended, from 0 to 60.
+  required: true
+Mode:
+  description: "The mode the arm operates in: `normal` extends and retracts the arm, `invert` retracts then extends it, and `toggle` switches between extend and retract."
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `keymitt_ble.calibrate`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: keymitt_ble.calibrate
+  target:
+    entity_id: switch.microbot_push
+  data:
+    depth: 50
+    duration: 1
+    mode: normal
+{% endexample %}
+
+This calibrates the `switch.microbot_push` device to extend the arm halfway, hold for one second, and operate in normal mode.
+
+### Options in YAML
+
+{% options_yaml %}
+depth:
+  description: How far the push arm extends, as a percentage from 0 to 100.
+  required: true
+  type: integer
+duration:
+  description: How long, in seconds, the push arm stays extended, from 0 to 60.
+  required: true
+  type: integer
+mode:
+  description: >
+    The mode the arm operates in: `normal` extends and retracts the arm,
+    `invert` retracts then extends it, and `toggle` switches between extend
+    and retract.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="switch" %}
+
+## Good to know
+
+- After the action runs, the push arm extends or retracts depending on the mode you set. The mode and depth are demonstrated right away, but the duration is not. The setting is still stored and can be confirmed by manually operating the device.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}

--- a/source/_integrations/keymitt_ble.markdown
+++ b/source/_integrations/keymitt_ble.markdown
@@ -17,7 +17,7 @@ ha_integration_type: device
 
 This {% term integration %} allows you to locally control a MicroBot Push (previously manufactured by Naran but now under the Keymitt brand).
 
-### Prerequisites
+## Prerequisites
 
 To use this integration, it is required to have working [Bluetooth](/integrations/bluetooth) set up on the device running Home Assistant. A Naran/Keymitt hub is not required.
 
@@ -29,15 +29,15 @@ The devices cannot remain paired to the MicroBot application for this integratio
 
 {% include integrations/config_flow.md %}
 
-### Supported devices
+## Supported devices
 
 This Integration is for the MicroBot Push only. The Keymitt lock is not supported.
 
 {% include integrations/actions.md %}
 
-### Error codes and troubleshooting
+## Error codes and troubleshooting
 
-The integration will automatically discover devices once the [Bluetooth](/integrations/bluetooth) integration is enabled and functional.
+The integration will automatically discover devices once the [Bluetooth](/integrations/bluetooth/) integration is enabled and functional.
 
 Due to the device going into deep sleep after extended periods of no activity, the response time can be up to a minute in extreme cases. On average it will be much quicker.
 

--- a/source/_integrations/keymitt_ble.markdown
+++ b/source/_integrations/keymitt_ble.markdown
@@ -33,19 +33,7 @@ The devices cannot remain paired to the MicroBot application for this integratio
 
 This Integration is for the MicroBot Push only. The Keymitt lock is not supported.
 
-### Action: Calibrate
-
-The `keymitt_ble.calibrate` action locally sets the MicroBot Push depth, duration, and mode.
-
-Please note: The push arm will extend or retract (depending on the mode defined) after the action is performed. The mode and depth will be demonstrated, but not the duration. The setting is, however, stored and can be confirmed by manually operating the device.
-
-| Data attribute | Required | Description                                                                                   |
-| ---------------------- | -------- | --------------------------------------------------------------------------------------------- |
-| `depth`                | yes      | How far (in percent) to extend the push arm.                                                  |
-| `duration`             | yes      | Duration (in seconds) to hold the arm extended.                                               |
-| `mode`                 | yes      |'Normal' - extend and retract the arm.                                                         |
-|                        |          |'Invert' - retract then extend the arm.                                                        |      
-|                        |          |'Toggle' - toggle between extend and retract.                                                  |
+{% include integrations/actions.md %}
 
 ### Error codes and troubleshooting
 


### PR DESCRIPTION
## Proposed change

Migrates the inline documentation for the `keymitt_ble.calibrate` action into a dedicated page under `source/_actions/`, and replaces the inline action section on the Keymitt BLE (MicroBot Push) integration page with the standard `{% include integrations/actions.md %}` include.

The new page follows the established action-page structure, with a UI walkthrough and a YAML reference. The fields are documented from the core schema, and the note about the arm extending after calibration is kept in a "Good to know" section.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
