### PR TITLE
Genius Hub: migrate actions to dedicated pages

### DIFF
--- a/source/_actions/geniushub.set_switch_override.markdown
+++ b/source/_actions/geniushub.set_switch_override.markdown
@@ -1,0 +1,65 @@
+---
+title: "Genius Hub: Set switch override"
+action: geniushub.set_switch_override
+domain: geniushub
+description: "Turns on a Genius Hub switch for a set duration."
+related_actions:
+  - geniushub.set_zone_mode
+  - geniushub.set_zone_override
+---
+
+Use this action to turn on a Genius Hub switch for a set duration, up to 24 hours. After the duration passes, the switch returns to its scheduled behavior.
+
+{% include actions/ui_header.md %}
+
+To override a switch from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the switch you want to override.
+6. From the actions shown for that target, select **Genius Hub: Set switch override**.
+7. Optionally set a **Duration**.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Duration:
+  description: How long the override stays active, between 5 minutes and 24 hours. If you leave this empty, the override lasts 1 hour.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `geniushub.set_switch_override`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: geniushub.set_switch_override
+  target:
+    entity_id: switch.smart_plug
+  data:
+    duration:
+      minutes: 135
+{% endexample %}
+
+This turns on `switch.smart_plug` for 2 hours and 15 minutes.
+
+### Options in YAML
+
+{% options_yaml %}
+duration:
+  description: How long the override stays active, given as a time mapping such as `minutes: 135`. The value must be between 5 minutes and 24 hours. If you omit it, the override lasts 1 hour.
+  required: false
+  type: map
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="switch" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/geniushub.set_switch_override.markdown
+++ b/source/_actions/geniushub.set_switch_override.markdown
@@ -51,7 +51,7 @@ This turns on `switch.smart_plug` for 2 hours and 15 minutes.
 
 {% options_yaml %}
 duration:
-  description: How long the override stays active, given as a time mapping such as `minutes: 135`. The value must be between 5 minutes and 24 hours. If you omit it, the override lasts 1 hour.
+  description: "How long the override stays active, given as a time mapping such as `minutes: 135`. The value must be between 5 minutes and 24 hours. If you omit it, the override lasts 1 hour."
   required: false
   type: map
 {% endoptions_yaml %}

--- a/source/_actions/geniushub.set_switch_override.markdown
+++ b/source/_actions/geniushub.set_switch_override.markdown
@@ -1,5 +1,5 @@
 ---
-title: "Genius Hub: Set switch override"
+title: "Set switch override"
 action: geniushub.set_switch_override
 domain: geniushub
 description: "Turns on a Genius Hub switch for a set duration."

--- a/source/_actions/geniushub.set_zone_mode.markdown
+++ b/source/_actions/geniushub.set_zone_mode.markdown
@@ -1,5 +1,5 @@
 ---
-title: "Genius Hub: Set zone mode"
+title: "Set zone mode"
 action: geniushub.set_zone_mode
 domain: geniushub
 description: "Changes the mode of a Genius Hub zone."

--- a/source/_actions/geniushub.set_zone_mode.markdown
+++ b/source/_actions/geniushub.set_zone_mode.markdown
@@ -1,0 +1,71 @@
+---
+title: "Genius Hub: Set zone mode"
+action: geniushub.set_zone_mode
+domain: geniushub
+description: "Changes the mode of a Genius Hub zone."
+related_actions:
+  - geniushub.set_zone_override
+  - geniushub.set_switch_override
+---
+
+Use this action to change a Genius Hub zone to one of its modes. This exposes modes that are not available through the standard climate controls, such as **Footprint** mode.
+
+{% include actions/ui_header.md %}
+
+To set a zone mode from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Genius Hub: Set zone mode**.
+6. Select the **Entity** for the zone you want to change, and set the **Mode**.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label. The zone is selected through the **Entity** option instead.
+
+### Options in the UI
+
+{% options_ui %}
+Entity:
+  description: The climate entity of the zone you want to change.
+  required: true
+Mode:
+  description: "The mode to set the zone to: `off`, `timer`, or `footprint`. Footprint mode is only available for radiator zones that have room sensors."
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `geniushub.set_zone_mode`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: geniushub.set_zone_mode
+  data:
+    entity_id: climate.kitchen
+    mode: footprint
+{% endexample %}
+
+This sets the `climate.kitchen` zone to footprint mode.
+
+### Options in YAML
+
+{% options_yaml %}
+entity_id:
+  description: The climate entity of the zone you want to change.
+  required: true
+  type: string
+mode:
+  description: "The mode to set the zone to: `off`, `timer`, or `footprint`. Footprint mode is only available for radiator zones that have room sensors."
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+This action does not support targets.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/geniushub.set_zone_override.markdown
+++ b/source/_actions/geniushub.set_zone_override.markdown
@@ -1,0 +1,80 @@
+---
+title: "Genius Hub: Set zone override"
+action: geniushub.set_zone_override
+domain: geniushub
+description: "Overrides the setpoint of a Genius Hub zone for a set duration."
+related_actions:
+  - geniushub.set_zone_mode
+  - geniushub.set_switch_override
+---
+
+Use this action to override the setpoint of a Genius Hub zone for a set duration, up to 24 hours. After the duration passes, the zone returns to its scheduled behavior.
+
+{% include actions/ui_header.md %}
+
+To override a zone setpoint from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Genius Hub: Set zone override**.
+6. Select the **Entity** for the zone, set the **Temperature**, and optionally set a **Duration**.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label. The zone is selected through the **Entity** option instead.
+
+### Options in the UI
+
+{% options_ui %}
+Entity:
+  description: The climate entity of the zone you want to override.
+  required: true
+Temperature:
+  description: The setpoint temperature to override the zone to.
+  required: true
+Duration:
+  description: How long the override stays active, between 5 minutes and 24 hours. If you leave this empty, the override lasts 1 hour.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `geniushub.set_zone_override`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: geniushub.set_zone_override
+  data:
+    entity_id: climate.kitchen
+    temperature: 20
+    duration:
+      minutes: 135
+{% endexample %}
+
+This overrides the `climate.kitchen` zone to 20° for 2 hours and 15 minutes.
+
+### Options in YAML
+
+{% options_yaml %}
+entity_id:
+  description: The climate entity of the zone you want to override.
+  required: true
+  type: string
+temperature:
+  description: The setpoint temperature to override the zone to, between 4 and 28.
+  required: true
+  type: float
+duration:
+  description: How long the override stays active, given as a time mapping such as `minutes: 135`. The value must be between 5 minutes and 24 hours. If you omit it, the override lasts 1 hour.
+  required: false
+  type: map
+{% endoptions_yaml %}
+
+This action does not support targets.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/geniushub.set_zone_override.markdown
+++ b/source/_actions/geniushub.set_zone_override.markdown
@@ -66,7 +66,7 @@ temperature:
   required: true
   type: float
 duration:
