### PR TITLE
Xiaomi Gateway (Aqara): migrate actions to dedicated pages

### DIFF
--- a/source/_actions/xiaomi_aqara.add_device.markdown
+++ b/source/_actions/xiaomi_aqara.add_device.markdown
@@ -1,0 +1,60 @@
+---
+title: "Add device"
+action: xiaomi_aqara.add_device
+domain: xiaomi_aqara
+description: "Enables pairing mode on a Xiaomi Aqara Gateway to add a new device."
+related_actions:
+  - xiaomi_aqara.remove_device
+---
+
+The **Add device** action enables the join permission of a Xiaomi Aqara Gateway for 30 seconds. While join permission is enabled, you can add a new device by pressing its pairing button once.
+
+{% include actions/ui_header.md %}
+
+To add a device from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Xiaomi Gateway (Aqara): Add device**.
+6. Enter the **Gateway MAC**.
+7. Select **Save**.
+
+This action does not support targets. In the UI, use the **Gateway MAC** field to choose which gateway enters pairing mode.
+
+### Options in the UI
+
+{% options_ui %}
+Gateway MAC:
+  description: The MAC address of the Xiaomi Aqara Gateway.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `xiaomi_aqara.add_device`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: xiaomi_aqara.add_device
+  data:
+    gw_mac: xxxxxxxxxxxx
+{% endexample %}
+
+This enables pairing mode on the gateway for 30 seconds.
+
+### Options in YAML
+
+{% options_yaml %}
+gw_mac:
+  description: The MAC address of the Xiaomi Aqara Gateway.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/xiaomi_aqara.play_ringtone.markdown
+++ b/source/_actions/xiaomi_aqara.play_ringtone.markdown
@@ -1,0 +1,107 @@
+---
+title: "Play ringtone"
+action: xiaomi_aqara.play_ringtone
+domain: xiaomi_aqara
+description: "Plays a specific ringtone on a Xiaomi Aqara Gateway."
+related_actions:
+  - xiaomi_aqara.stop_ringtone
+---
+
+The **Play ringtone** action plays a specific ringtone on a Xiaomi Aqara Gateway. The gateway firmware must be at least version `1.4.1_145`.
+
+{% include actions/ui_header.md %}
+
+To play a ringtone from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Xiaomi Gateway (Aqara): Play ringtone**.
+6. Enter the **Gateway MAC** and the **Ringtone ID**, and optionally set the **Ringtone volume**.
+7. Select **Save**.
+
+This action does not support targets. In the UI, use the **Gateway MAC** field to choose which gateway plays the ringtone.
+
+### Options in the UI
+
+{% options_ui %}
+Gateway MAC:
+  description: The MAC address of the Xiaomi Aqara Gateway.
+  required: true
+Ringtone ID:
+  description: The ID of the ringtone to play.
+  required: true
+Ringtone volume:
+  description: The volume in percent, between 0 and 100.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `xiaomi_aqara.play_ringtone`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: xiaomi_aqara.play_ringtone
+  data:
+    gw_mac: xxxxxxxxxxxx
+    ringtone_id: 8
+    ringtone_vol: 8
+{% endexample %}
+
+This plays the bark ringtone at a volume of 8 percent.
+
+### Options in YAML
+
+{% options_yaml %}
+gw_mac:
+  description: The MAC address of the Xiaomi Aqara Gateway.
+  required: true
+  type: string
+ringtone_id:
+  description: The ID of the ringtone to play.
+  required: true
+  type: integer
+ringtone_vol:
+  description: The volume in percent, between 0 and 100.
+  required: false
+  type: integer
+{% endoptions_yaml %}
+
+## Good to know
+
+The allowed values for the **Ringtone ID** are:
+
+- Alarms:
+  - 0: Police car 1
+  - 1: Police car 2
+  - 2: Accident
+  - 3: Countdown
+  - 4: Ghost
+  - 5: Sniper rifle
+  - 6: Battle
+  - 7: Air raid
+  - 8: Bark
+- Doorbells:
+  - 10: Doorbell
+  - 11: Knock at a door
+  - 12: Amuse
+  - 13: Alarm clock
+- Alarm clock:
+  - 20: MiMix
+  - 21: Enthusiastic
+  - 22: GuitarClassic
+  - 23: IceWorldPiano
+  - 24: LeisureTime
+  - 25: ChildHood
+  - 26: MorningStreamLiet
+  - 27: MusicBox
+  - 28: Orange
+  - 29: Thinker
+- Custom ringtones, uploaded with the Mi Home app, start from 10001.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/xiaomi_aqara.remove_device.markdown
+++ b/source/_actions/xiaomi_aqara.remove_device.markdown
@@ -1,0 +1,68 @@
+---
+title: "Remove device"
+action: xiaomi_aqara.remove_device
+domain: xiaomi_aqara
+description: "Removes a specific device from a Xiaomi Aqara Gateway."
+related_actions:
+  - xiaomi_aqara.add_device
+---
+
+The **Remove device** action removes a specific device from a Xiaomi Aqara Gateway. Removing a device is required before you can pair it with another gateway.
+
+{% include actions/ui_header.md %}
+
+To remove a device from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Xiaomi Gateway (Aqara): Remove device**.
+6. Enter the **Gateway MAC** and the **Device ID** of the device to remove.
+7. Select **Save**.
+
+This action does not support targets. In the UI, use the **Gateway MAC** field to choose which gateway the device is removed from.
+
+### Options in the UI
+
+{% options_ui %}
+Gateway MAC:
+  description: The MAC address of the Xiaomi Aqara Gateway.
+  required: true
+Device ID:
+  description: The hardware address of the device to remove.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `xiaomi_aqara.remove_device`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: xiaomi_aqara.remove_device
+  data:
+    gw_mac: xxxxxxxxxxxx
+    device_id: "158d0000000000"
+{% endexample %}
+
+This removes the device with the given hardware address from the gateway.
+
+### Options in YAML
+
+{% options_yaml %}
+gw_mac:
+  description: The MAC address of the Xiaomi Aqara Gateway.
+  required: true
+  type: string
+device_id:
+  description: The hardware address of the device to remove.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/xiaomi_aqara.stop_ringtone.markdown
+++ b/source/_actions/xiaomi_aqara.stop_ringtone.markdown
@@ -1,0 +1,60 @@
+---
+title: "Stop ringtone"
+action: xiaomi_aqara.stop_ringtone
+domain: xiaomi_aqara
+description: "Stops a playing ringtone on a Xiaomi Aqara Gateway."
+related_actions:
+  - xiaomi_aqara.play_ringtone
+---
+
+The **Stop ringtone** action immediately stops a ringtone that is playing on a Xiaomi Aqara Gateway.
+
+{% include actions/ui_header.md %}
+
+To stop a ringtone from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Xiaomi Gateway (Aqara): Stop ringtone**.
+6. Enter the **Gateway MAC**.
+7. Select **Save**.
+
+This action does not support targets. In the UI, use the **Gateway MAC** field to choose which gateway stops the ringtone.
+
+### Options in the UI
+
+{% options_ui %}
+Gateway MAC:
+  description: The MAC address of the Xiaomi Aqara Gateway.
+  required: true
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `xiaomi_aqara.stop_ringtone`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: xiaomi_aqara.stop_ringtone
+  data:
+    gw_mac: xxxxxxxxxxxx
+{% endexample %}
+
+This stops any ringtone playing on the gateway.
+
+### Options in YAML
+
+{% options_yaml %}
+gw_mac:
+  description: The MAC address of the Xiaomi Aqara Gateway.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/xiaomi_aqara.markdown
+++ b/source/_integrations/xiaomi_aqara.markdown
@@ -594,74 +594,7 @@ The following sensor types are supported:
 
 The switch entity allows you to get data from your [Xiaomi aqara](https://www.mi.com/en/) switches and to switch between states.
 
-## Actions
-
-The gateway provides the following actions:
-
-### Action: Play ringtone
-
-The `xiaomi_aqara.play_ringtone` action plays a specific ringtone. The version of the gateway firmware must be `1.4.1_145` at least. Take a look at the examples below.
-
-| Data attribute | Optional | Description                             |
-| -------------- | -------- | --------------------------------------- |
-| `gw_mac`       | no       | MAC address of the Xiaomi Aqara Gateway |
-| `ringtone_id`  | no       | One of the allowed ringtone ids         |
-| `ringtone_vol` | yes      | The volume in percent                   |
-
-Allowed values of the `ringtone_id` are:
-
-- Alarms
-  - 0 - Police car 1
-  - 1 - Police car 2
-  - 2 - Accident
-  - 3 - Countdown
-  - 4 - Ghost
-  - 5 - Sniper rifle
-  - 6 - Battle
-  - 7 - Air raid
-  - 8 - Bark
-- Doorbells
-  - 10 - Doorbell
-  - 11 - Knock at a door
-  - 12 - Amuse
-  - 13 - Alarm clock
-- Alarm clock
-  - 20 - MiMix
-  - 21 - Enthusiastic
-  - 22 - GuitarClassic
-  - 23 - IceWorldPiano
-  - 24 - LeisureTime
-  - 25 - ChildHood
-  - 26 - MorningStreamLiet
-  - 27 - MusicBox
-  - 28 - Orange
-  - 29 - Thinker
-- Custom ringtones (uploaded by the Mi Home app) starting from 10001
-
-### Action: Stop ringtone
-
-The `xiaomi_aqara.stop_ringtone` action stops a playing ringtone immediately.
-
-| Data attribute | Optional | Description                             |
-| -------------- | -------- | --------------------------------------- |
-| `gw_mac`       | no       | MAC address of the Xiaomi Aqara Gateway |
-
-### Action: Add device
-
-The `xiaomi_aqara.add_device` action enables the join permission of the Xiaomi Aqara Gateway for 30 seconds. A new device can be added afterwards by pressing the pairing button once.
-
-| Data attribute | Optional | Description                             |
-| -------------- | -------- | --------------------------------------- |
-| `gw_mac`       | no       | MAC address of the Xiaomi Aqara Gateway |
-
-### Action: Remove device
-
-The `xiaomi_aqara.remove_device` action removes a specific device. The removal is required if a device shall be paired with another gateway.
-
-| Data attribute | Optional | Description                              |
-| -------------- | -------- | ---------------------------------------- |
-| `gw_mac`       | no       | MAC address of the Xiaomi Aqara Gateway  |
-| `device_id`    | no       | Hardware address of the device to remove |
+{% include integrations/actions.md %}
 
 ## Examples
 


### PR DESCRIPTION
## Proposed change

<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Migrates the Xiaomi Gateway (Aqara) `play_ringtone`, `stop_ringtone`, `add_device`, and `remove_device` actions from inline sections on the integration page to dedicated action pages, replacing the inline documentation with the standard `{% include integrations/actions.md %}` list.

While migrating, all four actions and their fields were verified against the integration's source code. The existing example automations are kept on the integration page.

- Part of epic: home-assistant/epics#96

## Type of change

<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
