### PR TITLE
Document new Subaru sensors (vehicle state, recommended tire pressure, EV charger)

### DIFF
--- a/source/_integrations/subaru.markdown
+++ b/source/_integrations/subaru.markdown
@@ -69,7 +69,7 @@ Available sensors will vary by model, year, and subscription type. The integrati
 
 \* Gen 1 odometer only updates every 500 miles. <br>
 
-EV sensors (EV battery level, EV range, EV time to full charge) are only present on PHEV vehicles. The recommended tire pressure sensors are disabled by default and may report `unknown` on older Gen 2 vehicles that do not advertise the underlying tire-pressure recommendation in `vehicle_health`. The vehicle state sensor reports one of `ignition_off`, `ignition_acc` (accessory power), or `ignition_on`; if your vehicle reports a value not in that list, please file a bug — the disabled-by-default `vehicle_state (raw)` diagnostic companion will show the raw API string.
+EV sensors (EV battery level, EV range, EV time to full charge) are only present on PHEV vehicles. The recommended tire pressure sensors are disabled by default and may report `unknown` on older Gen 2 vehicles that do not advertise the underlying tire-pressure recommendation in `vehicle_health`. The vehicle state sensor reports one of `ignition_off`, `ignition_acc` (accessory power), `ignition_on`, or `engine_on_remote_start`; if your vehicle reports a value not in that list, please file a bug and attach the integration's diagnostics download.
 
 ## Lock
 

--- a/source/_integrations/subaru.markdown
+++ b/source/_integrations/subaru.markdown
@@ -59,8 +59,6 @@ Available sensors will vary by model, year, and subscription type. The integrati
 | Average fuel consumption          |          | &check; | &check; |
 | Distance to empty                 |          | &check; | &check; |
 | EV battery level                  |          | &check; | &check; |
-| EV charge mode                    |          | &check; | &check; |
-| EV charger state                  |          | &check; | &check; |
 | EV range                          |          | &check; | &check; |
 | EV time to full charge            |          | &check; | &check; |
 | Odometer                          | &check;* | &check; | &check; |
@@ -71,7 +69,7 @@ Available sensors will vary by model, year, and subscription type. The integrati
 
 \* Gen 1 odometer only updates every 500 miles. <br>
 
-EV sensors (EV battery level, EV charge mode, EV charger state, EV range, EV time to full charge) are only present on PHEV vehicles. The recommended tire pressure sensors may report `unknown` on older Gen 2 vehicles that do not advertise the underlying `TIR_*` / `TIF_*` feature flags.
+EV sensors (EV battery level, EV range, EV time to full charge) are only present on PHEV vehicles. The recommended tire pressure sensors are disabled by default and may report `unknown` on older Gen 2 vehicles that do not advertise the underlying tire-pressure recommendation in `vehicle_health`. The vehicle state sensor reports one of `ignition_off`, `ignition_acc` (accessory power), or `ignition_on`; if your vehicle reports a value not in that list, please file a bug — the disabled-by-default `vehicle_state (raw)` diagnostic companion will show the raw API string.
 
 ## Lock
 

--- a/source/_integrations/subaru.markdown
+++ b/source/_integrations/subaru.markdown
@@ -54,17 +54,24 @@ If your account includes multiple vehicles, the same PIN will be used for all ve
 
 Available sensors will vary by model, year, and subscription type. The integration will add all supported sensors for your vehicle. Sensor data is usually only updated when the vehicle is turned off unless the [polling option](#options) is enabled.
 
-| Sensor                   | Gen 1   | Gen 2   | Gen 3   |
-|--------------------------|---------|---------|---------|
-| Average fuel consumption |         | &check; | &check; |
-| Distance to empty        |         | &check; | &check; |
-| EV battery level         |         | &check; | &check; |
-| EV range                 |         | &check; | &check; |
-| EV time to full charge   |         | &check; | &check; |
-| Odometer                 | &check;*| &check; | &check; |
-| Tire pressures           |         | &check; | &check; |
+| Sensor                            | Gen 1    | Gen 2   | Gen 3   |
+|-----------------------------------|----------|---------|---------|
+| Average fuel consumption          |          | &check; | &check; |
+| Distance to empty                 |          | &check; | &check; |
+| EV battery level                  |          | &check; | &check; |
+| EV charge mode                    |          | &check; | &check; |
+| EV charger state                  |          | &check; | &check; |
+| EV range                          |          | &check; | &check; |
+| EV time to full charge            |          | &check; | &check; |
+| Odometer                          | &check;* | &check; | &check; |
+| Recommended tire pressure front   |          | &check; | &check; |
+| Recommended tire pressure rear    |          | &check; | &check; |
+| Tire pressures                    |          | &check; | &check; |
+| Vehicle state                     |          | &check; | &check; |
 
-\* Gen 1 odometer only updates every 500 miles <br>
+\* Gen 1 odometer only updates every 500 miles. <br>
+
+EV sensors (EV battery level, EV charge mode, EV charger state, EV range, EV time to full charge) are only present on PHEV vehicles. The recommended tire pressure sensors may report `unknown` on older Gen 2 vehicles that do not advertise the underlying `TIR_*` / `TIF_*` feature flags.
 
 ## Lock
 


### PR DESCRIPTION
## Proposed change

Documents the new sensor entities added by home-assistant/core#174054 — adds rows to the Subaru sensor table for:

- **Vehicle state** (reads \`VEHICLE_STATE_TYPE\`, e.g. \`IGNITION_OFF\` / \`IGNITION_ON\`)
- **Recommended tire pressure front / rear** (\`PRESSURE\` device class, PSI; sourced from \`vehicle_health.RECOMMENDED_TIRE_PRESSURE\`)
- **EV charger state** (reads \`EV_CHARGER_STATE_TYPE\`)
- **EV charge mode** (reads \`EV_STATE_OF_CHARGE_MODE\`)

Also adds a note clarifying that EV sensors only appear on PHEV vehicles and that the recommended tire pressure sensors may report \`unknown\` on older Gen 2 cars that lack the underlying \`TIR_*\` / \`TIF_*\` feature flags.

This PR is intentionally scoped to the sensor additions from #174054. A follow-up docs PR will cover the binary_sensor platform from the next code PR.

## Type of change

- [ ] Spelling, grammar or other readability improvements (\`current\` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (\`current\` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (\`next\` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (\`next\` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: home-assistant/core#174054
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the \`current\` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the \`next\` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards