### PR TITLE
Google Sheets: migrate actions to dedicated pages

### DIFF
--- a/source/_actions/google_sheets.append_sheet.markdown
+++ b/source/_actions/google_sheets.append_sheet.markdown
@@ -1,0 +1,111 @@
+---
+title: "Append sheet"
+action: google_sheets.append_sheet
+domain: google_sheets
+description: "Adds rows of data to a Google Sheets document."
+related_actions:
+  - google_sheets.get_sheet
+---
+
+Use this action to add rows of data to the Google Sheets document that was created when you set up the integration. This is handy for storing data from Home Assistant for further processing, for example logging energy usage over time.
+
+{% include actions/ui_header.md %}
+
+To append data from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Google Sheets: Append sheet**.
+6. Select the **Config entry** for the document you want to add to.
+7. Optionally, set the **Worksheet** and whether to add a **Created** column.
+8. Set the **Data** to append.
+9. Select **Save**.
+
+This action does not support targets. You select the document through the **Config entry** field instead of choosing an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Config entry:
+  description: The Google Sheets document to add to.
+  required: true
+Worksheet:
+  description: The name of the worksheet. Defaults to the first worksheet in the document.
+  required: false
+Add created column:
+  description: "Whether to add a `created` column with the date and time to the appended data."
+  required: false
+Data:
+  description: The data to append to the worksheet. Each value is placed on a new row, one value per column.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `google_sheets.append_sheet`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: google_sheets.append_sheet
+  data:
+    config_entry: 1b4a46c6cba0677bbfb5a8c53e8618b0
+    worksheet: "Car Charging"
+    add_created_column: false
+    data:
+      Date: "{{ now().strftime('%-d-%b-%y') }}"
+      KWh: "{{ states('input_number.car_charging_kwh') | float(0) }}"
+      Cost: "{{ states('input_number.car_charging_cost') | float(0) }}"
+{% endexample %}
+
+This appends a single row with the date, energy, and cost.
+
+### Options in YAML
+
+{% options_yaml %}
+config_entry:
+  description: The Google Sheets document to add to.
+  required: true
+  type: string
+worksheet:
+  description: The name of the worksheet. Defaults to the first worksheet in the document.
+  required: false
+  type: string
+add_created_column:
+  description: "Whether to add a `created` column with the date and time to the appended data."
+  required: false
+  type: boolean
+  default: true
+data:
+  description: The data to append to the worksheet. Each value is placed on a new row, one value per column.
+  required: true
+  type: map
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+### Automation: append multiple rows at once
+
+You can append more than one row in a single call by passing a list of mappings as the data.
+
+{% details "YAML example for appending multiple rows" %}
+
+{% example %}
+action: |
+  action: google_sheets.append_sheet
+  data:
+    config_entry: 1b4a46c6cba0677bbfb5a8c53e8618b0
+    worksheet: "Car Charging"
+    data:
+      - Item: "Car 1 cost"
+        Cost: "{{ states('input_number.car_1_charging_cost') | float(0) }}"
+      - Item: "Car 2 cost"
+        Cost: "{{ states('input_number.car_2_charging_cost') | float(0) }}"
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/google_sheets.append_sheet.markdown
+++ b/source/_actions/google_sheets.append_sheet.markdown
@@ -7,7 +7,7 @@ related_actions:
   - google_sheets.get_sheet
 ---
 
-Use this action to add rows of data to the Google Sheets document that was created when you set up the integration. This is handy for storing data from Home Assistant for further processing, for example logging energy usage over time.
+Use this action to add rows of data to the Google Sheets document that was created when you set up the integration. This is handy for storing data from Home Assistant for further processing, for example, logging energy usage over time.
 
 {% include actions/ui_header.md %}
 
@@ -38,7 +38,7 @@ Add created column:
   description: "Whether to add a `created` column with the date and time to the appended data."
   required: false
 Data:
-  description: The data to append to the worksheet. Each value is placed on a new row, one value per column.
+  description: The data to append. Provide a mapping for a single row, or a list of mappings for multiple rows. Each mapping key becomes a column name.
   required: true
 {% endoptions_ui %}
 
@@ -78,7 +78,7 @@ add_created_column:
   type: boolean
   default: true
 data:
-  description: The data to append to the worksheet. Each value is placed on a new row, one value per column.
+  description: The data to append. Provide a mapping for a single row, or a list of mappings for multiple rows. Each mapping key becomes a column name.
   required: true
   type: map
 {% endoptions_yaml %}

