### PR TITLE
Homematic: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/homematic.put_paramset.markdown
+++ b/source/_actions/homematic.put_paramset.markdown
@@ -1,0 +1,112 @@
+---
+title: "Put paramset"
+action: homematic.put_paramset
+domain: homematic
+description: "Manually changes a Homematic device's paramset using its putParamset method."
+related_actions:
+  - homematic.set_device_value
+  - homematic.virtualkey
+  - homematic.set_variable_value
+  - homematic.reconnect
+  - homematic.set_install_mode
+---
+
+Use this action to manually change a device's paramset, even devices without built-in support in Home Assistant. It gives you direct access to the putParamset method of the connection, which is useful for changing settings such as the week program of a wall thermostat.
+
+For BidCos-RF devices, the **RX mode** controls how the configuration data is sent to the device:
+
+- `BURST` is the default. It wakes up every device when sending the configuration data, which uses some battery on all of them, but the data is sent almost immediately.
+- `WAKEUP` sends the configuration data only after a device reports updated values, which usually happens every three minutes. It does not wake up every device, so it saves battery.
+
+{% include actions/ui_header.md %}
+
+To change a paramset from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Homematic: Put paramset**.
+6. Enter the **Interface**, **Address**, **Paramset key**, and **Paramset** and, optionally, an **RX mode**.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Interface:
+  description: "The name of the interface from your configuration."
+  required: true
+Address:
+  description: "The address of the Homematic device."
+  required: true
+Paramset key:
+  description: "The paramset key to change, such as MASTER."
+  required: true
+Paramset:
+  description: "A mapping of paramset values to set."
+  required: true
+RX mode:
+  description: "The receive mode used for BidCos-RF devices: BURST or WAKEUP."
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `homematic.put_paramset`:
+
+{% example %}
+action: |
+  action: homematic.put_paramset
+  data:
+    interface: wireless
+    address: "LEQ1234567"
+    paramset_key: MASTER
+    paramset:
+      WEEK_PROGRAM_POINTER: 1
+{% endexample %}
+
+To set the week program with an explicit receive mode, for BidCos-RF only:
+
+{% example %}
+action: |
+  action: homematic.put_paramset
+  data:
+    interface: wireless
+    address: "LEQ1234567"
+    paramset_key: MASTER
+    rx_mode: WAKEUP
+    paramset:
+      WEEK_PROGRAM_POINTER: 1
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+interface:
+  description: "The name of the interface from your configuration."
+  required: true
+  type: string
+address:
+  description: "The address of the Homematic device."
+  required: true
+  type: string
+paramset_key:
+  description: "The paramset key to change, such as MASTER."
+  required: true
+  type: string
+paramset:
+  description: "A mapping of paramset values to set."
+  required: true
+  type: map
+rx_mode:
+  description: "The receive mode used for BidCos-RF devices: BURST or WAKEUP."
+  required: false
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/homematic.put_paramset.markdown
+++ b/source/_actions/homematic.put_paramset.markdown
@@ -13,7 +13,7 @@ related_actions:
 
 Use this action to manually change a device's paramset, even devices without built-in support in Home Assistant. It gives you direct access to the putParamset method of the connection, which is useful for changing settings such as the week program of a wall thermostat.
 
-For BidCos-RF devices, the **RX mode** controls how the configuration data is sent to the device:
+For BidCoS-RF devices, the **RX mode** controls how the configuration data is sent to the device:
 
 - `BURST` is the default. It wakes up every device when sending the configuration data, which uses some battery on all of them, but the data is sent almost immediately.
 - `WAKEUP` sends the configuration data only after a device reports updated values, which usually happens every three minutes. It does not wake up every device, so it saves battery.
@@ -48,8 +48,7 @@ Paramset:
   description: "A mapping of paramset values to set."
   required: true
 RX mode:
-  description: "The receive mode used for BidCos-RF devices: BURST or WAKEUP."
-{% endoptions_ui %}
+  description: "The receive mode used for BidCoS-RF devices: BURST or WAKEUP."
 
 {% include actions/yaml_header.md %}
 
@@ -66,7 +65,7 @@ action: |
       WEEK_PROGRAM_POINTER: 1
 {% endexample %}
 
