### PR TITLE
Neato: migrate custom_cleaning action to a dedicated page

### DIFF
--- a/source/_actions/neato.custom_cleaning.markdown
+++ b/source/_actions/neato.custom_cleaning.markdown
@@ -87,3 +87,5 @@ zone:
 {% include actions/try_it.md %}
 
 {% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/neato.custom_cleaning.markdown
+++ b/source/_actions/neato.custom_cleaning.markdown
@@ -1,0 +1,89 @@
+---
+title: "Custom cleaning"
+action: neato.custom_cleaning
+domain: neato
+description: "Starts a custom cleaning run on a Neato Botvac."
+---
+
+Use this action to start a custom cleaning run on your Neato Botvac from an automation or a script. You can set the same options as in the Neato app, such as the cleaning mode, navigation mode, map usage, and a specific zone to clean.
+
+{% include actions/ui_header.md %}
+
+To start a custom cleaning run from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Neato Botvac you want to start.
+6. From the actions shown for that target, select **Neato: Custom cleaning**.
+7. Optionally, set the **Mode**, **Navigation**, **Category**, and **Zone** options.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Mode:
+  description: "The cleaning mode: `1` for eco or `2` for turbo. Defaults to turbo."
+  required: false
+Navigation:
+  description: "The navigation mode: `1` for normal, `2` for extra care, or `3` for deep. Defaults to normal. Deep cleaning is only supported on the Botvac D7."
+  required: false
+Category:
+  description: "Whether to use a persistent map for cleaning (the No-Go lines): `2` for no map or `4` for map. Defaults to using a map, and falls back to no map when none is found."
+  required: false
+Zone:
+  description: The name of the zone to clean, as set in the Neato app. Defaults to cleaning the whole house. Only supported on the Botvac D7.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `neato.custom_cleaning`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: neato.custom_cleaning
+  target:
+    entity_id: vacuum.neato
+  data:
+    mode: 2
+    navigation: 1
+{% endexample %}
+
+This starts a turbo cleaning run with normal navigation.
+
+### Options in YAML
+
+{% options_yaml %}
+mode:
+  description: "The cleaning mode: `1` for eco or `2` for turbo."
+  required: false
+  type: integer
+  default: 2
+navigation:
+  description: "The navigation mode: `1` for normal, `2` for extra care, or `3` for deep. Deep cleaning is only supported on the Botvac D7."
+  required: false
+  type: integer
+  default: 1
+category:
+  description: "Whether to use a persistent map for cleaning (the No-Go lines): `2` for no map or `4` for map. Falls back to no map when none is found."
+  required: false
+  type: integer
+  default: 4
+zone:
+  description: The name of the zone to clean, as set in the Neato app. Defaults to cleaning the whole house. Only supported on the Botvac D7.
+  required: false
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="vacuum" %}
+
+## Good to know
+
+- Not all Botvac models support every option. Only the Neato Botvac D7 supports the `zone` option and deep navigation.
+- Use unique names for your zones in the Neato app to avoid starting the wrong zone.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}

--- a/source/_integrations/neato.markdown
+++ b/source/_integrations/neato.markdown
@@ -88,37 +88,7 @@ Each `neato` vacuum has a _Dismiss alert_ button. This allows you to dismiss an 
 The `neato` vacuum platform allows you to control your [Neato Botvac Connected][botvac-connected].
 The status will contain attributes on the robots last clean session.
 
-### Actions
-
-Currently supported actions are:
-
-- `start`
-- `pause`
-- `stop`
-- `return_to_base`
-- `locate`
-- `clean_spot`
-
-And a specific integration-specific action:
-
-- `neato.custom_cleaning`
-
-#### Action: Custom cleaning
-
-The `neato.custom_cleaning` action starts a custom cleaning of your house. You can set the various options like in the mobile application (mode, map usage, navigation mode, zone).
-
-{% note %}
-Not all Botvac models support all the attributes. Only the Neato Botvac D7 supports the `zone` attribute.
-Some information about the capabilities might be found on the [Neato Developer Portal](https://developers.neatorobotics.com/api/robot-remote-protocol/housecleaning).
-{% endnote %}
-
-| Data attribute | Optional | Description                                                                                                                                                                   |
-| ---------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `entity_id`            | no       | Only act on a specific robot                                                                                                                                                  |
-| `mode`                 | yes      | Set the cleaning mode: 1 for eco and 2 for turbo. Defaults to turbo if not set.                                                                                               |
-| `navigation`           | yes      | Set the navigation mode: 1 for normal, 2 for extra care, 3 for deep. Defaults to normal if not set. Deep cleaning is only supported on the Botvac D7.                                                                           |
-| `category`             | yes      | Whether to use a persistent map or not for cleaning (that is, No go lines): 2 for no map, 4 for map. Default to using map if not set (and fallback to no map if no map is found). |
-| `zone`                 | yes      | Only supported on the Botvac D7. Name of the zone to clean from the Neato app. Use unique names for the zones to avoid the wrong zone from running. Defaults to no zone, that is, complete house cleanup.                                                                  |
+{% include integrations/actions.md %}
 
 [botvac-connected]: https://neatorobotics.com/products
 

--- a/source/_integrations/neato.markdown
+++ b/source/_integrations/neato.markdown
@@ -86,7 +86,7 @@ Each `neato` vacuum has a _Dismiss alert_ button. This allows you to dismiss an 
 ## Vacuum
 
 The `neato` vacuum platform allows you to control your [Neato Botvac Connected][botvac-connected].
-The status will contain attributes on the robots last clean session.
+The status includes attributes about the robot's last cleaning session.
 
 {% include integrations/actions.md %}
 


### PR DESCRIPTION
## Proposed change

Migrates the inline `neato.custom_cleaning` action documentation into a dedicated action page under `source/_actions/`, and replaces the inline section on the integration page with the standard `{% include integrations/actions.md %}`.

The action page documents the mode, navigation, category, and zone options, with both UI and YAML instructions and their defaults. The options and defaults were verified against the integration's service schema. The generic vacuum entity actions that were previously listed are covered by the vacuum integration documentation.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