--- a/source/_actions/google_sheets.append_sheet.markdown
+++ b/source/_actions/google_sheets.append_sheet.markdown
@@ -18,7 +18,7 @@ To append data from an automation or a script:
 3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
 4. In the **Then do** section, select **Add action**.
 5. From the search box, search for and select **Google Sheets: Append sheet**.
-6. Select the **Config entry** for the document you want to add to.
+6. Under **Integration**, select the **Sheet** you want to add to.
 7. Optionally, set the **Worksheet** and whether to add a **Created** column.
 8. Set the **Data** to append.
 9. Select **Save**.

--- a/source/_actions/google_sheets.get_sheet.markdown
+++ b/source/_actions/google_sheets.get_sheet.markdown
@@ -18,10 +18,11 @@ To get data from an automation or a script:
 3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
 4. In the **Then do** section, select **Add action**.
 5. From the search box, search for and select **Google Sheets: Get sheet**.
-6. Select the **Config entry** for the document you want to read from.
+6. Under **Integration**, select the **Sheet** you want to read from.
 7. Optionally, set the **Worksheet**.
 8. Set the number of **Rows** to return.
-9. Select **Save**.
+9. In the **Response variable** field, enter a name to store the data in, such as `sheet_data`.
+10. Select **Save**.``
 
 This action does not support targets. You select the document through the **Config entry** field instead of choosing an area, device, entity, or label.
 

