### PR TITLE
Nexia: migrate actions to dedicated pages

### DIFF
--- a/source/_actions/nexia.set_aircleaner_mode.markdown
+++ b/source/_actions/nexia.set_aircleaner_mode.markdown
@@ -1,5 +1,5 @@
 ---
-title: "Nexia: Set air cleaner mode"
+title: "Set air cleaner mode"
 action: nexia.set_aircleaner_mode
 domain: nexia
 description: "Sets the air cleaner mode on a Nexia thermostat."

--- a/source/_actions/nexia.set_aircleaner_mode.markdown
+++ b/source/_actions/nexia.set_aircleaner_mode.markdown
@@ -1,0 +1,69 @@
+---
+title: "Nexia: Set air cleaner mode"
+action: nexia.set_aircleaner_mode
+domain: nexia
+description: "Sets the air cleaner mode on a Nexia thermostat."
+related_actions:
+  - nexia.set_humidify_setpoint
+  - nexia.set_dehumidify_setpoint
+  - nexia.set_hvac_run_mode
+---
+
+Use this action to set the air cleaner mode on a Nexia, American Standard, or Trane thermostat. This setting affects all zones on the same thermostat.
+
+{% include actions/ui_header.md %}
+
+To set the air cleaner mode from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the thermostat you want to control.
+6. From the actions shown for that target, select **Nexia: Set air cleaner mode**.
+7. Set the **Air cleaner mode**.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Air cleaner mode:
+  description: "The air cleaner mode to set: `auto`, `quick`, or `allergy`."
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `nexia.set_aircleaner_mode`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: nexia.set_aircleaner_mode
+  target:
+    entity_id: climate.downstairs
+  data:
+    aircleaner_mode: allergy
+{% endexample %}
+
+This sets the air cleaner mode of `climate.downstairs` to allergy.
+
+### Options in YAML
+
+{% options_yaml %}
+aircleaner_mode:
+  description: "The air cleaner mode to set: `auto`, `quick`, or `allergy`."
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="climate" %}
+
+## Good to know
+
+- This setting affects all zones on the same thermostat.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/nexia.set_dehumidify_setpoint.markdown
+++ b/source/_actions/nexia.set_dehumidify_setpoint.markdown
@@ -1,5 +1,5 @@
 ---
-title: "Nexia: Set dehumidify setpoint"
+title: "Set dehumidify setpoint"
 action: nexia.set_dehumidify_setpoint
 domain: nexia
 description: "Sets the dehumidify setpoint on a Nexia thermostat."

--- a/source/_actions/nexia.set_dehumidify_setpoint.markdown
+++ b/source/_actions/nexia.set_dehumidify_setpoint.markdown
@@ -1,0 +1,69 @@
+---
+title: "Nexia: Set dehumidify setpoint"
+action: nexia.set_dehumidify_setpoint
+domain: nexia
+description: "Sets the dehumidify setpoint on a Nexia thermostat."
+related_actions:
+  - nexia.set_humidify_setpoint
+  - nexia.set_aircleaner_mode
+  - nexia.set_hvac_run_mode
+---
+
+Use this action to set the dehumidify setpoint on a Nexia, American Standard, or Trane thermostat. This setting affects all zones on the same thermostat.
+
+{% include actions/ui_header.md %}
+
+To set the dehumidify setpoint from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the thermostat you want to control.
+6. From the actions shown for that target, select **Nexia: Set dehumidify setpoint**.
+7. Set the **Humidity** level.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Humidity:
+  description: The dehumidify setpoint as a percentage, between 35 and 65.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `nexia.set_dehumidify_setpoint`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: nexia.set_dehumidify_setpoint
+  target:
+    entity_id: climate.downstairs
+  data:
+    humidity: 45
+{% endexample %}
+
+This sets the dehumidify setpoint of `climate.downstairs` to 45%.
+
+### Options in YAML
+
+{% options_yaml %}
+humidity:
+  description: The dehumidify setpoint as a percentage, between 35 and 65.
+  required: true
+  type: integer
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="climate" %}
+
+## Good to know
+
+- This setting affects all zones on the same thermostat.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/nexia.set_humidify_setpoint.markdown
+++ b/source/_actions/nexia.set_humidify_setpoint.markdown
@@ -1,5 +1,5 @@
 ---
-title: "Nexia: Set humidify setpoint"
+title: "Set humidify setpoint"
 action: nexia.set_humidify_setpoint
 domain: nexia
 description: "Sets the humidify setpoint on a Nexia thermostat."

