### PR TITLE
Foscam: migrate PTZ actions to dedicated pages

### DIFF
--- a/source/_actions/foscam.ptz.markdown
+++ b/source/_actions/foscam.ptz.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PTZ move"
+title: "PTZ"
 action: foscam.ptz
 domain: foscam
 description: "Pans or tilts a Foscam camera in a given direction."
@@ -18,7 +18,7 @@ To move a camera from an automation or a script:
 3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
 4. In the **Then do** section, select **Add action**.
 5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Foscam camera you want to move.
-6. From the actions shown for that target, select **PTZ move**.
+6. From the actions shown for that target, select **PTZ**.
 7. Select the **Movement** direction, and optionally set the **Travel time**.
 8. Select **Save**.
 

--- a/source/_actions/foscam.ptz.markdown
+++ b/source/_actions/foscam.ptz.markdown
@@ -1,0 +1,75 @@
+---
+title: "PTZ move"
+action: foscam.ptz
+domain: foscam
+description: "Pans or tilts a Foscam camera in a given direction."
+related_actions:
+  - foscam.ptz_preset
+---
+
+Use this action to pan or tilt a Foscam camera in a given direction from an automation or a script. This action is available for cameras that support pan, tilt, and zoom (PTZ).
+
+{% include actions/ui_header.md %}
+
+To move a camera from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Foscam camera you want to move.
+6. From the actions shown for that target, select **Foscam: PTZ move**.
+7. Select the **Movement** direction, and optionally set the **Travel time**.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Movement:
+  description: "The direction to move the camera: `up`, `down`, `left`, `right`, `top_left`, `top_right`, `bottom_left`, or `bottom_right`."
+  required: true
+Travel time:
+  description: How long the camera moves, in seconds, from 0 to 1. Defaults to 0.125.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `foscam.ptz`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: foscam.ptz
+  target:
+    entity_id: camera.bedroom
+  data:
+    movement: up
+{% endexample %}
+
+This pans the camera upward.
+
+### Options in YAML
+
+{% options_yaml %}
+movement:
+  description: "The direction to move the camera: `up`, `down`, `left`, `right`, `top_left`, `top_right`, `bottom_left`, or `bottom_right`."
+  required: true
+  type: string
+travel_time:
+  description: How long the camera moves, in seconds, from 0 to 1.
+  required: false
+  type: float
+  default: 0.125
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="camera" %}
+
+## Good to know
+
+- This action only works with Foscam cameras that support pan, tilt, and zoom (PTZ).
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/foscam.ptz.markdown
+++ b/source/_actions/foscam.ptz.markdown
@@ -18,7 +18,7 @@ To move a camera from an automation or a script:
 3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
 4. In the **Then do** section, select **Add action**.
 5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Foscam camera you want to move.
-6. From the actions shown for that target, select **Foscam: PTZ move**.
+6. From the actions shown for that target, select **PTZ move**.
 7. Select the **Movement** direction, and optionally set the **Travel time**.
 8. Select **Save**.
 
@@ -46,7 +46,7 @@ action: |
     movement: up
 {% endexample %}
 
-This pans the camera upward.
+This tilts the camera upward.
 
 ### Options in YAML
 

--- a/source/_actions/foscam.ptz_preset.markdown
+++ b/source/_actions/foscam.ptz_preset.markdown
@@ -1,5 +1,5 @@
 ---
-title: "PTZ move to preset"
+title: "PTZ preset"
 action: foscam.ptz_preset
 domain: foscam
 description: "Moves a Foscam camera to a saved preset position."
@@ -18,7 +18,7 @@ To move a camera to a preset from an automation or a script:
 3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
 4. In the **Then do** section, select **Add action**.
 5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Foscam camera you want to move.
-6. From the actions shown for that target, select **PTZ move to preset**.
+6. From the actions shown for that target, select **PTZ preset**.
 7. Set the **Preset name** to move to.
 8. Select **Save**.
 