--- a/source/_actions/google_sheets.get_sheet.markdown
+++ b/source/_actions/google_sheets.get_sheet.markdown
@@ -1,0 +1,91 @@
+---
+title: "Get sheet"
+action: google_sheets.get_sheet
+domain: google_sheets
+description: "Retrieves rows of data from a Google Sheets document."
+related_actions:
+  - google_sheets.append_sheet
+---
+
+Use this action to retrieve rows of data from a Google Sheets document, for example to read back values you stored earlier. This action returns [response data](/docs/scripts/perform-actions/#use-templates-to-handle-response-data) that you can use in the rest of your automation or script.
+
+{% include actions/ui_header.md %}
+
+To get data from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Google Sheets: Get sheet**.
+6. Select the **Config entry** for the document you want to read from.
+7. Optionally, set the **Worksheet**.
+8. Set the number of **Rows** to return.
+9. Select **Save**.
+
+This action does not support targets. You select the document through the **Config entry** field instead of choosing an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Config entry:
+  description: The Google Sheets document to read from.
+  required: true
+Worksheet:
+  description: The name of the worksheet. Defaults to the first worksheet in the document.
+  required: false
+Rows:
+  description: The number of rows to return, counted from the end of the worksheet.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `google_sheets.get_sheet`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: google_sheets.get_sheet
+  data:
+    config_entry: 1b4a46c6cba0677bbfb5a8c53e8618b0
+    worksheet: "Car Charging"
+    rows: 2
+  response_variable: sheet_data
+{% endexample %}
+
+This returns the last two rows from the `Car Charging` worksheet.
+
+### Options in YAML
+
+{% options_yaml %}
+config_entry:
+  description: The Google Sheets document to read from.
+  required: true
+  type: string
+worksheet:
+  description: The name of the worksheet. Defaults to the first worksheet in the document.
+  required: false
+  type: string
+rows:
+  description: The number of rows to return, counted from the end of the worksheet.
+  required: true
+  type: integer
+{% endoptions_yaml %}
+
+## Response data
+
+The action returns a `range` with the requested rows. Each row is a list of cell values.
+
+```yaml
+range:
+  - - 04/07/2024
+    - 9 Kw
+  - - 05/07/2024
+    - 8 Kw
+```
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/google_sheets.get_sheet.markdown
+++ b/source/_actions/google_sheets.get_sheet.markdown
@@ -7,7 +7,7 @@ related_actions:
   - google_sheets.append_sheet
 ---
 
-Use this action to retrieve rows of data from a Google Sheets document, for example to read back values you stored earlier. This action returns [response data](/docs/scripts/perform-actions/#use-templates-to-handle-response-data) that you can use in the rest of your automation or script.
+Use this action to retrieve rows of data from a Google Sheets document, for example, to read back values you stored earlier. This action returns [response data](/docs/scripts/perform-actions/#use-templates-to-handle-response-data) that you can use in the rest of your automation or script.
 
 {% include actions/ui_header.md %}
 

--- a/source/_actions/google_sheets.get_sheet.markdown
+++ b/source/_actions/google_sheets.get_sheet.markdown
@@ -19,7 +19,7 @@ To get data from an automation or a script:
 4. In the **Then do** section, select **Add action**.
 5. From the search box, search for and select **Google Sheets: Get sheet**.
 6. Under **Integration**, select the **Sheet** you want to read from.
-7. Optionally, set the **Worksheet**.
+7. Optionally, set a name for the **Worksheet**. Defaults to the first one in the document.
 8. Set the number of **Rows** to return.
 9. In the **Response variable** field, enter a name to store the data in, such as `sheet_data`.
 10. Select **Save**.``

--- a/source/_integrations/google_sheets.markdown
+++ b/source/_integrations/google_sheets.markdown
@@ -35,6 +35,8 @@ These are not the same as *Device Auth* credentials previously recommended for [
 
 {% include integrations/google_oauth.md %}
 
+{% include integrations/actions.md %}
+
 ## Troubleshooting
 
 If you have an error with your credentials you can delete them in the [Application Credentials](/integrations/application_credentials/) user interface.
@@ -44,79 +46,3 @@ If you have an error with your credentials you can delete them in the [Applicati
 This video tutorial explains how to set up the Google Sheets integration and how you can add data from Home Assistant to a Google Sheet.
 
 <lite-youtube videoid="hgGMgoxLYwo" videotitle="How to use Google Sheets in Home Assistant - TUTORIAL" posterquality="maxresdefault"></lite-youtube>
-
-### Action: Append sheet
-
-The `google_sheets.append_sheet` action allows you to add rows of data to the Sheets document created at setup.
-
-{% details "Create event action details" %}
-
-| Data attribute | Optional | Description | Example |
-| ---------------------- | -------- | ----------- | --------|
-| `config_entry` | no | Config entry to use. |
-| `worksheet` | yes | Name of the worksheet. Defaults to the first one in the document. | Sheet1 |
-| `add_created_column` | yes | Add `created` column containing date-time to the data being appended. Defaults to True. | True |
-| `data` | no | Data to be appended to the worksheet. This puts the data on new rows, one value per column. | {"hello": world, "cool": True, "count": 5} |
-
-```yaml
-# Example action
-action: google_sheets.append_sheet
-data:
-  config_entry: 1b4a46c6cba0677bbfb5a8c53e8618b0
-  worksheet: "Car Charging"
-  add_created_column: false
-  data:
-    Date: "{{ now().strftime('%-d-%b-%y') }}"
-    KWh: "{{ states('input_number.car_charging_kwh')|float(0) }}"
-    Cost: "{{ states('input_number.car_charging_cost')|float(0) }}"
-
-# Example action with multiple rows
-action: google_sheets.append_sheet
-data:
-  config_entry: 1b4a46c6cba0677bbfb5a8c53e8618b0
-  worksheet: "Car Charging"
-  data:
-    - Item: "Car 1 cost"
-      Cost: "{{ states('input_number.car_1_charging_cost')|float(0) }}"
-    - Item: "Car 2 cost"
-      Cost: "{{ states('input_number.car_2_charging_cost')|float(0) }}"
-```
-
-{% enddetails %}
-
-
-### Action: Get sheet
-
-You can use the `google_sheets.get_sheet` action to retrieve rows of [data](/docs/scripts/perform-actions#use-templates-to-handle-response-data) from a Sheets document.
-
-{% details "Create event action details" %}
-
-| Data attribute | Optional | Description | Example |
-| ---------------------- | -------- | ----------- | --------|
-| `config_entry` | no | Config entry to use. |
-| `worksheet` | yes | Name of the worksheet. Defaults to the first one in the document. | Sheet1 |
-| `rows` | no | Maximum number of rows from the end of the worksheet to return.  | 2 |
-
-```yaml
-# Example action
-action: google_sheets.get_sheet
-data:
-  config_entry: 1b4a46c6cba0677bbfb5a8c53e8618b0
-  worksheet: "Car Charging"
-  rows: 2
-```
-
-{% enddetails %}
-
-
-{% details "Example action response" %}
-
-```yaml
-range:
-  - - 04/07/2024
-    - 9 Kw
-  - - 05/07/2024
-    - 8 Kw
-```
-
-{% enddetails %}


### PR DESCRIPTION
## Proposed change

Migrates the inline `google_sheets.append_sheet` and `google_sheets.get_sheet` action documentation into dedicated action pages under `source/_actions/`, and replaces the inline sections on the integration page with the standard `{% include integrations/actions.md %}`.

The action pages document the config entry, worksheet, and other options with both UI and YAML instructions, and `get_sheet` documents its response data. The options and defaults were verified against the integration's service schema. The existing examples were carried over.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
