### PR TITLE
Prosegur: migrate request_image action to a dedicated page

### DIFF
--- a/source/_actions/prosegur.request_image.markdown
+++ b/source/_actions/prosegur.request_image.markdown
@@ -1,0 +1,52 @@
+---
+title: "Request image"
+action: prosegur.request_image
+domain: prosegur
+description: "Asks the Prosegur cloud service for a new image from a camera."
+---
+
+Use this action to ask the Prosegur cloud service to request a new image from one of your Prosegur cameras, for example to capture a fresh picture when an automation runs.
+
+{% include actions/ui_header.md %}
+
+To request an image from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Prosegur camera you want a new image from.
+6. From the actions shown for that target, select **Prosegur: Request image**.
+7. Select **Save**.
+
+### Options in the UI
+
+This action has no additional options beyond the target.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `prosegur.request_image`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: prosegur.request_image
+  target:
+    entity_id: camera.prosegur
+{% endexample %}
+
+This requests a new image from `camera.prosegur`.
+
+### Options in YAML
+
+This action has no additional YAML options beyond the target.
+
+{% include actions/targets.md domain="camera" %}
+
+## Good to know
+
+- This action only works with Prosegur camera entities.
+- Use this action sparingly. Prosegur tends to throttle image requests for long periods, which can cause errors in both this integration and the Prosegur mobile app.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}

--- a/source/_integrations/prosegur.markdown
+++ b/source/_integrations/prosegur.markdown
@@ -29,6 +29,4 @@ There is currently support for the following device types within Home Assistant:
 
 {% include integrations/config_flow.md %}
 
-### Action `camera.request_image`
-
-This action will have Prosegur cloud service "Request image" from your local camera. This action should only be called seldom, as Prosegur tends to throttle this action for long periods of time, resulting in errors for both this integration and your Prosegur mobile application.
+{% include integrations/actions.md %}


### PR DESCRIPTION
## Proposed change

Migrates the inline `request_image` action documentation into a dedicated action page under `source/_actions/`, and replaces the inline section on the integration page with the standard `{% include integrations/actions.md %}`.

While migrating, the action name was corrected: the inline docs referred to it as `camera.request_image`, but the integration registers it on its own platform, so the correct name is `prosegur.request_image`. The throttling guidance was kept.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
