### PR TITLE
Persistent notification: migrate actions to dedicated pages

### DIFF
--- a/source/_actions/persistent_notification.create.markdown
+++ b/source/_actions/persistent_notification.create.markdown
@@ -1,0 +1,104 @@
+---
+title: Create notification
+action: persistent_notification.create
+domain: persistent_notification
+description: "Creates a persistent notification in the Home Assistant frontend."
+related_actions:
+  - persistent_notification.dismiss
+  - persistent_notification.dismiss_all
+---
+
+The **Create notification** action shows a persistent notification in the Home Assistant frontend. The notification stays visible until someone dismisses it, which makes it useful for messages that need attention, such as a reminder or a warning from an automation.
+
+{% include actions/ui_header.md %}
+
+To use this action in an automation or script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create** to start a new one.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Persistent notification: Create**.
+6. Provide a **Message** and, if you want, a **Title** and a **Notification ID**.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Message:
+  description: The body of the notification. Supports Markdown formatting.
+Title:
+  description: The title of the notification.
+  required: false
+Notification ID:
+  description: An identifier for the notification. When you reuse the same ID, the existing notification is overwritten instead of a new one being added.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `persistent_notification.create`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: persistent_notification.create
+  data:
+    message: "Your message goes here"
+    title: "Custom subject"
+{% endexample %}
+
+This creates a notification with a fixed title and message.
+
+### Options in YAML
+
+{% options_yaml %}
+message:
+  description: The body of the notification. Supports Markdown formatting.
+  required: true
+  type: string
+title:
+  description: The title of the notification.
+  required: false
+  type: string
+notification_id:
+  description: An identifier for the notification. When you reuse the same ID, the existing notification is overwritten instead of a new one being added.
+  required: false
+  type: string
+{% endoptions_yaml %}
+
+## Markdown support
+
+The message supports the [Markdown formatting syntax](https://daringfireball.net/projects/markdown/syntax). Some examples are:
+
+- Headline 1: `# Headline`
+- Headline 2: `## Headline`
+- Newline: `\n`
+- Bold: `**My bold text**`
+- Italic: `*My italic text*`
+- Link: `[Link](https://www.home-assistant.io/)`
+- Image: `![image](/local/my_image.jpg)`
+
+{% note %}
+`/local/` in this context refers to the `.homeassistant/www/` folder.
+{% endnote %}
+
+{% include actions/more_examples.md %}
+
+To show runtime information, use a [template](/docs/templating/):
+
+{% example %}
+action: |
+  action: persistent_notification.create
+  data:
+    title: >
+      Thermostat is {{ state_attr('climate.thermostat', 'hvac_action') }}
+    message: "Temperature {{ state_attr('climate.thermostat', 'current_temperature') }}"
+{% endexample %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/persistent_notification.create.markdown
+++ b/source/_actions/persistent_notification.create.markdown
@@ -84,9 +84,10 @@ The message supports the [Markdown formatting syntax](https://daringfireball.net
 `/local/` in this context refers to the `.homeassistant/www/` folder.
 {% endnote %}
 
-{% include actions/more_examples.md %}
+## Show runtime information
 
-To show runtime information, use a [template](/docs/templating/):
+To show runtime information, use a [template](/docs/templating/).
+For example:
 
 {% example %}
 action: |

--- a/source/_actions/persistent_notification.dismiss.markdown
+++ b/source/_actions/persistent_notification.dismiss.markdown
@@ -1,0 +1,60 @@
+---
+title: Dismiss notification
+action: persistent_notification.dismiss
+domain: persistent_notification
+description: "Removes a single persistent notification from the Home Assistant frontend."
+related_actions:
+  - persistent_notification.create
+  - persistent_notification.dismiss_all
+---
+
+The **Dismiss notification** action removes a single persistent notification from the Home Assistant frontend. You identify the notification by its notification ID, so this works well to clear a notification that an automation or script created earlier.
+
+{% include actions/ui_header.md %}
+
+To use this action in an automation or script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create** to start a new one.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Persistent notification: Dismiss**.
+6. Provide the **Notification ID** of the notification to remove.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Notification ID:
+  description: The identifier of the notification to remove. This is the same ID you set when you created the notification.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `persistent_notification.dismiss`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: persistent_notification.dismiss
+  data:
+    notification_id: "1234"
+{% endexample %}
+
+This removes the notification with the ID `1234`.
+
+### Options in YAML
+
+{% options_yaml %}
+notification_id:
+  description: The identifier of the notification to remove. This is the same ID you set when you created the notification.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/persistent_notification.dismiss_all.markdown
+++ b/source/_actions/persistent_notification.dismiss_all.markdown
@@ -1,0 +1,43 @@
+---
+title: Dismiss all notifications
+action: persistent_notification.dismiss_all
+domain: persistent_notification
+description: "Removes all persistent notifications from the Home Assistant frontend."
+related_actions:
+  - persistent_notification.create
+  - persistent_notification.dismiss
+---
+
+The **Dismiss all notifications** action removes every persistent notification from the Home Assistant frontend at once. Use it to clear the list in a single step instead of dismissing notifications one by one.
+
+{% include actions/ui_header.md %}
+
+To use this action in an automation or script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create** to start a new one.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Persistent notification: Dismiss all**.
+6. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+This action has no options.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `persistent_notification.dismiss_all`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: persistent_notification.dismiss_all
+{% endexample %}
+
+This removes all persistent notifications.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/persistent_notification.markdown
+++ b/source/_integrations/persistent_notification.markdown
@@ -42,96 +42,12 @@ automation:
 
 See [Automation Trigger Variables: Persistent Notification](/docs/automation/templating/#persistent-notification) for additional trigger data available for conditions or actions.
 
-### Action: Create
+{% include integrations/actions.md %}
 
-The `persistent_notification.create` action creates a persistent notification with a message, title, and notification ID.
+## Use as a notifier
 
-| Data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `message`              |       no | Body of the notification. |
-| `title`                |      yes | Title of the notification. |
-| `notification_id`      |      yes | If `notification_id` is given, it will overwrite the notification if there already was a notification with that ID. |
+Persistent notifications can also be used as a pre-configured notifier for the [Notify integration](/integrations/notify/) when that integration is loaded. It is available as `notify.persistent_notification`. This lets you use it with features that require a notifier, such as [notify groups](/integrations/group/#notify-groups) or the [Alert integration](/integrations/alert/).
 
-Here is how an [action](/docs/automation/action) of your [automation setup](/getting-started/automation/) with static content could look like.
+You can place the following attribute inside `data` for extended functionality:
 
-```yaml
-actions:
-  - action: persistent_notification.create
-    data:
-      message: "Your message goes here"
-      title: "Custom subject"
-```
-
-If you want to show some runtime information, you have to use [templates](/docs/templating/).
-
-```yaml
-actions:
-  - action: persistent_notification.create
-    data:
-      title: >
-        Thermostat is {{ state_attr('climate.thermostat', 'hvac_action') }}
-      message: "Temperature {{ state_attr('climate.thermostat', 'current_temperature') }}"
-```
-
-The `persistent_notification.dismiss` action requires a `notification_id`.
-
-| Data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `notification_id`      |      no  | the `notification_id` is required to identify the notification that should be removed.
-
-This action allows you to remove a notifications by script or automation.
-
-```yaml
-actions:
-  - action: persistent_notification.dismiss
-    data:
-      notification_id: "1234"
-```
-
-The `persistent_notification.dismiss_all` action allows you to remove all notifications.
-
-```yaml
-actions:
-  - action: persistent_notification.dismiss_all
-```
-
-### Markdown support
-
-The message attribute supports the [Markdown formatting syntax](https://daringfireball.net/projects/markdown/syntax). Some examples are:
-
-| Type | Message |
-| ---- | ------- |
-| Headline 1 | `# Headline` |
-| Headline 2 | `## Headline` |
-| Newline | `\n` |
-| Bold | `**My bold text**` |
-| Italic | `*My italic text*` |
-| Link | `[Link](https://home-assistant.io/)` |
-| Image | `![image](/local/my_image.jpg)` |
-
-{% note %}
-`/local/` in this context refers to the `.homeassistant/www/` folder.
-{% endnote %}
-
-### Create a persistent notification
-
-Go to {% my developer_services title="**Settings** > **Developer tools** > **Actions**" %}, then select the {% my developer_services service="persistent_notification.create" title="`persistent_notification.create`" %} action from the **Action** dropdown. Enter something like the sample below into the **data** field and press the **Perform action** button.
-
-```json
-{
-  "notification_id": "1234",
-  "title": "Sample notification",
-  "message": "This is a sample text."
-}
-```
-This will create the notification entry shown above.
-
-### Use as a notifier
-
-Persistent notifications can also be used as a pre-configured notifier for the [Notify integration](/integrations/notify/) if that integration is loaded. It is available as `notify.persistent_notification`. This enables it to be used with features that require a notifier like [Notify Groups](/integrations/group/#notify-groups) or the [Alert integration](/integrations/alert/).
-
-The following attributes can be placed inside `data` for extended functionality.
-
-| Data attribute | Optional | Description |
-| ---------------------- | -------- | ----------- |
-| `notification_id`      |      yes | If `notification_id` is given, it will overwrite the notification if there already was a notification with that ID. |
+- `notification_id`: When a notification ID is given, it overwrites the notification if one with that ID already exists.


### PR DESCRIPTION
## Proposed change

Migrate the inline persistent notification action documentation (`persistent_notification.create`, `persistent_notification.dismiss`, and `persistent_notification.dismiss_all`) to dedicated action pages and reference them from the integration page with the standard actions include.

The data attribute tables are converted to lists, and the notifier usage (`notify.persistent_notification`) stays on the integration page.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
