### PR TITLE
Seerr: migrate get_requests action to a dedicated page

### DIFF
--- a/source/_actions/overseerr.get_requests.markdown
+++ b/source/_actions/overseerr.get_requests.markdown
@@ -45,7 +45,7 @@ In YAML, refer to this action as `overseerr.get_requests`. Store the result in a
 action: |
   action: overseerr.get_requests
   data:
-    config_entry_id: 6b4be47a1fa7c3764f14cf756dc9899d
+    config_entry_id: YOUR_CONFIG_ENTRY_ID
     status: pending
     sort_order: added
   response_variable: requests

--- a/source/_actions/overseerr.get_requests.markdown
+++ b/source/_actions/overseerr.get_requests.markdown
@@ -1,0 +1,85 @@
+---
+title: "Get requests"
+action: overseerr.get_requests
+domain: overseerr
+description: "Retrieves a list of media requests from Seerr."
+---
+
+The **Get requests** action retrieves a list of media requests from Seerr. You can filter the results by status and by the user who made the request, and choose the order in which they are returned.
+
+This action returns its result in a response variable, which you can use in later steps of the same automation or script, for example to notify yourself about pending requests.
+
+{% include actions/ui_header.md %}
+
+To get media requests from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Seerr: Get requests**.
+6. Select the **Seerr instance** and, if needed, set the **Request status**, **Sort order**, and **Requested by** filters.
+7. Select **Save**.
+
+This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
+
+### Options in the UI
+
+{% options_ui %}
+Seerr instance:
+  description: The Seerr instance to get requests from.
+  required: true
+Request status:
+  description: "Filter the requests by status. One of approved, pending, available, processing, unavailable, or failed."
+Sort order:
+  description: "Sort the requests by added or modified date."
+Requested by:
+  description: Filter the requests by the user ID that requested them.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `overseerr.get_requests`. Store the result in a response variable so you can use it in later steps:
+
+{% example %}
+action: |
+  action: overseerr.get_requests
+  data:
+    config_entry_id: 6b4be47a1fa7c3764f14cf756dc9899d
+    status: pending
+    sort_order: added
+  response_variable: requests
+{% endexample %}
+
+This fetches the pending media requests, sorted by the date they were added.
+
+### Options in YAML
+
+{% options_yaml %}
+config_entry_id:
+  description: The Seerr instance to get requests from.
+  required: true
+  type: string
+status:
+  description: "Filter the requests by status. One of approved, pending, available, processing, unavailable, or failed."
+  required: false
+  type: string
+sort_order:
+  description: "Sort the requests by date. One of added or modified."
+  required: false
+  type: string
+requested_by:
+  description: Filter the requests by the user ID that requested them.
+  required: false
+  type: integer
+{% endoptions_yaml %}
+
+## Response data
+
+The response contains a `requests` list. Each item describes a single media request, including its status, the media it refers to, and the users who requested and last modified it.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/overseerr.get_requests.markdown
+++ b/source/_actions/overseerr.get_requests.markdown
@@ -19,7 +19,8 @@ To get media requests from an automation or a script:
 4. In the **Then do** section, select **Add action**.
 5. From the search box, search for and select **Seerr: Get requests**.
 6. Select the **Seerr instance** and, if needed, set the **Request status**, **Sort order**, and **Requested by** filters.
-7. Select **Save**.
+7. In the **Response variable** field, enter a name to store the data in, such as `requests`.
+8. Select **Save**.```
 
 This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label.
 

--- a/source/_integrations/overseerr.markdown
+++ b/source/_integrations/overseerr.markdown
@@ -82,23 +82,7 @@ There are sensors for:
  - Audio issues
  - Subtitle issues
 
-## Actions
-
-The Seerr integration has the following actions:
-
-### Request actions
-
-- `seerr.get_requests` - Get a list of media requests
-
-### Get requests
-
-Get a list of media requests using the `seerr.get_requests` action.
-
-- **config_entry_id** (*Required*): The ID of the Seerr config entry to get data from.
-- **status** (*Optional*): The status to filter the results on.
-- **sort_order** (*Optional*): The sort order to sort the results in (`added`/`modified`).
-- **requested_by** (*Optional*): Filter the requests based on the user ID of the requester.
-
+{% include integrations/actions.md %}
 
 ## Use cases
 


### PR DESCRIPTION
## Proposed change

<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Migrates the Seerr (Overseerr) `get_requests` action from an inline section on the integration page to a dedicated action page, replacing the inline documentation with the standard `{% include integrations/actions.md %}` list.

While migrating, the action and its fields were verified against the integration's source code. The action is registered under the `overseerr` domain, so the action ID is `overseerr.get_requests`; the inline docs referred to it as `seerr.get_requests`, which has been corrected.

- Part of epic: home-assistant/epics#96

## Type of change

<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
