### PR TITLE
Xiaomi Miio: migrate actions to dedicated action pages

### DIFF
--- a/source/_actions/xiaomi_miio.fan_reset_filter.markdown
+++ b/source/_actions/xiaomi_miio.fan_reset_filter.markdown
@@ -1,0 +1,58 @@
+---
+title: "Fan reset filter"
+action: xiaomi_miio.fan_reset_filter
+domain: xiaomi_miio
+description: "Resets the filter lifetime and usage of a Xiaomi air purifier."
+related_actions:
+  - xiaomi_miio.fan_set_extra_features
+---
+
+The **Fan reset filter** action resets the filter lifetime and usage counter of a Xiaomi air purifier. Use it after you replace the filter so the remaining filter life is reported correctly again.
+
+{% include actions/ui_header.md %}
+
+To reset the filter from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Xiaomi Home: Fan reset filter**.
+6. Select **Save**.
+
+This action does not support targets. In the UI, use the **Entity ID** field to choose which Xiaomi air purifier to reset. If you leave it empty, the action applies to all of them.
+
+### Options in the UI
+
+{% options_ui %}
+Entity ID:
+  description: The Xiaomi air purifier to reset the filter for. If you leave this empty, all of them are reset.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `xiaomi_miio.fan_reset_filter`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: xiaomi_miio.fan_reset_filter
+  data:
+    entity_id: fan.air_purifier
+{% endexample %}
+
+This resets the filter counter for `fan.air_purifier`.
+
+### Options in YAML
+
+{% options_yaml %}
+entity_id:
+  description: The Xiaomi air purifier to reset the filter for. If you leave this out, all of them are reset.
+  required: false
+  type: [string, list]
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/xiaomi_miio.fan_set_extra_features.markdown
+++ b/source/_actions/xiaomi_miio.fan_set_extra_features.markdown
@@ -1,0 +1,67 @@
+---
+title: "Fan set extra features"
+action: xiaomi_miio.fan_set_extra_features
+domain: xiaomi_miio
+description: "Sets a storage register that unlocks extra features in the Mi Home app."
+related_actions:
+  - xiaomi_miio.fan_reset_filter
+---
+
+The **Fan set extra features** action writes a storage register on a Xiaomi air purifier that advertises extra features. The Mi Home app reads this value. Setting it to `1` unlocks a feature called turbo mode in the app.
+
+{% include actions/ui_header.md %}
+
+To set the extra features from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Xiaomi Home: Fan set extra features**.
+6. Enter the **Features** value.
+7. Select **Save**.
+
+This action does not support targets. In the UI, use the **Entity ID** field to choose which Xiaomi air purifier to act on. If you leave it empty, the action applies to all of them.
+
+### Options in the UI
+
+{% options_ui %}
+Entity ID:
+  description: The Xiaomi air purifier to act on. If you leave this empty, all of them are affected.
+Features:
+  description: "The features value to write. Known values are 0 (default) and 1 (turbo mode)."
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `xiaomi_miio.fan_set_extra_features`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: xiaomi_miio.fan_set_extra_features
+  data:
+    entity_id: fan.air_purifier
+    features: 1
+{% endexample %}
+
+This unlocks turbo mode in the Mi Home app for `fan.air_purifier`.
+
+### Options in YAML
+
+{% options_yaml %}
+entity_id:
+  description: The Xiaomi air purifier to act on. If you leave this out, all of them are affected.
+  required: false
+  type: [string, list]
+features:
+  description: "The features value to write. Known values are 0 (default) and 1 (turbo mode)."
+  required: true
+  type: integer
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/xiaomi_miio.light_eyecare_mode_off.markdown
+++ b/source/_actions/xiaomi_miio.light_eyecare_mode_off.markdown
@@ -1,0 +1,58 @@
+---
+title: "Light eyecare mode off"
+action: xiaomi_miio.light_eyecare_mode_off
+domain: xiaomi_miio
+description: "Turns off eyecare mode on a Xiaomi Philips Eyecare Smart Lamp 2."
+related_actions:
+  - xiaomi_miio.light_eyecare_mode_on
+---
+
+The **Light eyecare mode off** action turns off eyecare mode. This action only works with the Philips Eyecare Smart Lamp 2.
+
+{% include actions/ui_header.md %}
+
+To turn off eyecare mode from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Xiaomi Home: Light eyecare mode off**.
+6. Select **Save**.
+
+This action does not support targets. In the UI, use the **Entity ID** field to choose which Eyecare Smart Lamp 2 to act on. If you leave it empty, the action applies to all of them.
+
+### Options in the UI
+
+{% options_ui %}
+Entity ID:
+  description: The Eyecare Smart Lamp 2 to act on. If you leave this empty, all of them are affected.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `xiaomi_miio.light_eyecare_mode_off`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: xiaomi_miio.light_eyecare_mode_off
+  data:
+    entity_id: light.eyecare_lamp
+{% endexample %}
+
+This turns off eyecare mode on `light.eyecare_lamp`.
+
+### Options in YAML
+
+{% options_yaml %}
+entity_id:
+  description: The Eyecare Smart Lamp 2 to act on. If you leave this out, all of them are affected.
+  required: false
+  type: [string, list]
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/xiaomi_miio.light_eyecare_mode_on.markdown
+++ b/source/_actions/xiaomi_miio.light_eyecare_mode_on.markdown
@@ -1,0 +1,58 @@
+---
+title: "Light eyecare mode on"
+action: xiaomi_miio.light_eyecare_mode_on
+domain: xiaomi_miio
+description: "Turns on eyecare mode on a Xiaomi Philips Eyecare Smart Lamp 2."
+related_actions:
+  - xiaomi_miio.light_eyecare_mode_off
+---
+
+The **Light eyecare mode on** action turns on eyecare mode. This action only works with the Philips Eyecare Smart Lamp 2.
+
+{% include actions/ui_header.md %}
+
+To turn on eyecare mode from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Xiaomi Home: Light eyecare mode on**.
+6. Select **Save**.
+
+This action does not support targets. In the UI, use the **Entity ID** field to choose which Eyecare Smart Lamp 2 to act on. If you leave it empty, the action applies to all of them.
+
+### Options in the UI
+
+{% options_ui %}
+Entity ID:
+  description: The Eyecare Smart Lamp 2 to act on. If you leave this empty, all of them are affected.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `xiaomi_miio.light_eyecare_mode_on`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: xiaomi_miio.light_eyecare_mode_on
+  data:
+    entity_id: light.eyecare_lamp
+{% endexample %}
+
+This turns on eyecare mode on `light.eyecare_lamp`.
+
+### Options in YAML
+
+{% options_yaml %}
+entity_id:
+  description: The Eyecare Smart Lamp 2 to act on. If you leave this out, all of them are affected.
+  required: false
+  type: [string, list]
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/xiaomi_miio.light_night_light_mode_off.markdown
+++ b/source/_actions/xiaomi_miio.light_night_light_mode_off.markdown
@@ -1,0 +1,58 @@
+---
+title: "Light night light mode off"
+action: xiaomi_miio.light_night_light_mode_off
+domain: xiaomi_miio
+description: "Turns off night light mode on a Xiaomi Philips Eyecare Smart Lamp 2."
+related_actions:
+  - xiaomi_miio.light_night_light_mode_on
+---
+
+The **Light night light mode off** action turns off night light mode. This action only works with the Philips Eyecare Smart Lamp 2.
+
+{% include actions/ui_header.md %}
+
+To turn off night light mode from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Xiaomi Home: Light night light mode off**.
+6. Select **Save**.
+
+This action does not support targets. In the UI, use the **Entity ID** field to choose which Eyecare Smart Lamp 2 to act on. If you leave it empty, the action applies to all of them.
+
+### Options in the UI
+
+{% options_ui %}
+Entity ID:
+  description: The Eyecare Smart Lamp 2 to act on. If you leave this empty, all of them are affected.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `xiaomi_miio.light_night_light_mode_off`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: xiaomi_miio.light_night_light_mode_off
+  data:
+    entity_id: light.eyecare_lamp
+{% endexample %}
+
+This turns off night light mode on `light.eyecare_lamp`.
+
+### Options in YAML
+
+{% options_yaml %}
+entity_id:
+  description: The Eyecare Smart Lamp 2 to act on. If you leave this out, all of them are affected.
+  required: false
+  type: [string, list]
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/xiaomi_miio.light_night_light_mode_on.markdown
+++ b/source/_actions/xiaomi_miio.light_night_light_mode_on.markdown
@@ -1,0 +1,58 @@
+---
+title: "Light night light mode on"
+action: xiaomi_miio.light_night_light_mode_on
+domain: xiaomi_miio
+description: "Turns on night light mode on a Xiaomi Philips Eyecare Smart Lamp 2."
+related_actions:
+  - xiaomi_miio.light_night_light_mode_off
+---
+
+The **Light night light mode on** action turns on night light mode. This action only works with the Philips Eyecare Smart Lamp 2.
+
+{% include actions/ui_header.md %}
+
+To turn on night light mode from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Xiaomi Home: Light night light mode on**.
+6. Select **Save**.
+
+This action does not support targets. In the UI, use the **Entity ID** field to choose which Eyecare Smart Lamp 2 to act on. If you leave it empty, the action applies to all of them.
+
+### Options in the UI
+
+{% options_ui %}
+Entity ID:
+  description: The Eyecare Smart Lamp 2 to act on. If you leave this empty, all of them are affected.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `xiaomi_miio.light_night_light_mode_on`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: xiaomi_miio.light_night_light_mode_on
+  data:
+    entity_id: light.eyecare_lamp
+{% endexample %}
+
+This turns on night light mode on `light.eyecare_lamp`.
+
+### Options in YAML
+
+{% options_yaml %}
+entity_id:
+  description: The Eyecare Smart Lamp 2 to act on. If you leave this out, all of them are affected.
+  required: false
+  type: [string, list]
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/xiaomi_miio.light_reminder_off.markdown
+++ b/source/_actions/xiaomi_miio.light_reminder_off.markdown
@@ -1,0 +1,58 @@
+---
+title: "Light reminder off"
+action: xiaomi_miio.light_reminder_off
+domain: xiaomi_miio
+description: "Disables the eye fatigue reminder on a Xiaomi Philips Eyecare Smart Lamp 2."
+related_actions:
+  - xiaomi_miio.light_reminder_on
+---
+
+The **Light reminder off** action disables the eye fatigue reminder notification. This action only works with the Philips Eyecare Smart Lamp 2.
+
+{% include actions/ui_header.md %}
+
+To disable the reminder from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Xiaomi Home: Light reminder off**.
+6. Select **Save**.
+
+This action does not support targets. In the UI, use the **Entity ID** field to choose which Eyecare Smart Lamp 2 to act on. If you leave it empty, the action applies to all of them.
+
+### Options in the UI
+
+{% options_ui %}
+Entity ID:
+  description: The Eyecare Smart Lamp 2 to act on. If you leave this empty, all of them are affected.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `xiaomi_miio.light_reminder_off`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: xiaomi_miio.light_reminder_off
+  data:
+    entity_id: light.eyecare_lamp
+{% endexample %}
+
+This disables the eye fatigue reminder on `light.eyecare_lamp`.
+
+### Options in YAML
+
+{% options_yaml %}
+entity_id:
+  description: The Eyecare Smart Lamp 2 to act on. If you leave this out, all of them are affected.
+  required: false
+  type: [string, list]
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/xiaomi_miio.light_reminder_on.markdown
+++ b/source/_actions/xiaomi_miio.light_reminder_on.markdown
@@ -1,0 +1,58 @@
+---
+title: "Light reminder on"
+action: xiaomi_miio.light_reminder_on
+domain: xiaomi_miio
+description: "Enables the eye fatigue reminder on a Xiaomi Philips Eyecare Smart Lamp 2."
+related_actions:
+  - xiaomi_miio.light_reminder_off
+---
+
+The **Light reminder on** action enables the eye fatigue reminder notification. This action only works with the Philips Eyecare Smart Lamp 2.
+
+{% include actions/ui_header.md %}
+
+To enable the reminder from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Xiaomi Home: Light reminder on**.
+6. Select **Save**.
+
+This action does not support targets. In the UI, use the **Entity ID** field to choose which Eyecare Smart Lamp 2 to act on. If you leave it empty, the action applies to all of them.
+
+### Options in the UI
+
+{% options_ui %}
+Entity ID:
+  description: The Eyecare Smart Lamp 2 to act on. If you leave this empty, all of them are affected.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `xiaomi_miio.light_reminder_on`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: xiaomi_miio.light_reminder_on
+  data:
+    entity_id: light.eyecare_lamp
+{% endexample %}
+
+This enables the eye fatigue reminder on `light.eyecare_lamp`.
+
+### Options in YAML
+
+{% options_yaml %}
+entity_id:
+  description: The Eyecare Smart Lamp 2 to act on. If you leave this out, all of them are affected.
+  required: false
+  type: [string, list]
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/xiaomi_miio.light_set_delayed_turn_off.markdown
+++ b/source/_actions/xiaomi_miio.light_set_delayed_turn_off.markdown
@@ -1,0 +1,67 @@
+---
+title: "Light set delayed turn off"
+action: xiaomi_miio.light_set_delayed_turn_off
+domain: xiaomi_miio
+description: "Schedules a Xiaomi Philips light to turn off after a delay."
+related_actions:
+  - xiaomi_miio.light_set_scene
+---
+
+The **Light set delayed turn off** action schedules a Xiaomi Philips light to turn off automatically after a set amount of time.
+
+{% include actions/ui_header.md %}
+
+To schedule a delayed turn off from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Xiaomi Home: Light set delayed turn off**.
+6. Enter the **Time period** after which the light turns off.
+7. Select **Save**.
+
+This action does not support targets. In the UI, use the **Entity ID** field to choose which Xiaomi Philips light to act on. If you leave it empty, the action applies to all of them.
+
+### Options in the UI
+
+{% options_ui %}
+Entity ID:
+  description: The Xiaomi Philips light to act on. If you leave this empty, all of them are affected.
+Time period:
+  description: "The delay after which the light turns off, as a number of seconds or as a time in the format HH:MM:SS."
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `xiaomi_miio.light_set_delayed_turn_off`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: xiaomi_miio.light_set_delayed_turn_off
+  data:
+    entity_id: light.philips_light
+    time_period: "00:05:00"
+{% endexample %}
+
+This turns off `light.philips_light` after five minutes.
+
+### Options in YAML
+
+{% options_yaml %}
+entity_id:
+  description: The Xiaomi Philips light to act on. If you leave this out, all of them are affected.
+  required: false
+  type: [string, list]
+time_period:
+  description: "The delay after which the light turns off, as a number of seconds or as a time in the format HH:MM:SS."
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/xiaomi_miio.light_set_scene.markdown
+++ b/source/_actions/xiaomi_miio.light_set_scene.markdown
@@ -1,0 +1,67 @@
+---
+title: "Light set scene"
+action: xiaomi_miio.light_set_scene
+domain: xiaomi_miio
+description: "Sets a fixed scene on a Xiaomi Philips light."
+related_actions:
+  - xiaomi_miio.light_set_delayed_turn_off
+---
+
+The **Light set scene** action activates one of the fixed scenes built into a Xiaomi Philips light.
+
+{% include actions/ui_header.md %}
+
+To set a scene from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Xiaomi Home: Light set scene**.
+6. Enter the **Scene** number.
+7. Select **Save**.
+
+This action does not support targets. In the UI, use the **Entity ID** field to choose which Xiaomi Philips light to act on. If you leave it empty, the action applies to all of them.
+
+### Options in the UI
+
+{% options_ui %}
+Entity ID:
+  description: The Xiaomi Philips light to act on. If you leave this empty, all of them are affected.
+Scene:
+  description: The number of the fixed scene to activate, from 1 to 6.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `xiaomi_miio.light_set_scene`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: xiaomi_miio.light_set_scene
+  data:
+    entity_id: light.philips_light
+    scene: 1
+{% endexample %}
+
+This activates the first fixed scene on `light.philips_light`.
+
+### Options in YAML
+
+{% options_yaml %}
+entity_id:
+  description: The Xiaomi Philips light to act on. If you leave this out, all of them are affected.
+  required: false
+  type: [string, list]
+scene:
+  description: The number of the fixed scene to activate, from 1 to 6.
+  required: true
+  type: integer
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/xiaomi_miio.remote_learn_command.markdown
+++ b/source/_actions/xiaomi_miio.remote_learn_command.markdown
@@ -1,0 +1,72 @@
+---
+title: "Remote learn command"
+action: xiaomi_miio.remote_learn_command
+domain: xiaomi_miio
+description: "Learns an IR command with a Xiaomi IR remote."
+related_actions:
+  - xiaomi_miio.remote_set_led_on
+  - xiaomi_miio.remote_set_led_off
+---
+
+The **Remote learn command** action puts a Xiaomi IR remote into learning mode. After you start it, point a physical remote at the device and press a button. The learned command is shown as a notification in Overview, ready to copy into your configuration.
+
+{% include actions/ui_header.md %}
+
+To learn a command from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Xiaomi IR remote you want to control.
+6. From the actions shown for that target, select **Remote learn command**.
+7. Optionally, set the **Slot** and **Timeout**.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Slot:
+  description: The storage slot to save the learned IR command in.
+Timeout:
+  description: How long, in seconds, to wait for a command to be learned before giving up.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `xiaomi_miio.remote_learn_command`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: xiaomi_miio.remote_learn_command
+  target:
+    entity_id: remote.xiaomi_miio_remote
+  data:
+    slot: 1
+    timeout: 30
+{% endexample %}
+
+This starts learning a command on `remote.xiaomi_miio_remote`, saving it to slot 1, and waits up to 30 seconds.
+
+### Options in YAML
+
+{% options_yaml %}
+slot:
+  description: The storage slot to save the learned IR command in.
+  required: false
+  type: integer
+  default: 1
+timeout:
+  description: How long, in seconds, to wait for a command to be learned before giving up.
+  required: false
+  type: integer
+  default: 10
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="remote" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/xiaomi_miio.remote_set_led_off.markdown
+++ b/source/_actions/xiaomi_miio.remote_set_led_off.markdown
@@ -1,0 +1,44 @@
+---
+title: "Remote set LED off"
+action: xiaomi_miio.remote_set_led_off
+domain: xiaomi_miio
+description: "Turns off the blue LED of a Xiaomi IR remote."
+related_actions:
+  - xiaomi_miio.remote_set_led_on
+  - xiaomi_miio.remote_learn_command
+---
+
+The **Remote set LED off** action turns off the blue status LED of a Xiaomi IR remote.
+
+{% include actions/ui_header.md %}
+
+To turn off the LED from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Xiaomi IR remote you want to control.
+6. From the actions shown for that target, select **Remote set LED off**.
+7. Select **Save**.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `xiaomi_miio.remote_set_led_off`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: xiaomi_miio.remote_set_led_off
+  target:
+    entity_id: remote.xiaomi_miio_remote
+{% endexample %}
+
+This turns off the blue LED of `remote.xiaomi_miio_remote`.
+
+{% include actions/targets.md domain="remote" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/xiaomi_miio.remote_set_led_on.markdown
+++ b/source/_actions/xiaomi_miio.remote_set_led_on.markdown
@@ -1,0 +1,44 @@
+---
+title: "Remote set LED on"
+action: xiaomi_miio.remote_set_led_on
+domain: xiaomi_miio
+description: "Turns on the blue LED of a Xiaomi IR remote."
+related_actions:
+  - xiaomi_miio.remote_set_led_off
+  - xiaomi_miio.remote_learn_command
+---
+
+The **Remote set LED on** action turns on the blue status LED of a Xiaomi IR remote.
+
+{% include actions/ui_header.md %}
+
+To turn on the LED from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Xiaomi IR remote you want to control.
+6. From the actions shown for that target, select **Remote set LED on**.
+7. Select **Save**.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `xiaomi_miio.remote_set_led_on`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: xiaomi_miio.remote_set_led_on
+  target:
+    entity_id: remote.xiaomi_miio_remote
+{% endexample %}
+
+This turns on the blue LED of `remote.xiaomi_miio_remote`.
+
+{% include actions/targets.md domain="remote" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/xiaomi_miio.switch_set_power_mode.markdown
+++ b/source/_actions/xiaomi_miio.switch_set_power_mode.markdown
@@ -1,0 +1,67 @@
+---
+title: "Switch set power mode"
+action: xiaomi_miio.switch_set_power_mode
+domain: xiaomi_miio
+description: "Sets the power mode of a Xiaomi power strip."
+related_actions:
+  - xiaomi_miio.switch_set_power_price
+---
+
+The **Switch set power mode** action sets the power mode of a Xiaomi power strip. This action only works with power strips that support a power mode.
+
+{% include actions/ui_header.md %}
+
+To set the power mode from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Xiaomi Home: Switch set power mode**.
+6. Select the **Mode**.
+7. Select **Save**.
+
+This action does not support targets. In the UI, use the **Entity ID** field to choose which Xiaomi power strip to act on. If you leave it empty, the action applies to all of them.
+
+### Options in the UI
+
+{% options_ui %}
+Entity ID:
+  description: The Xiaomi power strip to act on. If you leave this empty, all of them are affected.
+Mode:
+  description: "The power mode to set. Choose either green or normal."
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `xiaomi_miio.switch_set_power_mode`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: xiaomi_miio.switch_set_power_mode
+  data:
+    entity_id: switch.power_strip
+    mode: green
+{% endexample %}
+
+This sets `switch.power_strip` to the green power mode.
+
+### Options in YAML
+
+{% options_yaml %}
+entity_id:
+  description: The Xiaomi power strip to act on. If you leave this out, all of them are affected.
+  required: false
+  type: [string, list]
+mode:
+  description: "The power mode to set. Choose either green or normal."
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/xiaomi_miio.switch_set_power_price.markdown
+++ b/source/_actions/xiaomi_miio.switch_set_power_price.markdown
@@ -1,0 +1,71 @@
+---
+title: "Switch set power price"
+action: xiaomi_miio.switch_set_power_price
+domain: xiaomi_miio
+description: "Sets the power price stored on a Xiaomi power strip."
+related_actions:
+  - xiaomi_miio.switch_set_power_mode
+---
+
+The **Switch set power price** action stores a power price on a Xiaomi power strip. The power strip uses this value to calculate energy cost.
+
+{% include actions/ui_header.md %}
+
+To set the power price from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Xiaomi Home: Switch set power price**.
+6. Enter the power price value.
+7. Select **Save**.
+
+This action does not support targets. In the UI, use the **Entity ID** field to choose which Xiaomi power strip to act on. If you leave it empty, the action applies to all of them.
+
+### Options in the UI
+
+{% options_ui %}
+Entity ID:
+  description: The Xiaomi power strip to act on. If you leave this empty, all of them are affected.
+Price:
+  description: The power price to store on the power strip.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `xiaomi_miio.switch_set_power_price`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: xiaomi_miio.switch_set_power_price
+  data:
+    entity_id: switch.power_strip
+    price: 0.25
+{% endexample %}
+
+This stores a power price of `0.25` on `switch.power_strip`.
+
+### Options in YAML
+
+{% options_yaml %}
+entity_id:
+  description: The Xiaomi power strip to act on. If you leave this out, all of them are affected.
+  required: false
+  type: [string, list]
+price:
+  description: The power price to store on the power strip.
+  required: true
+  type: float
+{% endoptions_yaml %}
+
+## Good to know
+
+- The power price is sent in the `price` field. If you call this action from YAML, use `price`, as shown above.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/xiaomi_miio.switch_set_wifi_led_off.markdown
+++ b/source/_actions/xiaomi_miio.switch_set_wifi_led_off.markdown
@@ -1,0 +1,58 @@
+---
+title: "Switch set Wi-Fi LED off"
+action: xiaomi_miio.switch_set_wifi_led_off
+domain: xiaomi_miio
+description: "Turns off the Wi-Fi LED of a Xiaomi smart plug or power strip."
+related_actions:
+  - xiaomi_miio.switch_set_wifi_led_on
+---
+
+The **Switch set Wi-Fi LED off** action turns off the Wi-Fi status LED of a Xiaomi smart plug or power strip.
+
+{% include actions/ui_header.md %}
+
+To turn off the Wi-Fi LED from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Xiaomi Home: Switch set Wi-Fi LED off**.
+6. Select **Save**.
+
+This action does not support targets. In the UI, use the **Entity ID** field to choose which Xiaomi switch to act on. If you leave it empty, the action applies to all of them.
+
+### Options in the UI
+
+{% options_ui %}
+Entity ID:
+  description: The Xiaomi switch to act on. If you leave this empty, all of them are affected.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `xiaomi_miio.switch_set_wifi_led_off`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: xiaomi_miio.switch_set_wifi_led_off
+  data:
+    entity_id: switch.power_strip
+{% endexample %}
+
+This turns off the Wi-Fi LED of `switch.power_strip`.
+
+### Options in YAML
+
+{% options_yaml %}
+entity_id:
+  description: The Xiaomi switch to act on. If you leave this out, all of them are affected.
+  required: false
+  type: [string, list]
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/xiaomi_miio.switch_set_wifi_led_on.markdown
+++ b/source/_actions/xiaomi_miio.switch_set_wifi_led_on.markdown
@@ -1,0 +1,58 @@
+---
+title: "Switch set Wi-Fi LED on"
+action: xiaomi_miio.switch_set_wifi_led_on
+domain: xiaomi_miio
+description: "Turns on the Wi-Fi LED of a Xiaomi smart plug or power strip."
+related_actions:
+  - xiaomi_miio.switch_set_wifi_led_off
+---
+
+The **Switch set Wi-Fi LED on** action turns on the Wi-Fi status LED of a Xiaomi smart plug or power strip.
+
+{% include actions/ui_header.md %}
+
+To turn on the Wi-Fi LED from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Xiaomi Home: Switch set Wi-Fi LED on**.
+6. Select **Save**.
+
+This action does not support targets. In the UI, use the **Entity ID** field to choose which Xiaomi switch to act on. If you leave it empty, the action applies to all of them.
+
+### Options in the UI
+
+{% options_ui %}
+Entity ID:
+  description: The Xiaomi switch to act on. If you leave this empty, all of them are affected.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `xiaomi_miio.switch_set_wifi_led_on`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: xiaomi_miio.switch_set_wifi_led_on
+  data:
+    entity_id: switch.power_strip
+{% endexample %}
+
+This turns on the Wi-Fi LED of `switch.power_strip`.
+
+### Options in YAML
+
+{% options_yaml %}
+entity_id:
+  description: The Xiaomi switch to act on. If you leave this out, all of them are affected.
+  required: false
+  type: [string, list]
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/xiaomi_miio.vacuum_clean_segment.markdown
+++ b/source/_actions/xiaomi_miio.vacuum_clean_segment.markdown
@@ -1,0 +1,68 @@
+---
+title: "Vacuum clean segment"
+action: xiaomi_miio.vacuum_clean_segment
+domain: xiaomi_miio
+description: "Starts a Xiaomi robot vacuum cleaning one or more segments or rooms."
+related_actions:
+  - xiaomi_miio.vacuum_clean_zone
+  - xiaomi_miio.vacuum_goto
+---
+
+The **Vacuum clean segment** action starts a Xiaomi robot vacuum cleaning one or more segments. A segment is a room that the vacuum has mapped, identified by a number. To find out which numbers map to which rooms, see [Retrieving room numbers](/integrations/xiaomi_miio/#retrieving-room-numbers).
+
+{% include actions/ui_header.md %}
+
+To clean a segment from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Xiaomi robot vacuum you want to control.
+6. From the actions shown for that target, select **Vacuum clean segment**.
+7. Enter the **Segments** to clean.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Segments:
+  description: A single segment number or a list of segment numbers to clean.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `xiaomi_miio.vacuum_clean_segment`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: xiaomi_miio.vacuum_clean_segment
+  target:
+    entity_id: vacuum.xiaomi_vacuum
+  data:
+    segments: [1, 2]
+{% endexample %}
+
+This cleans segments 1 and 2 on `vacuum.xiaomi_vacuum`. To clean a single segment, pass a single number, such as `segments: 1`.
+
+### Options in YAML
+
+{% options_yaml %}
+segments:
+  description: A single segment number or a list of segment numbers to clean.
+  required: true
+  type: [integer, list]
+{% endoptions_yaml %}
+
+## Good to know
+
+- To clean a room more than once, repeat its number in the list. For example, `segments: [1, 1]` cleans segment 1 twice.
+
+{% include actions/targets.md domain="vacuum" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/xiaomi_miio.vacuum_clean_zone.markdown
+++ b/source/_actions/xiaomi_miio.vacuum_clean_zone.markdown
@@ -1,0 +1,78 @@
+---
+title: "Vacuum clean zone"
+action: xiaomi_miio.vacuum_clean_zone
+domain: xiaomi_miio
+description: "Starts a Xiaomi robot vacuum cleaning one or more rectangular zones."
+related_actions:
+  - xiaomi_miio.vacuum_clean_segment
+  - xiaomi_miio.vacuum_goto
+---
+
+The **Vacuum clean zone** action starts a Xiaomi robot vacuum cleaning one or more rectangular zones. You define each zone with a set of coordinates, and you choose how many times the vacuum cleans each one.
+
+{% include actions/ui_header.md %}
+
+To clean a zone from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Xiaomi robot vacuum you want to control.
+6. From the actions shown for that target, select **Vacuum clean zone**.
+7. Enter the **Zone** coordinates and the number of **Repeats**.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Zone:
+  description: A list of zones. Each zone is a list of four integers that describe the start and end coordinates of a rectangle.
+  required: true
+Repeats:
+  description: The number of times to clean each zone, between 1 and 3.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `xiaomi_miio.vacuum_clean_zone`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: xiaomi_miio.vacuum_clean_zone
+  target:
+    entity_id: vacuum.xiaomi_vacuum
+  data:
+    repeats: 1
+    zone:
+      - [30914, 26007, 35514, 28807]
+      - [20232, 22496, 26032, 26496]
+{% endexample %}
+
+This cleans two zones once each on `vacuum.xiaomi_vacuum`.
+
+### Options in YAML
+
+{% options_yaml %}
+zone:
+  description: A list of zones. Each zone is a list of four integers that describe the start and end coordinates of a rectangle.
+  required: true
+  type: list
+repeats:
+  description: The number of times to clean each zone, between 1 and 3.
+  required: true
+  type: integer
+{% endoptions_yaml %}
+
+## Good to know
+
+Each zone is a list of four integers in the form `[x1, y1, x2, y2]`. The first pair is one corner of the rectangle, and the second pair is the opposite corner. For example, `[23510, 25311, 25110, 26361]` starts a box at the `23510, 25311` coordinates and expands it diagonally to the `25110, 26361` coordinates.
+
+{% include actions/targets.md domain="vacuum" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/xiaomi_miio.vacuum_goto.markdown
+++ b/source/_actions/xiaomi_miio.vacuum_goto.markdown
@@ -1,0 +1,76 @@
+---
+title: "Vacuum go to"
+action: xiaomi_miio.vacuum_goto
+domain: xiaomi_miio
+description: "Sends a Xiaomi robot vacuum to a specific coordinate on its map."
+related_actions:
+  - xiaomi_miio.vacuum_clean_zone
+  - xiaomi_miio.vacuum_clean_segment
+---
+
+The **Vacuum go to** action sends a Xiaomi robot vacuum to a specific point on its map, defined by an x- and y-coordinate.
+
+{% include actions/ui_header.md %}
+
+To send the vacuum to a coordinate from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Xiaomi robot vacuum you want to control.
+6. From the actions shown for that target, select **Vacuum go to**.
+7. Enter the **X coordinate** and **Y coordinate**.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+X coordinate:
+  description: The x-coordinate to send the vacuum to. The dock is at x-coordinate 25500.
+  required: true
+Y coordinate:
+  description: The y-coordinate to send the vacuum to. The dock is at y-coordinate 25500.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `xiaomi_miio.vacuum_goto`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: xiaomi_miio.vacuum_goto
+  target:
+    entity_id: vacuum.xiaomi_vacuum
+  data:
+    x_coord: 27500
+    y_coord: 32000
+{% endexample %}
+
+This sends `vacuum.xiaomi_vacuum` to the `27500, 32000` coordinates.
+
+### Options in YAML
+
+{% options_yaml %}
+x_coord:
+  description: The x-coordinate to send the vacuum to. The dock is at x-coordinate 25500.
+  required: true
+  type: integer
+y_coord:
+  description: The y-coordinate to send the vacuum to. The dock is at y-coordinate 25500.
+  required: true
+  type: integer
+{% endoptions_yaml %}
+
+## Good to know
+
+- If the vacuum is moving and does not respond to this action, call the `vacuum.pause` or `vacuum.stop` action first, then try again.
+
+{% include actions/targets.md domain="vacuum" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/xiaomi_miio.vacuum_remote_control_move.markdown
+++ b/source/_actions/xiaomi_miio.vacuum_remote_control_move.markdown
@@ -1,0 +1,78 @@
+---
+title: "Vacuum remote control move"
+action: xiaomi_miio.vacuum_remote_control_move
+domain: xiaomi_miio
+description: "Steers a Xiaomi robot vacuum while it is in remote control mode."
+related_actions:
+  - xiaomi_miio.vacuum_remote_control_start
+  - xiaomi_miio.vacuum_remote_control_move_step
+  - xiaomi_miio.vacuum_remote_control_stop
+---
+
+The **Vacuum remote control move** action steers a Xiaomi robot vacuum. First put the vacuum into remote control mode with the [Vacuum remote control start](/actions/xiaomi_miio.vacuum_remote_control_start/) action, then call this action to set the speed, rotation, and duration of the movement.
+
+{% include actions/ui_header.md %}
+
+To move the vacuum from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Xiaomi robot vacuum you want to control.
+6. From the actions shown for that target, select **Vacuum remote control move**.
+7. Set the **Velocity**, **Rotation**, and **Duration**.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Velocity:
+  description: The speed of the movement, between -0.29 and 0.29. Negative values move the vacuum backward.
+Rotation:
+  description: The rotation of the movement, between -179 and 179 degrees.
+Duration:
+  description: How long, in milliseconds, the vacuum should move for.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `xiaomi_miio.vacuum_remote_control_move`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: xiaomi_miio.vacuum_remote_control_move
+  target:
+    entity_id: vacuum.xiaomi_vacuum
+  data:
+    velocity: 0.2
+    rotation: 0
+    duration: 1500
+{% endexample %}
+
+This moves `vacuum.xiaomi_vacuum` forward for 1.5 seconds.
+
+### Options in YAML
+
+{% options_yaml %}
+velocity:
+  description: The speed of the movement, between -0.29 and 0.29. Negative values move the vacuum backward.
+  required: false
+  type: float
+rotation:
+  description: The rotation of the movement, between -179 and 179 degrees.
+  required: false
+  type: integer
+duration:
+  description: How long, in milliseconds, the vacuum should move for.
+  required: false
+  type: integer
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="vacuum" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/xiaomi_miio.vacuum_remote_control_move_step.markdown
+++ b/source/_actions/xiaomi_miio.vacuum_remote_control_move_step.markdown
@@ -1,0 +1,77 @@
+---
+title: "Vacuum remote control move step"
+action: xiaomi_miio.vacuum_remote_control_move_step
+domain: xiaomi_miio
+description: "Makes a Xiaomi robot vacuum perform a single remote control move."
+related_actions:
+  - xiaomi_miio.vacuum_remote_control_move
+  - xiaomi_miio.vacuum_remote_control_start
+---
+
+The **Vacuum remote control move step** action makes a Xiaomi robot vacuum enter remote control mode, perform one move, and then stop. Unlike [Vacuum remote control move](/actions/xiaomi_miio.vacuum_remote_control_move/), you don't have to start and stop remote control mode separately.
+
+{% include actions/ui_header.md %}
+
+To make a single move from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Xiaomi robot vacuum you want to control.
+6. From the actions shown for that target, select **Vacuum remote control move step**.
+7. Set the **Velocity**, **Rotation**, and **Duration**.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Velocity:
+  description: The speed of the movement, between -0.29 and 0.29. Negative values move the vacuum backward.
+Rotation:
+  description: The rotation of the movement, between -179 and 179 degrees.
+Duration:
+  description: How long, in milliseconds, the vacuum should move for.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `xiaomi_miio.vacuum_remote_control_move_step`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: xiaomi_miio.vacuum_remote_control_move_step
+  target:
+    entity_id: vacuum.xiaomi_vacuum
+  data:
+    velocity: 0.2
+    rotation: 0
+    duration: 1500
+{% endexample %}
+
+This makes `vacuum.xiaomi_vacuum` move forward once for 1.5 seconds and then stop.
+
+### Options in YAML
+
+{% options_yaml %}
+velocity:
+  description: The speed of the movement, between -0.29 and 0.29. Negative values move the vacuum backward.
+  required: false
+  type: float
+rotation:
+  description: The rotation of the movement, between -179 and 179 degrees.
+  required: false
+  type: integer
+duration:
+  description: How long, in milliseconds, the vacuum should move for.
+  required: false
+  type: integer
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="vacuum" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/xiaomi_miio.vacuum_remote_control_start.markdown
+++ b/source/_actions/xiaomi_miio.vacuum_remote_control_start.markdown
@@ -1,0 +1,44 @@
+---
+title: "Vacuum remote control start"
+action: xiaomi_miio.vacuum_remote_control_start
+domain: xiaomi_miio
+description: "Puts a Xiaomi robot vacuum into remote control mode."
+related_actions:
+  - xiaomi_miio.vacuum_remote_control_move
+  - xiaomi_miio.vacuum_remote_control_stop
+---
+
+The **Vacuum remote control start** action puts a Xiaomi robot vacuum into remote control mode. Once it is in this mode, you can steer it with the [Vacuum remote control move](/actions/xiaomi_miio.vacuum_remote_control_move/) action. When you're done, use [Vacuum remote control stop](/actions/xiaomi_miio.vacuum_remote_control_stop/).
+
+{% include actions/ui_header.md %}
+
+To start remote control mode from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Xiaomi robot vacuum you want to control.
+6. From the actions shown for that target, select **Vacuum remote control start**.
+7. Select **Save**.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `xiaomi_miio.vacuum_remote_control_start`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: xiaomi_miio.vacuum_remote_control_start
+  target:
+    entity_id: vacuum.xiaomi_vacuum
+{% endexample %}
+
+This puts `vacuum.xiaomi_vacuum` into remote control mode.
+
+{% include actions/targets.md domain="vacuum" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/xiaomi_miio.vacuum_remote_control_stop.markdown
+++ b/source/_actions/xiaomi_miio.vacuum_remote_control_stop.markdown
@@ -1,0 +1,44 @@
+---
+title: "Vacuum remote control stop"
+action: xiaomi_miio.vacuum_remote_control_stop
+domain: xiaomi_miio
+description: "Takes a Xiaomi robot vacuum out of remote control mode."
+related_actions:
+  - xiaomi_miio.vacuum_remote_control_start
+  - xiaomi_miio.vacuum_remote_control_move
+---
+
+The **Vacuum remote control stop** action takes a Xiaomi robot vacuum out of remote control mode. Use it once you finish steering the vacuum with the [Vacuum remote control move](/actions/xiaomi_miio.vacuum_remote_control_move/) action.
+
+{% include actions/ui_header.md %}
+
+To stop remote control mode from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the Xiaomi robot vacuum you want to control.
+6. From the actions shown for that target, select **Vacuum remote control stop**.
+7. Select **Save**.
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `xiaomi_miio.vacuum_remote_control_stop`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: xiaomi_miio.vacuum_remote_control_stop
+  target:
+    entity_id: vacuum.xiaomi_vacuum
+{% endexample %}
+
+This takes `vacuum.xiaomi_vacuum` out of remote control mode.
+
+{% include actions/targets.md domain="vacuum" %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/xiaomi_miio.markdown
+++ b/source/_integrations/xiaomi_miio.markdown
@@ -1200,53 +1200,9 @@ Clean mode and Motor speed can only be set when the device is turned on.
 
 ### Actions
 
-### Action: Set humidity
+These devices support the standard [humidifier](/integrations/humidifier/) and [fan](/integrations/fan/) actions, such as `humidifier.set_humidity`, `humidifier.set_mode`, `fan.set_percentage`, and `fan.set_preset_mode`. To act on a specific device, target its entity.
 
-The `humidifier.set_humidity` action sets the target humidity.
-
-| Data attribute | Optional | Description                                           |
-| ---------------------- | -------- | ----------------------------------------------------- |
-| `entity_id`            | no       | Only act on a specific Xiaomi humidifier entity.      |
-| `humidity`             | no       | Target humidity                                       |
-
-### Action: Set humidifier mode
-
-The `humidifier.set_mode` action sets the humidifier operation mode.
-
-| Data attribute | Optional | Description                                           |
-| ---------------------- | -------- | ----------------------------------------------------- |
-| `entity_id`            | no       | Only act on a specific Xiaomi humidifier entity.      |
-| `mode`                 | no       | The humidifier operation mode                         |
-
-| ---------------------- | -------- | ---------------------------------------------- |
-| `entity_id`            | no       | Only act on a specific Xiaomi fan entity.      |
-| `percentage`           | no       | Fan speed. Percentage speed setting            |
-
-### Action: Set fan preset mode
-
-The `fan.set_preset_mode` action sets the fan operation mode.
-
-| Data attribute | Optional | Description                                    |
-| ---------------------- | -------- | ---------------------------------------------- |
-| `entity_id`            | no       | Only act on a specific Xiaomi fan entity.      |
-| `preset_mode`          | no       | The fan operation mode                         |
-
-### Action: Reset filter (Air Purifier 2 only)
-
-The `xiaomi_miio.fan_reset_filter` action resets the filter lifetime and usage.
-
-| Data attribute | Optional | Description                                    |
-| ---------------------- | -------- | ---------------------------------------------- |
-| `entity_id`            | no       | Only act on a specific Xiaomi fan entity.      |
-
-### Action: Set extra features (Air Purifier only)
-
-The `xiaomi_miio.fan_set_extra_features` action sets the extra features.
-
-| Data attribute | Optional | Description                                    |
-| ---------------------- | -------- | ---------------------------------------------- |
-| `entity_id`            | no       | Only act on a specific Xiaomi fan entity.      |
-| `features`             | no       | Integer, known values are 0 and 1.             |
+The integration also adds Xiaomi-specific actions for air purifiers, such as **Fan reset filter** and **Fan set extra features**. For the full list, see [Actions](#list-of-actions).
 
 ## Xiaomi Air Quality Monitor
 
@@ -1386,7 +1342,7 @@ The Xiaomi IR Remote Platform currently supports two different formats for IR co
 
 ### Raw
 
-A raw command is a command learned from [`xiaomi_miio.remote_learn_command`](/integrations/xiaomi_miio/#xiaomi_miioremote_learn_command).
+A raw command is a command learned from the [Remote learn command](/actions/xiaomi_miio.remote_learn_command/) action.
 
 A raw command is defined as in the following example:
 
@@ -1427,29 +1383,15 @@ For now, pronto hex codes only work on the first version (`chuangmi.ir.v2`).
 
 ### Actions
 
-The Xiaomi IR Remote Platform registers four actions.
+The Xiaomi IR Remote registers a generic `remote.send_command` action, along with Xiaomi-specific actions for learning commands and controlling the remote's LED.
 
 ### `remote.send_command`
 
 Allows sending either named commands using an identifier or sending commands as one of the two types defined in [Command Types](/integrations/xiaomi_miio/#command-types).
 
-### `xiaomi_miio.remote_learn_command`
+To learn a new command, use the **Remote learn command** action. After learning, the base64 string is shown as a notification in Overview, where you can copy it. Commands learned to the same slot can still be sent using [`remote.send_command`](/integrations/xiaomi_miio/#remotesend_command) even if they are overwritten.
 
-Used to learn new commands.
-
-Use the entity_id of the Xiaomi IR Remote to start a learning process.
-
-`slot` and `timeout` can be specified, but multiple commands learned to the same slot can still be sent using [`remote.send_command`](/integrations/xiaomi_miio/#remotesend_command) even if they are overwritten.
-
-After learning the command the base64 string can be found as a notification in Overview, the string can be copied by left clicking on the string and choose the copy option.
-
-### `xiaomi_miio.remote_set_led_on`
-
-Used to turn remote's blue LED on.
-
-### `xiaomi_miio.remote_set_led_off`
-
-Used to turn remote's blue LED off.
+For the full list of actions this integration adds, see [Actions](#list-of-actions).
 
 ## Xiaomi Mi Robot Vacuum
 
@@ -1472,203 +1414,7 @@ Currently supported actions are:
 
 ### Actions
 
-In addition to all of the actions provided by the `vacuum` {% term integration %} (`start`, `pause`, `stop`, `return_to_base`, `locate`, `set_fan_speed` and `send_command`), the `xiaomi_miio` platform introduces specific actions to access the remote control mode of the robot. These are:
-
-- `xiaomi_miio.vacuum_clean_zone`
-- `xiaomi_miio.vacuum_clean_segment`
-- `xiaomi_miio.vacuum_goto`
-- `xiaomi_miio.vacuum_remote_control_start`
-- `xiaomi_miio.vacuum_remote_control_stop`
-- `xiaomi_miio.vacuum_remote_control_move`
-- `xiaomi_miio.vacuum_remote_control_move_step`
-
-### Action: Clean zone
-
-The `xiaomi_miio.vacuum_clean_zone` action starts the cleaning operation in the areas selected for the number of repeats indicated.
-
-- **Data attribute**: `entity_id`
-  - **Description**: Only act on a specific robot.
-  - **Optional**: No.
-
-- **Data attribute**: `zone`
-  - **Description**: List of zones. Each zone is an array of four integer values. These values represent two sets of x- and y-axis coordinates that describe the beginning and ending points of a square or rectangle cleaning zone. For example, `[[23510,25311,25110,26361]]` creates a box that starts in one corner at the 23510, 25311 (x- and y-axis) coordinates and then is expanded diagonally to the 25110, 26361 coordinates to create a rectangular cleaning zone.
-  - **Optional**: No.
-
-- **Data attribute**: `repeats`
-  - **Description**: Number of cleaning repeats for each zone between 1 and 3.
-  - **Optional**: No.
-
-Example of `xiaomi_miio.vacuum_clean_zone` use:
-
-Inline array:
-```yaml
-automation:
-  - alias: "Test vacuum zone3"
-    triggers:
-      - trigger: homeassistant
-        event: start
-    actions:
-      - action: xiaomi_miio.vacuum_clean_zone
-        target:
-          entity_id: vacuum.xiaomi_vacuum
-        data:
-          repeats: "{{states('input_number.vacuum_passes')|int}}"
-          zone: [[30914, 26007, 35514, 28807], [20232, 22496, 26032, 26496]]
-```
-
-Array with inline zone:
-```yaml
-automation:
-  - alias: "Test vacuum zone3"
-    triggers:
-      - trigger: homeassistant
-        event: start
-    actions:
-      - action: xiaomi_miio.vacuum_clean_zone
-        target:
-          entity_id: vacuum.xiaomi_vacuum
-        data:
-          repeats: "{{states('input_number.vacuum_passes')|int}}"
-          zone:
-            - [30914, 26007, 35514, 28807]
-            - [20232, 22496, 26032, 26496]
-```
-
-Array mode:
-
-```yaml
-automation:
-  - alias: "Test vacuum zone3"
-    triggers:
-      - trigger: homeassistant
-        event: start
-    actions:
-      - action: xiaomi_miio.vacuum_clean_zone
-        target:
-          entity_id: vacuum.xiaomi_vacuum
-        data:
-          repeats: 1
-          zone:
-            - - 30914
-              - 26007
-              - 35514
-              - 28807
-            - - 20232
-              - 22496
-              - 26032
-              - 26496
-```
-
-### Action: Clean segment
-
-The `xiaomi_miio.vacuum_clean_segment` action cleans the specified segment/room. A room is identified by a number. Instructions on how to find the valid room numbers and determine what rooms they map to, read the section [Retrieving room numbers](#retrieving-room-numbers).
-
-- **Data attribute**: `entity_id`
-  - **Description**: Only act on a specific robot.
-  - **Optional**: No.
-- **Data attribute**: `segments`
-  - **Description**: List of segment numbers or one single segment number.
-  - **Optional**: No.
-
-Example of `xiaomi_miio.vacuum_clean_segment` use:
-
-Multiple segments:
-
-```yaml
-automation:
-  - alias: "Vacuum kitchen and living room"
-    triggers:
-      - trigger: homeassistant
-        event: start
-    actions:
-      - action: xiaomi_miio.vacuum_clean_segment
-        target:
-          entity_id: vacuum.xiaomi_vacuum
-        data:
-          segments: [1, 2]
-```
-
-Single segment:
-
-```yaml
-automation:
-  - alias: "Vacuum kitchen"
-    triggers:
-      - trigger: homeassistant
-        event: start
-    actions:
-      - action: xiaomi_miio.vacuum_clean_segment
-        target:
-          entity_id: vacuum.xiaomi_vacuum
-        data:
-          segments: 1
-```
-
-The original app for Xiaomi vacuum has a nice feature of room cleaning with repetition, you can achieve the same result with repeating segments:
-
-```yaml
-automation:
-  - alias: "Vacuum kitchen"
-    triggers:
-      - trigger: homeassistant
-        event: start
-    actions:
-      - action: xiaomi_miio.vacuum_clean_segment
-        target:
-          entity_id: vacuum.xiaomi_vacuum
-        data:
-          segments: [1, 1]
-```
-
-### Action: Go to coordinates
-
-The `xiaomi_miio.vacuum_goto` action sends the vacuum to the specified coordinates.
-
-- **Data attribute**: `entity_id`
-  - **Description**: Only act on a specific robot.
-  - **Optional**: No.
-- **Data attribute**: `x_coord`
-  - **Description**: X-coordinate, integer value. The dock is located at x-coordinate 25500.
-  - **Optional**: No.
-- **Data attribute**: `y_coord`
-  - **Description**: Y-coordinate, integer value. The dock is located at y-coordinate 25500.
-  - **Optional**: No.
-
-Note: If your vacuum is in motion and does not respond to the `xiaomi_miio.vacuum_goto` command, call the `vacuum.pause` or `vacuum.stop` action first.
-
-### Action: Start remote control
-
-The `xiaomi_miio.vacuum_remote_control_start` action starts the remote control mode of the robot. You can then move it with `remote_control_move`; when done, call `remote_control_stop`.
-
-| Data attribute | Optional | Description                  |
-| -------------- | -------- | ---------------------------- |
-| `entity_id`    | no       | Only act on a specific robot |
-
-### Action: Stop remote control
-
-The `xiaomi_miio.vacuum_remote_control_stop` action exits the remote control mode of the robot.
-
-| Data attribute | Optional | Description                  |
-| -------------- | -------- | ---------------------------- |
-| `entity_id`    | no       | Only act on a specific robot |
-
-### Action: Remote control move
-
-The `xiaomi_miio.vacuum_remote_control_move` action remote controls the robot. Please ensure you first set it in remote control mode with `remote_control_start`.
-
-- `entity_id`: Only act on a specific robot. Not optional.
-- `velocity`: Speed: between -0.29 and 0.29. Not optional.
-- `rotation`: Rotation: between -179 degrees and 179 degrees. Not optional.
-- `duration`: The number of milliseconds that the robot should move for. Not optional.
-
-### Action: Remote control move step
-
-The `xiaomi_miio.vacuum_remote_control_move_step` action enters remote control mode, makes one move, stops, and exits remote control mode.
-
-- **entity_id**: Only act on a specific robot. Not optional.
-- **velocity**: Speed: between -0.29 and 0.29. Not optional.
-- **rotation**: Rotation: between -179 degrees and 179 degrees. Not optional.
-- **duration**: The number of milliseconds that the robot should move for. Not optional.
+In addition to all of the actions provided by the [vacuum](/integrations/vacuum/) integration (`start`, `pause`, `stop`, `return_to_base`, `locate`, `set_fan_speed`, and `send_command`), this integration adds Xiaomi-specific actions to clean zones and segments, send the robot to a coordinate, and remote control the robot. For the full list, see [Actions](#list-of-actions).
 
 ### Buttons
 
@@ -1905,71 +1651,7 @@ Supported models: `philips.light.moonlight`
 
 ### Actions
 
-### Action: Set scene
-
-The `xiaomi_miio.light_set_scene` action sets one of the 4 available fixed scenes.
-
-| Data attribute | Optional | Description                                      |
-| ---------------------- | -------- | ------------------------------------------------ |
-| `entity_id`            | no       | Only act on a specific Xiaomi light entity.      |
-| `scene`                | no       | Scene, between 1 and 4.                          |
-
-### Action: Set delayed turn off
-
-The `xiaomi_miio.light_set_delayed_turn_off` action sets a delayed turn off.
-
-| Data attribute | Optional | Description                                      |
-| ---------------------- | -------- | ------------------------------------------------ |
-| `entity_id`            | no       | Only act on a specific Xiaomi light entity.      |
-| `time_period`          | no       | Time period for the delayed turn off.            |
-
-### Action: Turn on reminder (Eyecare Smart Lamp 2 only)
-
-The `xiaomi_miio.light_reminder_on` action enables the eye fatigue reminder/notification.
-
-| Data attribute | Optional | Description                                      |
-| ---------------------- | -------- | ------------------------------------------------ |
-| `entity_id`            | no       | Only act on a specific Xiaomi light entity.      |
-
-### Action: Turn off reminder (Eyecare Smart Lamp 2 only)
-
-The `xiaomi_miio.light_reminder_off` action disables the eye fatigue reminder/notification.
-
-| Data attribute | Optional | Description                                      |
-| ---------------------- | -------- | ------------------------------------------------ |
-| `entity_id`            | no       | Only act on a specific Xiaomi light entity.      |
-
-### Action: Turn on night light mode (Eyecare Smart Lamp 2 only)
-
-The `xiaomi_miio.light_night_light_mode_on` action turns the smart night light mode on.
-
-| Data attribute | Optional | Description                                      |
-| ---------------------- | -------- | ------------------------------------------------ |
-| `entity_id`            | no       | Only act on a specific Xiaomi light entity.      |
-
-### Action: Turn off night light mode (Eyecare Smart Lamp 2 only)
-
-The `xiaomi_miio.light_night_light_mode_off` action turns the smart night light mode off.
-
-| Data attribute | Optional | Description                                      |
-| ---------------------- | -------- | ------------------------------------------------ |
-| `entity_id`            | no       | Only act on a specific Xiaomi light entity.      |
-
-### Action: Turn on eyecare mode (Eyecare Smart Lamp 2 only)
-
-The `xiaomi_miio.light_eyecare_mode_on` action turns the eyecare mode on.
-
-| Data attribute | Optional | Description                                      |
-| ---------------------- | -------- | ------------------------------------------------ |
-| `entity_id`            | no       | Only act on a specific Xiaomi light entity.      |
-
-### Action: Turn off eyecare mode (Eyecare Smart Lamp 2 only)
-
-The `xiaomi_miio.light_eyecare_mode_off` action turns the eyecare mode off.
-
-| Data attribute | Optional | Description                                      |
-| ---------------------- | -------- | ------------------------------------------------ |
-| `entity_id`            | no       | Only act on a specific Xiaomi light entity.      |
+This integration adds actions to set a fixed scene, schedule a delayed turn off, and, on the Philips Eyecare Smart Lamp 2, toggle the reminder, night light, and eyecare modes. For the full list, see [Actions](#list-of-actions).
 
 ## Xiaomi Smart WiFi Socket and Smart Power Strip
 
@@ -2019,35 +1701,9 @@ Supported models: `lumi.acpartner.v3` (the socket of the `acpartner.v1` and `v2`
 
 ### Actions
 
-### Action: Turn on WiFi LED (Power Strip only)
+This integration adds actions to toggle the Wi-Fi LED and, on supported power strips, set the power mode and power price. For the full list, see [Actions](#list-of-actions).
 
-The `xiaomi_miio.switch_set_wifi_led_on` action turns the WiFi LED on.
-
-| Data attribute | Optional | Description                                       |
-| ---------------------- | -------- | ------------------------------------------------- |
-| `entity_id`            | no       | Only act on a specific Xiaomi switch entity.      |
-
-### Action: Turn off WiFi LED (Power Strip only)
-
-The `xiaomi_miio.switch_set_wifi_led_off` action turns the WiFi LED off.
-
-| Data attribute | Optional | Description                                       |
-| ---------------------- | -------- | ------------------------------------------------- |
-| `entity_id`            | no       | Only act on a specific Xiaomi switch entity.      |
-
-| Data attribute | Optional | Description                                       |
-| ---------------------- | -------- | ------------------------------------------------- |
-| `entity_id`            | no       | Only act on a specific Xiaomi switch entity.      |
-| `price`                | no       | Power price, between 0 and 999.                   |
-
-### Action: Set power mode (Power Strip V1 only)
-
-The `xiaomi_miio.switch_set_power_mode` action sets the power mode.
-
-| Data attribute | Optional | Description                                       |
-| ---------------------- | -------- | ------------------------------------------------- |
-| `entity_id`            | no       | Only act on a specific Xiaomi switch entity.      |
-| `mode`                 | no       | Power mode, valid values are 'normal' and 'green' |
+{% include integrations/actions.md %}
 
 ## Retrieving the Access Token
 


### PR DESCRIPTION
## Proposed change

<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Migrates the Xiaomi Miio actions from inline sections on the integration page to dedicated action pages under `source/_actions/`, replacing the scattered inline documentation with the standard `{% include integrations/actions.md %}` list.

While migrating, every action and its options were verified against the integration's source code, so required/optional flags, value ranges, and types now match the actual schemas.

- Part of epic: home-assistant/epics#96

## Type of change

<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
