### PR TITLE
Yamaha: migrate actions to dedicated pages

### DIFF
--- a/source/_actions/yamaha.enable_output.markdown
+++ b/source/_actions/yamaha.enable_output.markdown
@@ -1,0 +1,73 @@
+---
+title: "Yamaha: Enable output"
+action: yamaha.enable_output
+domain: yamaha
+description: "Enables or disables an output port on a Yamaha receiver."
+related_actions:
+  - yamaha.menu_cursor
+  - yamaha.select_scene
+---
+
+Use this action to enable or disable an output port, such as an HDMI port, on a Yamaha receiver.
+
+{% include actions/ui_header.md %}
+
+To enable or disable an output from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the receiver you want to control.
+6. From the actions shown for that target, select **Yamaha: Enable output**.
+7. Set the **Port** and turn **Enabled** on or off.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Port:
+  description: The output port to enable or disable, for example `hdmi1`.
+  required: true
+Enabled:
+  description: Turn on to enable the port, turn off to disable it.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `yamaha.enable_output`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: yamaha.enable_output
+  target:
+    entity_id: media_player.living_room_stereo
+  data:
+    port: hdmi1
+    enabled: true
+{% endexample %}
+
+This enables the `hdmi1` output on `media_player.living_room_stereo`.
+
+### Options in YAML
+
+{% options_yaml %}
+port:
+  description: The output port to enable or disable, for example `hdmi1`.
+  required: true
+  type: string
+enabled:
+  description: Set to `true` to enable the port, or `false` to disable it.
+  required: true
+  type: boolean
+  default: false
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="media_player" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/yamaha.enable_output.markdown
+++ b/source/_actions/yamaha.enable_output.markdown
@@ -1,5 +1,5 @@
 ---
-title: "Yamaha: Enable output"
+title: "Enable output"
 action: yamaha.enable_output
 domain: yamaha
 description: "Enables or disables an output port on a Yamaha receiver."

--- a/source/_actions/yamaha.menu_cursor.markdown
+++ b/source/_actions/yamaha.menu_cursor.markdown
@@ -1,0 +1,64 @@
+---
+title: "Yamaha: Menu cursor"
+action: yamaha.menu_cursor
+domain: yamaha
+description: "Controls the on-screen menu cursor of a Yamaha receiver."
+related_actions:
+  - yamaha.enable_output
+  - yamaha.select_scene
+---
+
+Use this action to move the on-screen menu cursor of a Yamaha receiver, or to confirm or go back, by pressing one of the cursor keys.
+
+{% include actions/ui_header.md %}
+
+To control the menu cursor from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the receiver you want to control.
+6. From the actions shown for that target, select **Yamaha: Menu cursor**.
+7. Set the **Cursor** key to press.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Cursor:
+  description: "The cursor key to press: `up`, `down`, `left`, `right`, `select`, or `return`."
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `yamaha.menu_cursor`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: yamaha.menu_cursor
+  target:
+    entity_id: media_player.living_room_stereo
+  data:
+    cursor: down
+{% endexample %}
+
+This presses the down cursor key on `media_player.living_room_stereo`.
+
+### Options in YAML
+
+{% options_yaml %}
+cursor:
+  description: "The cursor key to press: `up`, `down`, `left`, `right`, `select`, or `return`."
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="media_player" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/yamaha.menu_cursor.markdown
+++ b/source/_actions/yamaha.menu_cursor.markdown
@@ -1,5 +1,5 @@
 ---
-title: "Yamaha: Menu cursor"
+title: "Menu cursor"
 action: yamaha.menu_cursor
 domain: yamaha
 description: "Controls the on-screen menu cursor of a Yamaha receiver."

--- a/source/_actions/yamaha.select_scene.markdown
+++ b/source/_actions/yamaha.select_scene.markdown
@@ -1,0 +1,64 @@
+---
+title: "Yamaha: Select scene"
+action: yamaha.select_scene
+domain: yamaha
+description: "Selects a scene on a Yamaha receiver."
+related_actions:
+  - yamaha.enable_output
+  - yamaha.menu_cursor
+---
+
+Use this action to select one of the scenes configured on a Yamaha receiver, such as a scene for movie viewing or radio listening.
+
+{% include actions/ui_header.md %}
+
+To select a scene from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the receiver you want to control.
+6. From the actions shown for that target, select **Yamaha: Select scene**.
+7. Set the **Scene** to select.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Scene:
+  description: The name of the scene to select, for example `TV Viewing`.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `yamaha.select_scene`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: yamaha.select_scene
+  target:
+    entity_id: media_player.living_room_stereo
+  data:
+    scene: "TV Viewing"
+{% endexample %}
+
+This selects the `TV Viewing` scene on `media_player.living_room_stereo`.
+
+### Options in YAML
+
+{% options_yaml %}
+scene:
+  description: The name of the scene to select, for example `TV Viewing`.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="media_player" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/yamaha.select_scene.markdown
+++ b/source/_actions/yamaha.select_scene.markdown
@@ -1,5 +1,5 @@
 ---
-title: "Yamaha: Select scene"
+title: "Select scene"
 action: yamaha.select_scene
 domain: yamaha
 description: "Selects a scene on a Yamaha receiver."

--- a/source/_integrations/yamaha.markdown
+++ b/source/_integrations/yamaha.markdown
@@ -128,30 +128,4 @@ script:
 
 ```
 
-### Action: Enable output
-
-The `enable_output` action enables or disables an output port (HDMI) on the receiver.
-
-| Data attribute | Optional | Description                                                               |
-| ---------------------- | -------- | ------------------------------------------------------------------------- |
-| `entity_id`            | yes      | String or list of strings that point at `entity_id`s of Yamaha receivers. |
-| `port`                 | no       | Port to enable or disable, e.g., `hdmi1`.                                 |
-| `enabled`              | no       | To enable set true, otherwise set to false.                               |
-
-### Action: Menu cursor
-
-The `menu_cursor` action controls the menu cursor.
-
-| Data attribute | Optional | Description                                                                        |
-| ---------------------- | -------- | ---------------------------------------------------------------------------------- |
-| `entity_id`            | yes      | String or list of strings that point at `entity_id`s of Yamaha receivers.          |
-| `cursor`               | no       | Name of the cursor key to press: `up`, `down`, `left`, `right`, `select`, `return` |
-
-### Action: Select scene
-
-The `select_scene` action selects a scene on the receiver.
-
-| Data attribute | Optional | Description                                                                                              |
-| ---------------------- | -------- | -------------------------------------------------------------------------------------------------------- |
-| `entity_id`            | yes      | String or list of strings that point at `entity_id`s of Yamaha receivers.                                |
-| `scene`                | no       | Scene to select, e.g., `BD/DVD Movie Viewing`, `TV Viewing`, `NET Audio Listening` or `Radio Listening`. |
+{% include integrations/actions.md %}


### PR DESCRIPTION
## Proposed change

Migrates the three Yamaha Network Receivers actions (`enable_output`, `menu_cursor`, and `select_scene`) into dedicated action pages under `source/_actions/`, and replaces the inline `### Action:` blocks with the shared `{% include integrations/actions.md %}` snippet.

All three are entity-targeted actions on the receiver's media player. Field details were verified against the integration's voluptuous schemas in core: `enable_output` (port + enabled), `menu_cursor` (cursor key), and `select_scene` (scene name).

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
