### PR TITLE
UniFi Access: migrate set_lock_rule action to dedicated page

### DIFF
--- a/source/_actions/unifi_access.set_lock_rule.markdown
+++ b/source/_actions/unifi_access.set_lock_rule.markdown
@@ -1,0 +1,100 @@
+---
+title: "Set lock rule"
+action: unifi_access.set_lock_rule
+domain: unifi_access
+description: "Applies a temporary lock rule to a UniFi Access door."
+---
+
+Use this action to apply a temporary lock rule to a specific UniFi Access door from an automation or a script. It complements the **Door Lock Rule** select entity and adds support for setting how long the rule stays active.
+
+This action is available for controllers that support temporary lock rules.
+
+{% include actions/ui_header.md %}
+
+To set a lock rule from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **UniFi Access: Set lock rule**.
+6. Select the **Device** for the UniFi Access door you want to update.
+7. Select the **Rule** you want to apply.
+8. Optionally, set the **Interval** to control how long a custom rule stays active.
+9. Select **Save**.
+
+This action does not support targets. In the UI, you select the door through the **Device** field instead of choosing an area, device, entity, or label as a target.
+
+### Options in the UI
+
+{% options_ui %}
+Device:
+  description: The UniFi Access door to update.
+  required: true
+Rule:
+  description: "The lock rule to apply: `keep_lock`, `keep_unlock`, `custom`, `reset`, or `lock_early`."
+  required: true
+Interval:
+  description: How long a `custom` rule stays active, as a duration. Defaults to 10 minutes when left empty. The minimum is 1 minute and the maximum is 8 hours.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `unifi_access.set_lock_rule`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: unifi_access.set_lock_rule
+  data:
+    device_id: 0123456789abcdef0123456789abcdef
+    rule: keep_lock
+{% endexample %}
+
+This keeps the door locked.
+
+### Options in YAML
+
+{% options_yaml %}
+device_id:
+  description: The UniFi Access door to update.
+  required: true
+  type: string
+rule:
+  description: "The lock rule to apply: `keep_lock`, `keep_unlock`, `custom`, `reset`, or `lock_early`."
+  required: true
+  type: string
+interval:
+  description: How long a `custom` rule stays active, as a duration. Defaults to 10 minutes when omitted. The minimum is 1 minute and the maximum is 8 hours.
+  required: false
+  type: string
+{% endoptions_yaml %}
+
+### Automation: keep a door unlocked for half an hour
+
+Apply a custom rule that keeps a door unlocked for 30 minutes when an automation runs.
+
+{% details "YAML example for a timed custom lock rule" %}
+
+{% example %}
+automation: |
+  alias: "Unlock front door for deliveries"
+  triggers:
+    - trigger: state
+      entity_id: input_boolean.delivery_mode
+      to: "on"
+  actions:
+    - action: unifi_access.set_lock_rule
+      data:
+        device_id: 0123456789abcdef0123456789abcdef
+        rule: custom
+        interval:
+          hours: 0
+          minutes: 30
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}

--- a/source/_actions/unifi_access.set_lock_rule.markdown
+++ b/source/_actions/unifi_access.set_lock_rule.markdown
@@ -65,7 +65,10 @@ rule:
   required: true
   type: string
 interval:
-  description: How long a `custom` rule stays active, as a duration. Defaults to 10 minutes when omitted. The minimum is 1 minute and the maximum is 8 hours.
+  description: >
+    How long a `custom` rule stays active. Use a duration like "00:30:00" for
+    30 minutes. Defaults to 10 minutes when omitted. The minimum is 1 minute
+    and the maximum is 8 hours.
   required: false
   type: string
 {% endoptions_yaml %}
@@ -98,3 +101,5 @@ automation: |
 {% include actions/try_it.md %}
 
 {% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/unifi_access.set_lock_rule.markdown
+++ b/source/_actions/unifi_access.set_lock_rule.markdown
@@ -77,6 +77,14 @@ interval:
 
 Apply a custom rule that keeps a door unlocked for 30 minutes when an automation runs.
 
+- **Trigger**: State
+  - **Entity**: Delivery mode (`input_boolean.delivery_mode`)
+  - **To**: On
+- **Action**: Set lock rule
+  - **Device**: Front door
+  - **Rule**: Custom
+  - **Interval**: 00:30:00
+
 {% details "YAML example for a timed custom lock rule" %}
 
 {% example %}

--- a/source/_integrations/unifi_access.markdown
+++ b/source/_integrations/unifi_access.markdown
@@ -136,30 +136,7 @@ For controllers that support temporary lock rules, each door also exposes the fo
 
 - **Rule End Time**: Reports the date and time when the active temporary lock rule expires. Returns `unknown` when no temporary rule is active or when the rule has no expiry.
 
-### Actions
-
-For controllers that support temporary lock rules, the integration also provides the `unifi_access.set_lock_rule` action.
-
-Use this action to apply a temporary lock rule to a specific door from an automation or script. It complements the existing **Door Lock Rule** select entity and adds support for setting the interval directly. In the automation editor, select the UniFi Access door device you want to target.
-
-| Data attribute | Optional | Description                                                                                                   |
-| -------------- | -------- | ------------------------------------------------------------------------------------------------------------- |
-| `device_id`    | no       | The UniFi Access door device to update.                                                                       |
-| `rule`         | no       | The lock rule to apply. Supported values are `custom`, `keep_lock`, `keep_unlock`, `lock_early`, and `reset`. |
-| `interval`     | yes      | How long the rule stays active, as a duration (for example, `"00:30:00"` for 30 minutes). Defaults to 10 minutes when omitted. |
-
-Example action:
-
-```yaml
-action: unifi_access.set_lock_rule
-data:
-  device_id: 0123456789abcdef0123456789abcdef
-  rule: keep_lock
-  interval:
-    hours: 0
-    minutes: 30
-    seconds: 0
-```
+{% include integrations/actions.md %}
 
 ## Data updates
 


### PR DESCRIPTION
## Proposed change

Migrates the inline `unifi_access.set_lock_rule` action documentation into a dedicated action page under `source/_actions/`, and replaces the inline section on the integration page with the standard `{% include integrations/actions.md %}`.

The action page documents the device, rule, and interval options, with both UI and YAML instructions. The rule options and interval range were verified against the integration's service schema.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