-To set the week program with an explicit receive mode, for BidCos-RF only:
+To set the week program with an explicit receive mode, for BidCoS-RF only:
 
 {% example %}
 action: |
@@ -100,7 +99,7 @@ paramset:
   required: true
   type: map
 rx_mode:
-  description: "The receive mode used for BidCos-RF devices: BURST or WAKEUP."
+  description: "The receive mode used for BidCoS-RF devices: BURST or WAKEUP."
   required: false
   type: string
 {% endoptions_yaml %}

--- a/source/_actions/homematic.put_paramset.markdown
+++ b/source/_actions/homematic.put_paramset.markdown
@@ -49,6 +49,7 @@ Paramset:
   required: true
 RX mode:
   description: "The receive mode used for BidCoS-RF devices: BURST or WAKEUP."
+{% endoptions_ui %}
 
 {% include actions/yaml_header.md %}
 

--- a/source/_actions/homematic.reconnect.markdown
+++ b/source/_actions/homematic.reconnect.markdown
@@ -1,0 +1,42 @@
+---
+title: "Reconnect"
+action: homematic.reconnect
+domain: homematic
+description: "Reconnects to all Homematic hubs."
+related_actions:
+  - homematic.set_device_value
+  - homematic.set_variable_value
+  - homematic.virtualkey
+  - homematic.put_paramset
+  - homematic.set_install_mode
+---
+
+Use this action to reconnect to all your Homematic hubs without restarting Home Assistant. This is useful when your CCU or Homegear has been restarted and Home Assistant stops getting updates from your devices.
+
+{% include actions/ui_header.md %}
+
+To reconnect from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Homematic: Reconnect**.
+6. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `homematic.reconnect`:
+
+{% example %}
+action: |
+  action: homematic.reconnect
+{% endexample %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/homematic.set_device_value.markdown
+++ b/source/_actions/homematic.set_device_value.markdown
@@ -1,0 +1,113 @@
+---
+title: "Set device value"
+action: homematic.set_device_value
+domain: homematic
+description: "Controls a Homematic device manually using its setValue method."
+related_actions:
+  - homematic.put_paramset
+  - homematic.virtualkey
+  - homematic.set_variable_value
+  - homematic.reconnect
+  - homematic.set_install_mode
+---
+
+Use this action to control a device manually, even devices without built-in support in Home Assistant. It gives you direct access to the setValue method of the device, which can serve as a workaround when a device is not yet supported or only partially implemented.
+
+If you have multiple hosts, you can choose the one hosting a specific device by setting the **Interface** to the name you gave it in your configuration.
+
+{% include actions/ui_header.md %}
+
+To set a device value from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Homematic: Set device value**.
+6. Enter the **Address**, **Channel**, **Param**, and **Value** and, optionally, a **Value type** and **Interface**.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Address:
+  description: "The address of the Homematic device, or BidCoS-RF for the virtual remote."
+  required: true
+Channel:
+  description: "The channel to send the value to."
+  required: true
+Param:
+  description: "The parameter to set, such as STATE or SET_TEMPERATURE."
+  required: true
+Value:
+  description: "The new value to set."
+  required: true
+Value type:
+  description: "The type to convert the value to: boolean, dateTime.iso8601, double, int, or string."
+Interface:
+  description: "The name of the interface from your configuration. Only needed when you have more than one."
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `homematic.set_device_value`:
+
+{% example %}
+action: |
+  action: homematic.set_device_value
+  data:
+    address: "LEQ1234567"
+    channel: 4
+    param: SET_TEMPERATURE
+    value: 23.0
+{% endexample %}
+
+To set the active profile on a thermostat, pass the value as an integer:
+
+{% example %}
+action: |
+  action: homematic.set_device_value
+  data:
+    address: "LEQ1234567"
+    channel: 1
+    param: ACTIVE_PROFILE
+    value: 1
+    value_type: int
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+address:
+  description: "The address of the Homematic device, or BidCoS-RF for the virtual remote."
+  required: true
+  type: string
+channel:
+  description: "The channel to send the value to."
+  required: true
+  type: integer
+param:
+  description: "The parameter to set, such as STATE or SET_TEMPERATURE."
+  required: true
+  type: string
+value:
+  description: "The new value to set."
+  required: true
+  type: any
+value_type:
+  description: "The type to convert the value to: boolean, dateTime.iso8601, double, int, or string."
+  required: false
+  type: string
+interface:
+  description: "The name of the interface from your configuration. Only needed when you have more than one."
+  required: false
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/homematic.set_install_mode.markdown
+++ b/source/_actions/homematic.set_install_mode.markdown
@@ -1,0 +1,83 @@
+---
+title: "Set install mode"
+action: homematic.set_install_mode
+domain: homematic
+description: "Sets a Homematic RPC XML interface into installation mode."
+related_actions:
+  - homematic.virtualkey
+  - homematic.set_device_value
+  - homematic.set_variable_value
+  - homematic.put_paramset
+  - homematic.reconnect
+---
+
+Use this action to put an RPC XML interface into installation mode so you can pair, or learn, a new device.
+
+{% include actions/ui_header.md %}
+
+To set install mode from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Homematic: Set install mode**.
+6. Enter the **Interface** and, optionally, a **Mode**, **Time**, and **Address**.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label. Only users with administrator rights can run this action.
+
+### Options in the UI
+
+{% options_ui %}
+Interface:
+  description: "The interface to set into install mode."
+  required: true
+Mode:
+  description: "The install mode: 1 for normal mode, or 2 to remove existing old links."
+Time:
+  description: "How long to stay in install mode, in seconds."
+Address:
+  description: "The address of the Homematic device, or BidCoS-RF, to learn."
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `homematic.set_install_mode`:
+
+{% example %}
+action: |
+  action: homematic.set_install_mode
+  data:
+    interface: wireless
+    time: 120
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+interface:
+  description: "The interface to set into install mode."
+  required: true
+  type: string
+mode:
+  description: "The install mode: 1 for normal mode, or 2 to remove existing old links."
+  required: false
+  type: integer
+  default: 1
+time:
+  description: "How long to stay in install mode, in seconds."
+  required: false
+  type: integer
+  default: 60
+address:
+  description: "The address of the Homematic device, or BidCoS-RF, to learn."
+  required: false
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/homematic.set_install_mode.markdown
+++ b/source/_actions/homematic.set_install_mode.markdown
@@ -2,7 +2,7 @@
 title: "Set install mode"
 action: homematic.set_install_mode
 domain: homematic
-description: "Sets a Homematic RPC XML interface into installation mode."
+description: "Sets a Homematic XML-RPC interface into installation mode."
 related_actions:
   - homematic.virtualkey
   - homematic.set_device_value
@@ -11,7 +11,7 @@ related_actions:
   - homematic.reconnect
 ---
 
-Use this action to put an RPC XML interface into installation mode so you can pair, or learn, a new device.
+Use this action to put an XML-RPC interface into installation mode so you can pair, or learn, a new device.
 
 {% include actions/ui_header.md %}
 

--- a/source/_actions/homematic.set_variable_value.markdown
+++ b/source/_actions/homematic.set_variable_value.markdown
@@ -1,0 +1,77 @@
+---
+title: "Set variable value"
+action: homematic.set_variable_value
+domain: homematic
+description: "Sets the value of a Homematic system variable."
+related_actions:
+  - homematic.set_device_value
+  - homematic.virtualkey
+  - homematic.put_paramset
+  - homematic.reconnect
+  - homematic.set_install_mode
+---
+
+Use this action to set the value of a system variable on your CCU or Homegear.
+
+{% include actions/ui_header.md %}
+
+To set a variable value from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Homematic: Set variable value**.
+6. Enter the variable **Name** and the new **Value** and, optionally, choose an **Entity**.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label. To set the variable on a specific Homematic hub, use the **Entity** field instead. When you leave it empty, the variable is set on all hubs.
+
+### Options in the UI
+
+{% options_ui %}
+Name:
+  description: "The name of the variable to set."
+  required: true
+Value:
+  description: "The new value for the variable."
+  required: true
+Entity:
+  description: "One or more Homematic hub entities to set the variable on. Defaults to all hubs."
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `homematic.set_variable_value`:
+
+{% example %}
+action: |
+  action: homematic.set_variable_value
+  data:
+    name: "Variablename"
+    value: true
+    entity_id: homematic.ccu2
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+name:
+  description: "The name of the variable to set."
+  required: true
+  type: string
+value:
+  description: "The new value for the variable."
+  required: true
+  type: any
+entity_id:
+  description: "One or more Homematic hub entities to set the variable on. Defaults to all hubs."
+  required: false
+  type: [string, list]
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/homematic.virtualkey.markdown
+++ b/source/_actions/homematic.virtualkey.markdown
@@ -1,0 +1,95 @@
+---
+title: "Virtual key"
+action: homematic.virtualkey
+domain: homematic
+description: "Simulates a keypress on a Homematic device or virtual remote."
+related_actions:
+  - homematic.set_device_value
+  - homematic.set_variable_value
+  - homematic.put_paramset
+  - homematic.reconnect
+  - homematic.set_install_mode
+---
+
+Use this action to simulate a keypress, or another valid action, on a CCU or Homegear using virtual or device keys. It is handy for pressing buttons on devices such as a BidCoS-RF virtual remote or a KeyMatic lock.
+
+{% include actions/ui_header.md %}
+
+To simulate a keypress from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Homematic: Virtual key**.
+6. Enter the **Address**, **Channel**, and **Param** and, optionally, an **Interface**.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Address:
+  description: "The address of the Homematic device, or BidCoS-RF for the virtual remote."
+  required: true
+Channel:
+  description: "The channel to send the keypress to."
+  required: true
+Param:
+  description: "The event to send, such as PRESS_LONG or PRESS_SHORT."
+  required: true
+Interface:
+  description: "The name of the interface from your configuration. Only needed when you have more than one."
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `homematic.virtualkey`:
+
+{% example %}
+action: |
+  action: homematic.virtualkey
+  data:
+    address: "BidCoS-RF"
+    channel: 1
+    param: PRESS_LONG
+{% endexample %}
+
+To open a KeyMatic lock:
+
+{% example %}
+action: |
+  action: homematic.virtualkey
+  data:
+    address: "LEQ1234567"
+    channel: 1
+    param: OPEN
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+address:
+  description: "The address of the Homematic device, or BidCoS-RF for the virtual remote."
+  required: true
+  type: string
+channel:
+  description: "The channel to send the keypress to."
+  required: true
+  type: integer
+param:
+  description: "The event to send, such as PRESS_LONG or PRESS_SHORT."
+  required: true
+  type: string
+interface:
+  description: "The name of the interface from your configuration. Only needed when you have more than one."
+  required: false
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/homematic.markdown
+++ b/source/_integrations/homematic.markdown
@@ -289,155 +289,9 @@ To get the `homematic.keypress` event for some Homematic IP devices like WRC2 / 
 8. When your channel is working now, you can edit it to select the other channels one by one
 9. At the end, you can delete this program from the CCU
 
-### Actions
+{% include integrations/actions.md %}
 
-- *homematic.virtualkey*: Simulate a keypress (or other valid action) on CCU/Homegear with device or virtual keys.
-- *homematic.reconnect*: Reconnect to CCU/Homegear without restarting Home Assistant (useful when CCU has been restarted)
-- *homematic.set_variable_value*: Set the value of a system variable.
-- *homematic.set_device_value*: Control a device manually (even devices without support). Equivalent to setValue-method from XML-RPC.
-- *homematic.put_paramset*: Manually change a device's paramset (even devices without support). Equivalent to putParamset-method from XML-RPC.
-
-#### Examples
-
-Simulate a button being pressed:
-
-```yaml
-...
-actions:
-  - action: homematic.virtualkey
-    data:
-      address: "BidCoS-RF"
-      channel: 1
-      param: PRESS_LONG
-```
-
-Open KeyMatic:
-
-```yaml
-...
-actions:
-  - action: homematic.virtualkey
-    data:
-      address: "LEQ1234567"
-      channel: 1
-      param: OPEN
-```
-
-Set boolean variable to true:
-
-```yaml
-...
-actions:
-  - action: homematic.set_variable_value
-    target:
-      entity_id: homematic.ccu2
-    data:
-      name: "Variablename"
-      value: true
-```
-
-#### Advanced examples
-
-If you are familiar with the internals of Homematic devices, you can manually set values on the devices. This can serve as a workaround if support for a device is currently not available, or only limited functionality has been implemented.
-Using this action provides you direct access to the setValue-method of the primary connection. If you have multiple hosts, you may select the one hosting a specific device by providing the proxy-parameter with a value equivalent to the name you have chosen. In the example configuration from above, `rf`, `wired`, and `ip` would be valid values.
-
-Manually turn on a switch actor:
-
-```yaml
-...
-actions:
-  - action: homematic.set_device_value
-    data:
-      address: "LEQ1234567"
-      channel: 1
-      param: STATE
-      value: true
-```
-
-Manually set temperature on thermostat:
-
-```yaml
-...
-actions:
-  - action: homematic.set_device_value
-    data:
-      address: "LEQ1234567"
-      channel: 4
-      param: SET_TEMPERATURE
-      value: 23.0
-```
-
-Manually set the active profile on thermostat:
-
-```yaml
-...
-actions:
-  - action: homematic.set_device_value
-    data:
-      address: "LEQ1234567"
-      channel: 1
-      param: ACTIVE_PROFILE
-      value: 1
-      value_type: int
-```
-
-Set the week program of a wall thermostat:
-
-```yaml
-...
-actions:
-  - action: homematic.put_paramset
-    data:
-      interface: wireless
-      address: "LEQ1234567"
-      paramset_key: MASTER
-      paramset:
-        WEEK_PROGRAM_POINTER: 1
-```
-
-Set the week program of a wall thermostat with explicit `rx_mode` (BidCos-RF only):
-
-```yaml
-...
-actions:
-  - action: homematic.put_paramset
-    data:
-      interface: wireless
-      address: "LEQ1234567"
-      paramset_key: MASTER
-      rx_mode: WAKEUP
-      paramset:
-        WEEK_PROGRAM_POINTER: 1
-```
-
-BidCos-RF devices have an optional parameter for put_paramset which defines the way the configuration data is sent to the device.
-
-`rx_mode` `BURST`, which is the default value, will wake up every device when submitting the configuration data and hence makes all devices use some battery. It is instant, that is, the data is sent almost immediately.
-
-`rx_mode` `WAKEUP` will send the configuration data only after a device submitted updated values to CCU, which usually happens every 3 minutes. It will not wake up every device and thus saves devices battery.
-
-Manually set lock on KeyMatic devices:
-
-```yaml
-...
-actions:
-  - action: lock.lock
-    target:
-      entity_id: lock.leq1234567
-```
-
-Manually set unlock on KeyMatic devices:
-
-```yaml
-...
-actions:
-  - action: lock.unlock
-    target:
-      entity_id: lock.leq1234567
-```
-
-
-#### Integrating HMIP-DLD
+## Integrating HMIP-DLD
 
 There is no available default integration for HMIP Doorlock (HMIP-DLD) in the current `pyhomematic` implementation.
 A workaround is to define a template lock in your configuration:
@@ -464,7 +318,7 @@ lock:
         value: 1
 ```
 
-#### Detecting lost connections
+## Detecting lost connections
 
 When the connection to your Homematic CCU or Homegear is lost, Home Assistant will stop getting updates from devices. This may happen after rebooting the CCU for example. Due to the nature of the communication protocol this cannot be handled automatically, so you must call *homematic.reconnect* in this case. That's why it is usually a good idea to check if your Homematic integrations are still updated properly, to detect connection losses. This can be done in several ways through an automation:
 


### PR DESCRIPTION
## Proposed change

Migrate the Homematic action documentation from the integration page into dedicated action pages under `source/_actions/`, one file per action, and replace the inline action list and examples with `{% include integrations/actions.md %}`.

This covers all six actions registered by the integration: `virtualkey`, `set_variable_value`, `set_device_value`, `reconnect`, `put_paramset`, and `set_install_mode`. The `set_install_mode` action was callable but undocumented, so it is now documented for completeness. The HMIP-DLD workaround and the connection-loss detection guidance are kept on the integration page.

- Part of epic: home-assistant/epics#96

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
