### PR TITLE
ZoneMinder: migrate set_run_state action to a dedicated page

### DIFF
--- a/source/_actions/zoneminder.set_run_state.markdown
+++ b/source/_actions/zoneminder.set_run_state.markdown
@@ -16,15 +16,15 @@ To set the run state from an automation or a script:
 3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
 4. In the **Then do** section, select **Add action**.
 5. From the search box, search for and select **ZoneMinder: Set run state**.
-6. Set the **Id** of the ZoneMinder host and the **Name** of the run state to apply.
+6. Set the **ID** of the ZoneMinder host and the **Name** of the run state to apply.
 7. Select **Save**.
 
-This action does not support targets. You select the ZoneMinder instance through the **Id** field instead of choosing an area, device, entity, or label.
+This action does not support targets. You select the ZoneMinder instance through the **ID** field instead of choosing an area, device, entity, or label.
 
 ### Options in the UI
 
 {% options_ui %}
-Id:
+ID:
   description: The host of the ZoneMinder instance to update.
   required: true
 Name:
@@ -41,7 +41,7 @@ action: |
   action: zoneminder.set_run_state
   data:
     id: ZM_HOST
-    name: Home
+    name: "Home"
 {% endexample %}
 
 This switches the ZoneMinder instance to the `Home` run state.

--- a/source/_actions/zoneminder.set_run_state.markdown
+++ b/source/_actions/zoneminder.set_run_state.markdown
@@ -1,0 +1,64 @@
+---
+title: "Set run state"
+action: zoneminder.set_run_state
+domain: zoneminder
+description: "Changes the active run state of a ZoneMinder instance."
+---
+
+Use this action to switch your ZoneMinder instance to a different run state from an automation or a script, for example to change to a "Home" run state when you arrive home.
+
+{% include actions/ui_header.md %}
+
+To set the run state from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **ZoneMinder: Set run state**.
+6. Set the **Id** of the ZoneMinder host and the **Name** of the run state to apply.
+7. Select **Save**.
+
+This action does not support targets. You select the ZoneMinder instance through the **Id** field instead of choosing an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Id:
+  description: The host of the ZoneMinder instance to update.
+  required: true
+Name:
+  description: The name of the run state to apply.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `zoneminder.set_run_state`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: zoneminder.set_run_state
+  data:
+    id: ZM_HOST
+    name: Home
+{% endexample %}
+
+This switches the ZoneMinder instance to the `Home` run state.
+
+### Options in YAML
+
+{% options_yaml %}
+id:
+  description: The host of the ZoneMinder instance to update.
+  required: true
+  type: string
+name:
+  description: The name of the run state to apply.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}

--- a/source/_integrations/zoneminder.markdown
+++ b/source/_integrations/zoneminder.markdown
@@ -94,24 +94,7 @@ zoneminder:
     password: YOUR_PASSWORD
 ```
 
-### Action: Set run state
-
-The `zoneminder.set_run_state` action changes the current run state of ZoneMinder.
-
-| Data attribute | Optional | Description                       |
-| :--------------------- | :------- | :-------------------------------- |
-| `id`                   | no       | Host of the ZoneMinder instance.  |
-| `name`                 | no       | Name of the new run state to set. |
-
-For example, if your ZoneMinder instance was configured with a run state called "Home", you could write an [automation](/getting-started/automation/) that changes ZoneMinder to the "Home" run state by including the following [action](/getting-started/automation-action/):
-
- ```yaml
-actions:
-  action: zoneminder.set_run_state
-  data:
-    id: ZM_HOST
-    name: Home
-```
+{% include integrations/actions.md %}
 
 ## Binary sensor
 


### PR DESCRIPTION
## Proposed change

Migrates the inline `zoneminder.set_run_state` action documentation into a dedicated action page under `source/_actions/`, and replaces the inline section on the integration page with the standard `{% include integrations/actions.md %}`.

The action page documents the host and run state options, with both UI and YAML instructions. Both required fields were verified against the integration's service schema.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
