### PR TITLE
Channels: migrate seek actions to dedicated pages

### DIFF
--- a/source/_actions/channels.seek_backward.markdown
+++ b/source/_actions/channels.seek_backward.markdown
@@ -1,5 +1,5 @@
 ---
-title: "Channels: Seek backward"
+title: "Seek backward"
 action: channels.seek_backward
 domain: channels
 description: "Seeks backward by the number of seconds set in the Channels app."
@@ -19,7 +19,7 @@ To seek backward from an automation or a script:
 3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
 4. In the **Then do** section, select **Add action**.
 5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Channels media player you want to control.
-6. From the actions shown for that target, select **Channels: Seek backward**.
+6. From the actions shown for that target, select **Seek backward**.
 7. Select **Save**.
 
 ### Options in the UI

--- a/source/_actions/channels.seek_backward.markdown
+++ b/source/_actions/channels.seek_backward.markdown
@@ -1,0 +1,52 @@
+---
+title: "Channels: Seek backward"
+action: channels.seek_backward
+domain: channels
+description: "Seeks backward by the number of seconds set in the Channels app."
+related_actions:
+  - channels.seek_forward
+  - channels.seek_by
+---
+
+Use this action to jump backward in what is currently playing on a Channels app. The amount of time it seeks is the number of seconds set in the settings on that instance of Channels.
+
+{% include actions/ui_header.md %}
+
+To seek backward from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Channels media player you want to control.
+6. From the actions shown for that target, select **Channels: Seek backward**.
+7. Select **Save**.
+
+### Options in the UI
+
+This action has no additional options beyond the target.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `channels.seek_backward`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: channels.seek_backward
+  target:
+    entity_id: media_player.family_room_channels
+{% endexample %}
+
+This seeks backward on `media_player.family_room_channels`.
+
+### Options in YAML
+
+This action has no additional YAML options beyond the target.
+
+{% include actions/targets.md domain="media_player" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/channels.seek_by.markdown
+++ b/source/_actions/channels.seek_by.markdown
@@ -1,0 +1,64 @@
+---
+title: "Channels: Seek by"
+action: channels.seek_by
+domain: channels
+description: "Seeks forward or backward by a number of seconds."
+related_actions:
+  - channels.seek_forward
+  - channels.seek_backward
+---
+
+Use this action to jump forward or backward in what is currently playing on a Channels app by a number of seconds that you choose. A positive value seeks forward, and a negative value seeks backward.
+
+{% include actions/ui_header.md %}
+
+To seek by a number of seconds from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Channels media player you want to control.
+6. From the actions shown for that target, select **Channels: Seek by**.
+7. Set **Seconds** to the number of seconds you want to seek by.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Seconds:
+  description: The number of seconds to seek by. Use a negative value to seek backward.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `channels.seek_by`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: channels.seek_by
+  target:
+    entity_id: media_player.family_room_channels
+  data:
+    seconds: 30
+{% endexample %}
+
+This seeks 30 seconds forward on `media_player.family_room_channels`. To seek backward, use a negative value such as `-30`.
+
+### Options in YAML
+
+{% options_yaml %}
+seconds:
+  description: The number of seconds to seek by. Use a negative value to seek backward.
+  required: true
+  type: integer
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="media_player" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/channels.seek_by.markdown
+++ b/source/_actions/channels.seek_by.markdown
@@ -1,5 +1,5 @@
 ---
-title: "Channels: Seek by"
+title: "Seek by"
 action: channels.seek_by
 domain: channels
 description: "Seeks forward or backward by a number of seconds."
@@ -19,7 +19,7 @@ To seek by a number of seconds from an automation or a script:
 3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
 4. In the **Then do** section, select **Add action**.
 5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Channels media player you want to control.
-6. From the actions shown for that target, select **Channels: Seek by**.
+6. From the actions shown for that target, select **Seek by**.
 7. Set **Seconds** to the number of seconds you want to seek by.
 8. Select **Save**.
 

--- a/source/_actions/channels.seek_forward.markdown
+++ b/source/_actions/channels.seek_forward.markdown
@@ -1,5 +1,5 @@
 ---
-title: "Channels: Seek forward"
+title: "Seek forward"
 action: channels.seek_forward
 domain: channels
 description: "Seeks forward by the number of seconds set in the Channels app."
@@ -19,7 +19,7 @@ To seek forward from an automation or a script:
 3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
 4. In the **Then do** section, select **Add action**.
 5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Channels media player you want to control.
-6. From the actions shown for that target, select **Channels: Seek forward**.
+6. From the actions shown for that target, select **Seek forward**.
 7. Select **Save**.
 
 ### Options in the UI

--- a/source/_actions/channels.seek_forward.markdown
+++ b/source/_actions/channels.seek_forward.markdown
@@ -1,0 +1,52 @@
+---
+title: "Channels: Seek forward"
+action: channels.seek_forward
+domain: channels
+description: "Seeks forward by the number of seconds set in the Channels app."
+related_actions:
+  - channels.seek_backward
+  - channels.seek_by
+---
+
+Use this action to jump forward in what is currently playing on a Channels app. The amount of time it seeks is the number of seconds set in the settings on that instance of Channels.
+
+{% include actions/ui_header.md %}
+
+To seek forward from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Channels media player you want to control.
+6. From the actions shown for that target, select **Channels: Seek forward**.
+7. Select **Save**.
+
+### Options in the UI
+
+This action has no additional options beyond the target.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `channels.seek_forward`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: channels.seek_forward
+  target:
+    entity_id: media_player.family_room_channels
+{% endexample %}
+
+This seeks forward on `media_player.family_room_channels`.
+
+### Options in YAML
+
+This action has no additional YAML options beyond the target.
+
+{% include actions/targets.md domain="media_player" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/channels.markdown
+++ b/source/_integrations/channels.markdown
@@ -49,27 +49,4 @@ name:
   type: string
 {% endconfiguration %}
 
-### Action `seek_forward`
-
-Seek forward by the number of seconds currently set in settings on the instance of Channels.
-
-| Data attribute | Optional | Description                                        |
-| ---------------------- | -------- | -------------------------------------------------- |
-| `entity_id`            | no       | String that points at `entity_id` of Channels app. |
-
-### Action `seek_backward`
-
-Seek backward by the number of seconds currently set in settings on the instance of Channels.
-
-| Data attribute | Optional | Description                                        |
-| ---------------------- | -------- | -------------------------------------------------- |
-| `entity_id`            | no       | String that points at `entity_id` of Channels app. |
-
-### Action `seek_by`
-
-Seek forward or backward by a provided number of seconds.
-
-| Data attribute | Optional | Description                                                                     |
-| ---------------------- | -------- | ------------------------------------------------------------------------------- |
-| `entity_id`            | no       | String that points at `entity_id` of Channels app.                              |
-| `seconds`              | no       | Number of seconds to seek in the timeline by. Negative seconds seeks backwards. |
+{% include integrations/actions.md %}


### PR DESCRIPTION
## Proposed change

Migrates the inline `seek_forward`, `seek_backward`, and `seek_by` action documentation on the Channels integration page to dedicated action pages under `source/_actions/`, and replaces the inline blocks with the shared `{% include integrations/actions.md %}` snippet.

Field and action details were verified against the integration's voluptuous schemas in core: `seek_forward` and `seek_backward` take no fields, and `seek_by` requires a `seconds` value (a negative value seeks backward).

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