-  description: How long the override stays active, given as a time mapping such as `minutes: 135`. The value must be between 5 minutes and 24 hours. If you omit it, the override lasts 1 hour.
+  description: "How long the override stays active, given as a time mapping such as `minutes: 135`. The value must be between 5 minutes and 24 hours. If you omit it, the override lasts 1 hour."
   required: false
   type: map
 {% endoptions_yaml %}

--- a/source/_actions/geniushub.set_zone_override.markdown
+++ b/source/_actions/geniushub.set_zone_override.markdown
@@ -1,5 +1,5 @@
 ---
-title: "Genius Hub: Set zone override"
+title: "Set zone override"
 action: geniushub.set_zone_override
 domain: geniushub
 description: "Overrides the setpoint of a Genius Hub zone for a set duration."

--- a/source/_integrations/geniushub.markdown
+++ b/source/_integrations/geniushub.markdown
@@ -51,13 +51,7 @@ Currently, there is no support for altering zone schedules, although entities ca
 
 There are limitations due to the differences between the Genius Hub and Home Assistant schemas (for example, Home Assistant has no **Footprint** mode) - use the actions below, for this functionality.
 
-### Action handlers
-
-Home Assistant is obligated to place restrictions upon integrations such as **geniushub** to maintain compatibility with other ecosystems (e.g.,  Google Home) and so not all of the **geniushub** functionality is available via the web UI. Some of this missing functionality is exposed via integration-specific actions:
-
-- `set_switch_override`: change the switches on time _for a specified duration_ (up to 24h),
-- `set_zone_override`: change the zone's setpoint _for a specified duration_ (up to 24h), and
-- `set_zone_mode`: change the zone's mode to one of `off`, `timer` or (if supported by the zone) `footprint`
+Not all Genius Hub functionality is available through the standard Home Assistant controls, so some of it is exposed through integration-specific actions. These let you change a zone's mode (including **Footprint** mode), override a zone's setpoint for a set duration, and override a switch for a set duration. For details, see the list of actions below.
 
 ### Climate and water heater entities
 
@@ -128,6 +122,8 @@ This alert may be useful to see if the CH is being turned on while you're on a h
           {{ trigger.to_state.attributes.friendly_name }} has changed
           from {{ trigger.from_state.state }} to {{ trigger.to_state.state }}.
 ```
+
+{% include integrations/actions.md %}
 
 ## State attributes
 


### PR DESCRIPTION
## Proposed change

Migrates the three Genius Hub integration-specific actions (`set_zone_mode`, `set_zone_override`, and `set_switch_override`) into dedicated action pages under `source/_actions/`, and replaces the inline `### Action handlers` block with the shared `{% include integrations/actions.md %}` snippet.

The original page only listed the action names in a short bullet list with no field details. The new pages document each field, verified against the integration's voluptuous schemas in core: `set_zone_mode` (zone entity + mode), `set_zone_override` (zone entity + temperature + optional duration), and `set_switch_override` (switch target + optional duration). `set_zone_mode` and `set_zone_override` are registered at the domain level, so the zone is selected through an entity field rather than a target.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
