### PR TITLE
Belkin WeMo: migrate humidifier actions to dedicated pages

### DIFF
--- a/source/_actions/wemo.reset_filter_life.markdown
+++ b/source/_actions/wemo.reset_filter_life.markdown
@@ -1,0 +1,55 @@
+---
+title: "Belkin WeMo: Reset filter life"
+action: wemo.reset_filter_life
+domain: wemo
+description: "Resets the filter life of a WeMo humidifier to 100%."
+related_actions:
+  - wemo.set_humidity
+---
+
+Use this action to reset the filter lifetime of a Belkin WeMo (Holmes) Smart Humidifier back to 100%. Run it after you replace the filter on your humidifier.
+
+{% include actions/ui_header.md %}
+
+To reset the filter life from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the humidifier you want to control.
+6. From the actions shown for that target, select **Belkin WeMo: Reset filter life**.
+7. Select **Save**.
+
+### Options in the UI
+
+This action has no additional options beyond the target.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `wemo.reset_filter_life`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: wemo.reset_filter_life
+  target:
+    entity_id: fan.bedroom_humidifier
+{% endexample %}
+
+This resets the filter life of `fan.bedroom_humidifier` to 100%.
+
+### Options in YAML
+
+This action has no additional YAML options beyond the target.
+
+{% include actions/targets.md domain="fan" %}
+
+## Good to know
+
+- Run this action only after you physically replace the filter, so the reported filter life stays accurate.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/wemo.reset_filter_life.markdown
+++ b/source/_actions/wemo.reset_filter_life.markdown
@@ -1,5 +1,5 @@
 ---
-title: "Belkin WeMo: Reset filter life"
+title: "Reset filter life"
 action: wemo.reset_filter_life
 domain: wemo
 description: "Resets the filter life of a WeMo humidifier to 100%."

--- a/source/_actions/wemo.set_humidity.markdown
+++ b/source/_actions/wemo.set_humidity.markdown
@@ -1,5 +1,5 @@
 ---
-title: "Belkin WeMo: Set humidity"
+title: "Set target humidity"
 action: wemo.set_humidity
 domain: wemo
 description: "Sets the target humidity on a WeMo humidifier."

--- a/source/_actions/wemo.set_humidity.markdown
+++ b/source/_actions/wemo.set_humidity.markdown
@@ -1,0 +1,67 @@
+---
+title: "Belkin WeMo: Set humidity"
+action: wemo.set_humidity
+domain: wemo
+description: "Sets the target humidity on a WeMo humidifier."
+related_actions:
+  - wemo.reset_filter_life
+---
+
+Use this action to set the target relative humidity on a Belkin WeMo (Holmes) Smart Humidifier.
+
+{% include actions/ui_header.md %}
+
+To set the target humidity from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the humidifier you want to control.
+6. From the actions shown for that target, select **Belkin WeMo: Set humidity**.
+7. Set **Target humidity** to the relative humidity you want.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Target humidity:
+  description: The target relative humidity as a percentage. The value is rounded down and mapped to one of the humidity settings the WeMo humidifier supports (45, 50, 55, 60, or 100).
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `wemo.set_humidity`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: wemo.set_humidity
+  target:
+    entity_id: fan.bedroom_humidifier
+  data:
+    target_humidity: 55
+{% endexample %}
+
+This sets the target humidity of `fan.bedroom_humidifier` to 55%.
+
+### Options in YAML
+
+{% options_yaml %}
+target_humidity:
+  description: The target relative humidity as a percentage. The value is rounded down and mapped to one of the humidity settings the WeMo humidifier supports (45, 50, 55, 60, or 100).
+  required: true
+  type: float
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="fan" %}
+
+## Good to know
+
+- The WeMo humidifier only supports the humidity settings 45, 50, 55, 60, and 100. Any other value you set is rounded down to the nearest supported setting.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/wemo.markdown
+++ b/source/_integrations/wemo.markdown
@@ -122,18 +122,9 @@ There are several attributes which can be used for automations and templates:
 | `target_humidity` | An integer that indicates the desired relative humidity percentage (this is constrained to the humidity settings of the device, which are 45, 50, 55, 60, and 100).
 | `water level` | String that indicates whether the water level is Good, Low, or Empty.
 
-### Actions
+You can control the humidifier with the standard fan actions, such as turning it on or off and setting its speed. When you set the fan speed, the speed `low` maps to the WeMo humidifier speed of minimum, and `high` maps to maximum. The WeMo humidifier speeds of low and high are unused, because of the fan speeds that Home Assistant supports.
 
-There are several actions which can be used for automations and control of the humidifier:
-
-| Action | Description |
-| --------- | ----------- |
-| `set_speed` | Performing this action sets the fan speed (entity_id and speed are required parameters, and speed must be one of the following: off, low, medium, or high). When selecting low for the speed, this will map to the WeMo humidifier speed of minimum. When selecting high for the speed, this will map to the WeMo humidifier speed of maximum. The WeMo humidifier speeds of low and high are unused due to constraints on which fan speeds Home Assistant supports.
-| `toggle` | Performing this action will toggle the humidifier between on and off states.
-| `turn_off` | Performing this action will turn the humidifier off (entity_id is required).
-| `turn_on` | Performing this action will turn the humidifier on and set the speed to the last used speed (defaults to medium, entity_id is required).
-| `wemo.set_humidity` | Performing this action will set the desired relative humidity setting on the device (entity_id is a required list of 1 or more entities to set humidity on, and target_humidity is a required float value between 0 and 100 (this value will be rounded down and mapped to one of the valid desired humidity settings of 45, 50, 55, 60, or 100 that are supported by the WeMo humidifier)).
-| `wemo.reset_filter_life` | Performing this action will reset the humdifier's filter lifetime back to 100% (entity_id is a required list of 1 or more entities to reset the filter lifetime on). Call this action when you change the filter on your humidifier.
+{% include integrations/actions.md %}
 
 ## Long press events and triggers
 


### PR DESCRIPTION
## Proposed change

Migrates the WeMo-specific humidifier action documentation (`wemo.set_humidity` and `wemo.reset_filter_life`) from the Belkin WeMo integration page into dedicated action pages under `source/_actions/`, and replaces the inline block with the shared `{% include integrations/actions.md %}` snippet.

The inline table also listed the generic fan platform actions (`set_speed`, `toggle`, `turn_off`, `turn_on`). Those are documented with the fan platform, so I kept only the WeMo-specific speed-mapping note as prose and dropped the duplicated generic rows. Field details were verified against the integration's voluptuous schema in core: `set_humidity` requires a `target_humidity` float (rounded down to a supported setting), and `reset_filter_life` takes no fields.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
