### PR TITLE
Onkyo: migrate select HDMI output action to dedicated page

### DIFF
--- a/source/_actions/onkyo.onkyo_select_hdmi_output.markdown
+++ b/source/_actions/onkyo.onkyo_select_hdmi_output.markdown
@@ -21,7 +21,7 @@ To use this action in an automation or script:
 6. Set the receiver entity and the HDMI output code you want.
 7. Select **Save**.
 
-This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label. Instead, you set the receiver as a regular option.
+This action does not support targets. In the UI, you choose the receiver in the **Entity** field.
 
 ### Options in the UI
 

--- a/source/_actions/onkyo.onkyo_select_hdmi_output.markdown
+++ b/source/_actions/onkyo.onkyo_select_hdmi_output.markdown
@@ -1,0 +1,70 @@
+---
+title: Select HDMI output
+action: media_player.onkyo_select_hdmi_output
+domain: onkyo
+description: "Switches the active HDMI output on your Onkyo, Integra, or Pioneer receiver."
+---
+
+The **Select HDMI output** action switches the active HDMI output (or output combination) on your Onkyo, Integra, or Pioneer receiver. Use it to send the picture to your main TV, a projector on a sub output, or both at once.
+
+The output codes that work depend on your specific model, so you may need to try a few to find the right one.
+
+{% include actions/ui_header.md %}
+
+To use this action in an automation or script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create** to start a new one.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Onkyo: Select HDMI output**.
+6. Set the receiver entity and the HDMI output code you want.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label. Instead, you set the receiver as a regular option.
+
+### Options in the UI
+
+{% options_ui %}
+Entity:
+  description: The media player entity of the receiver you want to control. You can provide more than one.
+HDMI output:
+  description: "The output code to switch to. One of: no, analog, yes, out, out-sub, sub, hdbaset, or both."
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `media_player.onkyo_select_hdmi_output`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: media_player.onkyo_select_hdmi_output
+  data:
+    entity_id: media_player.onkyo
+    hdmi_output: out-sub
+{% endexample %}
+
+This sends the picture to the sub HDMI output.
+
+### Options in YAML
+
+{% options_yaml %}
+entity_id:
+  description: The media player entity (or entities) of the receiver you want to control.
+  required: true
+  type: string
+hdmi_output:
+  description: "The output code to switch to. One of: no, analog, yes, out, out-sub, sub, hdbaset, or both."
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+## Good to know
+
+- The available output codes vary by model. For example, on the TX-NR676E, `out` selects the main output, `out-sub` selects the sub output, and `sub` selects both.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/onkyo.markdown
+++ b/source/_integrations/onkyo.markdown
@@ -57,45 +57,16 @@ If your receiver has a second or third zone available, they are displayed as add
 
 If your receiver supports channel muting, the integration creates a switch for each speaker channel. Turning a switch on mutes that channel, and turning it off unmutes it. This lets you mute individual channels independently of the main volume.
 
-## Actions
+{% include integrations/actions.md %}
 
-### Action `onkyo_select_hdmi_output`
+## Examples
 
-Changes HDMI output of your receiver
+### Play a radio preset
 
-| Data attribute | Optional | Description                                                     |
-| ---------------------- | -------- | --------------------------------------------------------------- |
-| `entity_id`            | no       | String or list of a single `entity_id` that will change output. |
-| `hdmi_output`          | no       | The desired output code.                                        |
-
-Accepted values are:
-'no', 'analog', 'yes', 'out', 'out-sub', 'sub', 'hdbaset', 'both', 'up'
-which one to use seems to vary depending on model so you will have to try them out.
-( For model TX-NR676E it seems to be 'out' for main, 'out-sub' for sub, and 'sub' for both )
-
-### Example `onkyo_select_hdmi_output` script
-
-```yaml
-# Example onkyo_select_hdmi_output script
-#
-script:
-  hdmi_sub:
-    alias: "Hdmi out projector"
-    sequence:
-      - action: media_player.onkyo_select_hdmi_output
-        data:
-          entity_id: media_player.onkyo
-          hdmi_output: out-sub
-```
-
-### Example `play_media` script
-
-The `play_media` function can be used in script to play radio station by preset number.
-Not working for NET radio.
+You can use the `media_player.play_media` action in a script to play a radio station by its preset number. This does not work for NET radio.
 
 ```yaml
 # Example play_media script
-#
 script:
   radio1:
     alias: "Radio 1"


### PR DESCRIPTION
## Proposed change

Migrate the Onkyo `onkyo_select_hdmi_output` action to a dedicated action page and reference it from the integration page with the standard actions include. This also drops the outdated `up` output code, which the integration no longer accepts, and keeps the generic `play_media` script under a clearer **Examples** section.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
