### PR TITLE
Modbus: migrate actions to dedicated pages

### DIFF
--- a/source/_actions/modbus.reload.markdown
+++ b/source/_actions/modbus.reload.markdown
@@ -1,0 +1,54 @@
+---
+title: Reload
+action: modbus.reload
+domain: modbus
+description: "Reloads the Modbus configuration from your YAML configuration."
+related_actions:
+  - modbus.stop
+  - modbus.write_register
+  - modbus.write_coil
+---
+
+Use this action to reload your Modbus configuration from YAML without restarting Home Assistant. This applies changes to your hubs and entities and restarts the connections.
+
+{% include actions/ui_header.md %}
+
+To reload the Modbus configuration from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create** to start a new one.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Modbus: Reload**.
+6. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label. Only users with administrator rights can run this action.
+
+### Options in the UI
+
+This action has no additional options in the UI.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `modbus.reload`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: modbus.reload
+{% endexample %}
+
+This reloads the Modbus configuration from your YAML configuration.
+
+### Options in YAML
+
+This action has no additional options in YAML.
+
+## Good to know
+
+- Run this action after you change your Modbus configuration in YAML so the changes take effect without a restart.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/modbus.reload.markdown
+++ b/source/_actions/modbus.reload.markdown
@@ -1,5 +1,5 @@
 ---
-title: Reload
+title: Reload Modbus configuration
 action: modbus.reload
 domain: modbus
 description: "Reloads the Modbus configuration from your YAML configuration."

