### PR TITLE
Revert "Add documentation for `multiple` in media selector"

### DIFF
--- a/source/_docs/blueprint/selectors.markdown
+++ b/source/_docs/blueprint/selectors.markdown
@@ -1131,13 +1131,6 @@ accept:
     List of media types the user is allowed to select.
   type: list
   required: false
-multiple:
-  description: >
-    Allows selecting multiple media items. If set to `true`, the resulting value of
-    this selector will be a list instead of a single object.
-  type: boolean
-  default: false
-  required: false
 {% endconfiguration %}
 
 The output of the media selector is a mapping with information about
@@ -1182,19 +1175,6 @@ metadata:
     - media_content_type: provider
       media_content_id: >-
         media-source://tts/cloud?message=TTS+Message&language=en-US&gender=female
-```
-
-Example output when `multiple` is set to `true` (a list of media objects):
-
-```yaml
-- media_content_id: media-source://media_source/local/image1.jpg
-  media_content_type: image/jpeg
-  metadata:
-    title: image1.jpg
-- media_content_id: media-source://media_source/local/image2.jpg
-  media_content_type: image/jpeg
-  metadata:
-    title: image2.jpg
 ```
 
 ## Number selector


### PR DESCRIPTION
Reverts home-assistant/home-assistant.io#42167

No frontend PR was ever done to add this support. Adding 'multiple' to the media selector does not do anything to the selector visibly, and users cannot select multiple medias.

Documention should be withheld until such time as this support actually exists?