### PR TITLE
Fix UniFi Protect related actions front matter

### DIFF
--- a/source/_actions/unifiprotect.add_doorbell_text.markdown
+++ b/source/_actions/unifiprotect.add_doorbell_text.markdown
@@ -4,7 +4,7 @@ action: unifiprotect.add_doorbell_text
 domain: unifiprotect
 description: "Adds a custom message that can be shown on a UniFi Protect doorbell."
 related_actions:
-  - action: unifiprotect.remove_doorbell_text
+  - unifiprotect.remove_doorbell_text
 ---
 
 With this action, you can add a custom message to the list of texts available on your UniFi Protect doorbells. Once added, you can select the message on the doorbell so visitors see it on the screen.

--- a/source/_actions/unifiprotect.remove_doorbell_text.markdown
+++ b/source/_actions/unifiprotect.remove_doorbell_text.markdown
@@ -4,7 +4,7 @@ action: unifiprotect.remove_doorbell_text
 domain: unifiprotect
 description: "Removes a custom message from a UniFi Protect doorbell."
 related_actions:
-  - action: unifiprotect.add_doorbell_text
+  - unifiprotect.add_doorbell_text
 ---
 
 With this action, you can remove a custom message from the list of texts available on your UniFi Protect doorbells. Use it to clean up messages you added earlier and no longer need.


### PR DESCRIPTION
## Proposed change

The `related_actions` front matter on the UniFi Protect doorbell text action pages used a nested `- action:` mapping instead of a flat list of action IDs. The related actions include iterates over plain action IDs, so the nested form caused the "Related actions" section to render empty. This corrects both pages to use the flat list format.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #
- Part of epic: home-assistant/epics#96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
