### PR TITLE
PlayStation 4: migrate send_command action to a dedicated page

### DIFF
--- a/source/_actions/ps4.send_command.markdown
+++ b/source/_actions/ps4.send_command.markdown
@@ -1,0 +1,80 @@
+---
+title: "Send command"
+action: ps4.send_command
+domain: ps4
+description: "Emulates a button press on a PlayStation 4."
+---
+
+The **Send command** action emulates a button press on a PlayStation 4. It mimics the buttons available in the PS4 Second Screen App, so you can navigate the console from an automation or a script. These are not the buttons on a DualShock 4 controller.
+
+{% include actions/ui_header.md %}
+
+To send a command from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **PlayStation 4: Send command**.
+6. Select the **Entity** of your PlayStation 4 and the **Command** to send.
+7. Select **Save**.
+
+This action does not support targets. In the UI, use the **Entity** field to choose which PlayStation 4 to send the command to.
+
+### Options in the UI
+
+{% options_ui %}
+Entity:
+  description: The PlayStation 4 to send the command to.
+  required: true
+Command:
+  description: The button to press.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `ps4.send_command`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: ps4.send_command
+  data:
+    entity_id: media_player.ps4
+    command: ps
+{% endexample %}
+
+This presses the PS (PlayStation) button on `media_player.ps4`.
+
+### Options in YAML
+
+{% options_yaml %}
+entity_id:
+  description: The PlayStation 4 to send the command to.
+  required: true
+  type: [string, list]
+command:
+  description: The button to press.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+## Good to know
+
+The **Command** accepts one of the following values, each emulating a button:
+
+- `up`: Swipe up
+- `down`: Swipe down
+- `left`: Swipe left
+- `right`: Swipe right
+- `enter`: Enter
+- `back`: Back
+- `option`: Option
+- `ps`: PS (PlayStation)
+- `ps_hold`: PS hold (long press)
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/ps4.send_command.markdown
+++ b/source/_actions/ps4.send_command.markdown
@@ -50,9 +50,11 @@ This presses the PS (PlayStation) button on `media_player.ps4`.
 
 {% options_yaml %}
 entity_id:
-  description: The PlayStation 4 to send the command to.
+  description: >
+    The entity ID, or list of entity IDs, of the PlayStation 4 to send the
+    command to.
   required: true
-  type: [string, list]
+  type: string
 command:
   description: The button to press.
   required: true

--- a/source/_integrations/ps4.markdown
+++ b/source/_integrations/ps4.markdown
@@ -121,7 +121,7 @@ To edit, simply open the file in a text editor, find the game or app you would l
 
 ## Switching games and apps
 
-To open a different game or app and close the one currently running, use the media player's source selection. The game or app must be in the entity's source list. Games are added automatically when you open them normally on the console.
+To open a different game or app and close the one currently running, use the `media_player.select_source` action. The game or app must be in the entity's source list. Games are added automatically when you open them normally on the console.
 
 You can select a source by its title or by its SKU ID, such as `CUSA00123`. Using the SKU ID is the most reliable.
 

--- a/source/_integrations/ps4.markdown
+++ b/source/_integrations/ps4.markdown
@@ -117,41 +117,13 @@ Backup a copy of your `.ps4-games.json` file before continuing. If there are err
 
 To edit, simply open the file in a text editor, find the game or app you would like to edit, and edit the value(s) you wish to change and then save the file. The changes will appear the next time you play the game or app on your console. 
 
-## Actions
+{% include integrations/actions.md %}
 
-### Action `select_source`
+## Switching games and apps
 
-Opens new application/game and closes currently running application/game. The game/app must be in the entity's source list. Games will be added automatically when you open them normally.
+To open a different game or app and close the one currently running, use the media player's source selection. The game or app must be in the entity's source list. Games are added automatically when you open them normally on the console.
 
-| Data attribute | Optional | Example                    | Description                                                                                                 |
-| ---------------------- | -------- | -------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| `entity_id`            | No       | `media_player.ps4`         | The entity id for your PlayStation 4.                                                                       |
-| `source`               | No       | `Some Game` or `CUSA00123` | The game/app you want to open. You can use the title or SKU ID. Using the SKU ID will be the most reliable. |
-
-### Action `send_command`
-
-Emulate button press on PlayStation 4. This emulates the commands available for the PS4 Second Screen App. This is not to be confused with DualShock 4 controller buttons.
-
-| Data attribute | Optional | Example            | Description                           |
-| ---------------------- | -------- | ------------------ | ------------------------------------- |
-| `entity_id`            | No       | `media_player.ps4` | The entity id for your PlayStation 4. |
-| `command`              | No       | `ps`               | The command you want to send.         |
-
-#### Available Commands
-
-Full list of supported commands.
-
-| Command   | Button Emulated    |
-| --------- | ------------------ |
-| `ps`      | PS (PlayStation)   |
-| `ps_hold` | PS Hold/Long Press |
-| `option`  | Option             |
-| `enter`   | Enter              |
-| `back`    | Back               |
-| `up`      | Swipe Up           |
-| `down`    | Swipe Down         |
-| `left`    | Swipe Left         |
-| `right`   | Swipe Right        |
+You can select a source by its title or by its SKU ID, such as `CUSA00123`. Using the SKU ID is the most reliable.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Proposed change

<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Migrates the PlayStation 4 `send_command` action from an inline section on the integration page to a dedicated action page, replacing the inline documentation with the standard `{% include integrations/actions.md %}` list.

The inline page also documented `select_source` as a PlayStation 4 action, but that is the generic `media_player.select_source` action. Its PlayStation 4 specific guidance (using a game title or SKU ID) is kept on the page under a separate heading.

- Part of epic: home-assistant/epics#96

## Type of change

<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