--- a/source/_actions/foscam.ptz_preset.markdown
+++ b/source/_actions/foscam.ptz_preset.markdown
@@ -1,0 +1,68 @@
+---
+title: "PTZ move to preset"
+action: foscam.ptz_preset
+domain: foscam
+description: "Moves a Foscam camera to a saved preset position."
+related_actions:
+  - foscam.ptz
+---
+
+Use this action to move a Foscam camera to a saved preset position from an automation or a script. This action is available for cameras that support pan, tilt, and zoom (PTZ) presets.
+
+{% include actions/ui_header.md %}
+
+To move a camera to a preset from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Foscam camera you want to move.
+6. From the actions shown for that target, select **Foscam: PTZ move to preset**.
+7. Set the **Preset name** to move to.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Preset name:
+  description: The name of the preset to move to. Presets can be created in the official Foscam apps.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `foscam.ptz_preset`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: foscam.ptz_preset
+  target:
+    entity_id: camera.bedroom
+  data:
+    preset_name: TopMost
+{% endexample %}
+
+This moves the camera to the `TopMost` preset.
+
+### Options in YAML
+
+{% options_yaml %}
+preset_name:
+  description: The name of the preset to move to. Presets can be created in the official Foscam apps.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="camera" %}
+
+## Good to know
+
+- This action only works with Foscam cameras that support pan, tilt, and zoom (PTZ) presets.
+- Create presets in the official Foscam apps before using this action.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/foscam.ptz_preset.markdown
+++ b/source/_actions/foscam.ptz_preset.markdown
@@ -18,7 +18,7 @@ To move a camera to a preset from an automation or a script:
 3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
 4. In the **Then do** section, select **Add action**.
 5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Foscam camera you want to move.
-6. From the actions shown for that target, select **Foscam: PTZ move to preset**.
+6. From the actions shown for that target, select **PTZ move to preset**.
 7. Set the **Preset name** to move to.
 8. Select **Save**.
 
@@ -40,7 +40,7 @@ action: |
   target:
     entity_id: camera.bedroom
   data:
-    preset_name: TopMost
+    preset_name: "TopMost"
 {% endexample %}
 
 This moves the camera to the `TopMost` preset.

--- a/source/_integrations/foscam.markdown
+++ b/source/_integrations/foscam.markdown
@@ -77,30 +77,11 @@ The Foscam integration provides the following entities.
   - **Description**: Adjust the device’s intercom volume.
   - **Available for machines**: all.
 
-#### Action `foscam.ptz`
-- **Control the device’s PTZ functions**
-  - **Description**: If your Foscam camera supports <abbr title="pan, tilt, and zoom">PTZ</abbr>, you will be able to pan or tilt your camera.
-    
-| Data attribute | Description |
-| -----------------------| ----------- |
-| `entity_id` | String or list of strings that point at `entity_id`s of cameras. Use `entity_id: all` to target all. |
-| `movement` | 	Direction of the movement. Allowed values: `up`, `down`, `left`, `right`, `top_left`, `top_right`, `bottom_left`, `bottom_right` |
-| `travel_time` | (Optional) Travel time in seconds. Allowed values: float from 0 to 1. Default: 0.125 |
+{% include integrations/actions.md %}
 
-- **Available for machines**: Devices with PTZ functionality.
+## Examples
 
-#### Action `foscam.ptz_preset`
-- **Direct the device to a specified preset position.**
-  - **Description**: If your Foscam camera supports <abbr title="pan, tilt, and zoom">PTZ</abbr> presets, you will be able to move the camera to a predefined          preset using the preset name.
-
-| Data attribute | Description |
-| -----------------------| ----------- |
-| `entity_id` | String or list of strings that point at `entity_id`s of cameras. Use `entity_id: all` to target all. |
-| `preset_name` | The name of the preset to move to. Presets can be created from within the official Foscam apps. |
-
-- **Available for machines**: Devices with PTZ functionality.
-
-#### Example card with controls
+### Example card with controls
 
 <p class='img'>
   <img src='/images/integrations/foscam/example-card.png' alt='Screenshot showing a foscam camera using a picture-elements with PTZ controls.'>
@@ -222,6 +203,6 @@ elements:
         movement: bottom_right
 ```
 
-### Extra CGI Commands
+## Extra CGI commands
 
 Foscam Webcams which support CGI Commands can be controlled by Home Assistant ([Source](https://community.jeedom.com/uploads/short-url/2A5aSBcCyoVZOdpiFC8HRDAOxqG.pdf)).


### PR DESCRIPTION
## Proposed change

Migrates the inline `foscam.ptz` and `foscam.ptz_preset` action documentation into dedicated action pages under `source/_actions/`, and replaces the inline sections on the integration page with the standard `{% include integrations/actions.md %}`.

The action pages document the movement, travel time, and preset name options, with both UI and YAML instructions. The options and defaults were verified against the integration's service schema. The picture-elements example card was kept and moved into a standard Examples section.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