--- a/source/_actions/nexia.set_humidify_setpoint.markdown
+++ b/source/_actions/nexia.set_humidify_setpoint.markdown
@@ -1,0 +1,69 @@
+---
+title: "Nexia: Set humidify setpoint"
+action: nexia.set_humidify_setpoint
+domain: nexia
+description: "Sets the humidify setpoint on a Nexia thermostat."
+related_actions:
+  - nexia.set_dehumidify_setpoint
+  - nexia.set_aircleaner_mode
+  - nexia.set_hvac_run_mode
+---
+
+Use this action to set the humidify setpoint on a Nexia, American Standard, or Trane thermostat. This setting affects all zones on the same thermostat.
+
+{% include actions/ui_header.md %}
+
+To set the humidify setpoint from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the thermostat you want to control.
+6. From the actions shown for that target, select **Nexia: Set humidify setpoint**.
+7. Set the **Humidity** level.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Humidity:
+  description: The humidify setpoint as a percentage, between 10 and 45.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `nexia.set_humidify_setpoint`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: nexia.set_humidify_setpoint
+  target:
+    entity_id: climate.downstairs
+  data:
+    humidity: 35
+{% endexample %}
+
+This sets the humidify setpoint of `climate.downstairs` to 35%.
+
+### Options in YAML
+
+{% options_yaml %}
+humidity:
+  description: The humidify setpoint as a percentage, between 10 and 45.
+  required: true
+  type: integer
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="climate" %}
+
+## Good to know
+
+- This setting affects all zones on the same thermostat.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/nexia.set_hvac_run_mode.markdown
+++ b/source/_actions/nexia.set_hvac_run_mode.markdown
@@ -1,0 +1,77 @@
+---
+title: "Nexia: Set HVAC run mode"
+action: nexia.set_hvac_run_mode
+domain: nexia
+description: "Sets the run mode and HVAC mode on a Nexia thermostat."
+related_actions:
+  - nexia.set_aircleaner_mode
+  - nexia.set_humidify_setpoint
+  - nexia.set_dehumidify_setpoint
+---
+
+Use this action to set the run mode, the HVAC mode, or both on a Nexia, American Standard, or Trane thermostat. The run mode controls whether the thermostat follows its schedule or holds a setting. The HVAC mode controls whether it heats, cools, or both.
+
+{% include actions/ui_header.md %}
+
+To set the run mode from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the thermostat you want to control.
+6. From the actions shown for that target, select **Nexia: Set HVAC run mode**.
+7. Set the **Run mode**, the **HVAC mode**, or both.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Run mode:
+  description: "How the thermostat follows its schedule: `permanent_hold` to hold the current setting, or `run_schedule` to follow the schedule."
+  required: false
+HVAC mode:
+  description: "The HVAC mode to set: `auto`, `cool`, or `heat`."
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `nexia.set_hvac_run_mode`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: nexia.set_hvac_run_mode
+  target:
+    entity_id: climate.downstairs
+  data:
+    run_mode: permanent_hold
+    hvac_mode: cool
+{% endexample %}
+
+This holds `climate.downstairs` in cooling mode.
+
+### Options in YAML
+
+{% options_yaml %}
+run_mode:
+  description: "How the thermostat follows its schedule: `permanent_hold` to hold the current setting, or `run_schedule` to follow the schedule."
+  required: false
+  type: string
+hvac_mode:
+  description: "The HVAC mode to set: `auto`, `cool`, or `heat`."
+  required: false
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="climate" %}
+
+## Good to know
+
+- Both options are optional, but you must provide at least one of **Run mode** or **HVAC mode**.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/nexia.set_hvac_run_mode.markdown
+++ b/source/_actions/nexia.set_hvac_run_mode.markdown
@@ -1,5 +1,5 @@
 ---
-title: "Nexia: Set HVAC run mode"
+title: "Set HVAC run mode"
 action: nexia.set_hvac_run_mode
 domain: nexia
 description: "Sets the run mode and HVAC mode on a Nexia thermostat."
@@ -12,9 +12,7 @@ related_actions:
 Use this action to set the run mode, the HVAC mode, or both on a Nexia, American Standard, or Trane thermostat. The run mode controls whether the thermostat follows its schedule or holds a setting. The HVAC mode controls whether it heats, cools, or both.
 
 {% include actions/ui_header.md %}
-
-To set the run mode from an automation or a script:
-
+To set the run mode, the HVAC mode, or both from an automation or a script:
 1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
 2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
 3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.

--- a/source/_integrations/nexia.markdown
+++ b/source/_integrations/nexia.markdown
@@ -102,21 +102,4 @@ It usually takes 10–15 seconds to complete, depending on the web service.
 At least one sensor must be selected.
 If you exclude all sensors, the switches will revert to show the zone's settings.
 
-### Action `nexia.set_aircleaner_mode`
-
-Sets the air cleaner mode. Options include 'auto', 'quick', and 
-'allergy'. This setting will affect all zones on the same thermostat.
-
-| Data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `entity_id` | no | String or list of strings that point at `entity_id`'s of climate devices to control.
-| `aircleaner_mode` | no | 'auto', 'quick', or 'allergy'
-
-### Action `nexia.set_humidify_setpoint`
-
-Sets the humidify setpoint. This setting will affect all zones on the same thermostat.
-
-| Data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `entity_id` | no | String or list of strings that point at `entity_id`'s of climate devices to control.
-| `humidity` | no | Humidify setpoint level, from 35 to 65.
+{% include integrations/actions.md %}


### PR DESCRIPTION
## Proposed change

Migrates the Nexia/American Standard/Trane actions into dedicated action pages under `source/_actions/`, and replaces the inline `### Action` blocks with the shared `{% include integrations/actions.md %}` snippet.

While migrating, I verified every action against the integration's voluptuous schemas in core. This surfaced two actions that were callable but not documented at all (`set_dehumidify_setpoint` and `set_hvac_run_mode`), which are now included. It also corrected the documented range for `set_humidify_setpoint`: the page listed 35 to 65, but the schema enforces 10 to 45 (35 to 65 is the dehumidify range).

All four actions are entity-targeted on the thermostat's climate entity.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