--- a/source/_actions/modbus.stop.markdown
+++ b/source/_actions/modbus.stop.markdown
@@ -1,0 +1,65 @@
+---
+title: Stop hub
+action: modbus.stop
+domain: modbus
+description: "Stops a Modbus hub and closes its connection."
+related_actions:
+  - modbus.reload
+  - modbus.write_register
+  - modbus.write_coil
+---
+
+The **Stop hub** action stops a Modbus hub and closes its connection to your hardware. Use it when you need to release the connection, for example before another application takes over the serial port or network connection.
+
+{% include actions/ui_header.md %}
+
+To use this action in an automation or script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create** to start a new one.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Modbus: Stop hub**.
+6. Enter the name of the hub you want to stop.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label. Instead, you select the Modbus hub by name.
+
+### Options in the UI
+
+{% options_ui %}
+Hub:
+  description: The name of the Modbus hub to stop. Defaults to `modbus_hub`.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `modbus.stop`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: modbus.stop
+  data:
+    hub: modbus_hub
+{% endexample %}
+
+This stops the hub named `modbus_hub`.
+
+### Options in YAML
+
+{% options_yaml %}
+hub:
+  description: The name of the Modbus hub to stop.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+## Good to know
+
+- To start the hub again, use the [Reload](/actions/modbus.reload/) action.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/modbus.write_coil.markdown
+++ b/source/_actions/modbus.write_coil.markdown
@@ -1,0 +1,85 @@
+---
+title: Write coil
+action: modbus.write_coil
+domain: modbus
+description: "Writes a state to one or more Modbus coils."
+related_actions:
+  - modbus.write_register
+  - modbus.stop
+  - modbus.reload
+---
+
+The **Write coil** action writes an on or off state to one or more Modbus coils on a connected device. Use it to switch outputs, relays, or other binary controls directly on your hardware.
+
+You can write a single state or a list of states. A single state uses Modbus function code `0x05` (write single coil), while a list uses function code `0x0F` (write multiple coils).
+
+{% include actions/ui_header.md %}
+
+To use this action in an automation or script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create** to start a new one.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Modbus: Write coil**.
+6. Fill in the address, the state to write, and optionally the device address and hub.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label. Instead, you select the Modbus hub by name.
+
+### Options in the UI
+
+{% options_ui %}
+Address:
+  description: The address of the coil to write to.
+State:
+  description: A single state or a list of states to write.
+Slave:
+  description: The device (slave) address on the Modbus network. Defaults to 1.
+  required: false
+Hub:
+  description: The name of the Modbus hub to use. Defaults to `modbus_hub`.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `modbus.write_coil`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: modbus.write_coil
+  data:
+    address: 17
+    state: true
+{% endexample %}
+
+This switches the coil at address `17` on, using the default hub.
+
+### Options in YAML
+
+{% options_yaml %}
+address:
+  description: The address of the coil to write to.
+  required: true
+  type: integer
+state:
+  description: A single state or a list of states. A single state calls Modbus function code `0x05`, a list calls function code `0x0F`.
+  required: true
+  type: any
+slave:
+  description: The device (slave) address on the Modbus network, between 0 and 255. Defaults to 1.
+  required: false
+  type: integer
+hub:
+  description: The name of the Modbus hub to use.
+  required: false
+  type: string
+  default: modbus_hub
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/modbus.write_register.markdown
+++ b/source/_actions/modbus.write_register.markdown
@@ -1,0 +1,105 @@
+---
+title: Write register
+action: modbus.write_register
+domain: modbus
+description: "Writes a value to one or more Modbus holding registers."
+related_actions:
+  - modbus.write_coil
+  - modbus.stop
+  - modbus.reload
+---
+
+The **Write register** action writes a value to one or more Modbus holding registers on a connected device. Use it to send setpoints, commands, or other numeric values directly to your hardware.
+
+You can write a single value or a list of values. A single value uses Modbus function code `0x06` (write single register), while a list uses function code `0x10` (write multiple registers).
+
+{% include actions/ui_header.md %}
+
+To use this action in an automation or script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create** to start a new one.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Modbus: Write register**.
+6. Fill in the address, the value to write, and optionally the device address and hub.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label. Instead, you select the Modbus hub by name.
+
+### Options in the UI
+
+{% options_ui %}
+Address:
+  description: The address of the register to write to.
+Value:
+  description: "A single value or a list of 16-bit values. To set a value like `0x0004`, you may need to reverse the byte order, for example `[4, 0]`, depending on the byte order of your device."
+Slave:
+  description: The device (slave) address on the Modbus network. Defaults to 1.
+  required: false
+Hub:
+  description: The name of the Modbus hub to use. Defaults to `modbus_hub`.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `modbus.write_register`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: modbus.write_register
+  data:
+    address: 138
+    value: 42
+{% endexample %}
+
+This writes the value `42` to register `138` on the default hub.
+
+### Options in YAML
+
+{% options_yaml %}
+address:
+  description: The address of the register to write to.
+  required: true
+  type: integer
+value:
+  description: "A single value or a list of 16-bit values. A single value calls Modbus function code `0x06`, a list calls function code `0x10`. To set a value like `0x0004`, you may need to reverse the byte order, for example `[4, 0]`, depending on the byte order of your device."
+  required: true
+  type: any
+slave:
+  description: The device (slave) address on the Modbus network, between 0 and 255. Defaults to 1.
+  required: false
+  type: integer
+hub:
+  description: The name of the Modbus hub to use.
+  required: false
+  type: string
+  default: modbus_hub
+{% endoptions_yaml %}
+
+## Good to know
+
+- Whether you need to reverse the byte or word order depends on the device and the byte order of your CPU.
+
+{% include actions/more_examples.md %}
+
+### Write a float32 value
+
+To write a `float32` value, use the network format. For example, `10.0` is `0x41200000` in network-order hexadecimal, which you write as two 16-bit registers.
+
+{% example %}
+action: |
+  action: modbus.write_register
+  data:
+    address: 138
+    slave: 1
+    hub: modbus_hub
+    value:
+      - 0x4120
+      - 0x0000
+{% endexample %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -1726,50 +1726,7 @@ Some parameters exclude other parameters, the following tables show what can be 
 | swap: word_byte | No     | No     | No  | Yes | Yes |
 
 
-# Actions
-
-The modbus integration provides two generic write actions in addition to the platform-specific actions.
-
-| Action                | Description                 |
-| --------------------- | --------------------------- |
-| modbus.write_register | Write register or registers |
-| modbus.write_coil     | Write coil or coils         |
-
-Description:
-
-| Attribute | Description                                                                                                                                                                                                                                                                                 |
-| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| hub       | Hub name (defaults to 'modbus_hub' when omitted)                                                                                                                                                                                                                                            |
-| slave     | Slave address (0-255, defaults to 1 when omitted)                                                                                                                                                                                                                                           |
-| address   | Address of the Register (e.g. 138)                                                                                                                                                                                                                                                          |
-| value     | (write_register) A single value or an array of 16-bit values. Single value will call modbus function code 0x06. Array will call modbus function code 0x10. Values might need reverse ordering. E.g., to set 0x0004 you might need to set `[4,0]`, this depend on the byte order of your CPU |
-| state     | (write_coil) A single boolean or an array of booleans. Single boolean will call modbus function code 0x05. Array will call modbus function code 0x0F                                                                                                                                        |
-
-## Example: writing a float32 type register
-
-To write a float32 datatype register use network format like `10.0` == `0x41200000` (network order float hexadecimal).
-
-```yaml
-action: modbus.write_register
-data:
-  address: <target register address>
-  slave: <target slave address>
-  hub: <hub name>
-  value: [0x4120, 0x0000]
-```
-
-## Action `modbus.set-temperature`
-
-| Action          | Description                                                                                                                                   |
-| --------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| set_temperature | Set temperature. Requires `value` to be passed in, which is the desired target temperature. `value` should be in the same type as `data_type` |
-
-## Action `modbus.set_hvac_mode`
-
-| Action        | Description                                                                                                                                                                                                                                                                                                                           |
-| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| set_hvac_mode | Set HVAC mode. Requires `value` to be passed in, which is the desired mode. `value` should be a valid HVAC mode. A mapping between the desired state and the value to be written to the HVAC mode register must exist. Performing this action will also set the On/Off register to an appropriate value, if such a register is defined. |
-
+{% include integrations/actions.md %}
 
 # Opening an issue
 


### PR DESCRIPTION
## Proposed change

Migrate the Modbus actions to dedicated action pages and reference them from the integration page with the standard actions include. This covers the `write_register`, `write_coil`, `stop`, and `reload` actions.

It also removes the `set_temperature` and `set_hvac_mode` sections. Those described the generic `climate.set_temperature` and `climate.set_hvac_mode` platform actions rather than Modbus-specific actions, and their behavior is already covered by the climate configuration options.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
