### PR TITLE
Add CVE-2026-54318 to the past advisories

### DIFF
--- a/source/security/index.markdown
+++ b/source/security/index.markdown
@@ -62,6 +62,13 @@ As an open source project, Home Assistant cannot offer bounties for security vul
 
 The following is a list of past security advisories that have been published by the Home Assistant project.
 
+**2026-05-08: Exported BroadcastReceiver allows local apps to spoof device location**  
+Severity: _High (CVSS: 7.1)_  
+Detailed information: _[Security advisory](https://github.com/home-assistant/core/security/advisories/GHSA-77r5-pw5w-mgj3)_  
+Assigned CVE: _[CVE-2026-54318](https://nvd.nist.gov/vuln/detail/CVE-2026-54318)_  
+Discovered by: _[waihankan](https://github.com/waihankan)_  
+Fixed in: _Home Assistant for Android 2026.5.3_
+
 **2026-05-11: Cross-origin iframe access token exfiltration via WebView JS bridge callback injection**  
 Severity: _High (CVSS: 8.3)_  
 Detailed information: _[Security advisory](https://github.com/home-assistant/core/security/advisories/GHSA-7jp2-p2fw-mgvf)_  

--- a/source/security/index.markdown
+++ b/source/security/index.markdown
@@ -62,7 +62,7 @@ As an open source project, Home Assistant cannot offer bounties for security vul
 
 The following is a list of past security advisories that have been published by the Home Assistant project.
 
-**2026-05-08: Exported BroadcastReceiver allows local apps to spoof device location**  
+**2026-06-17: Exported BroadcastReceiver allows local apps to spoof device location**  
 Severity: _High (CVSS: 7.1)_  
 Detailed information: _[Security advisory](https://github.com/home-assistant/core/security/advisories/GHSA-77r5-pw5w-mgj3)_  
 Assigned CVE: _[CVE-2026-54318](https://nvd.nist.gov/vuln/detail/CVE-2026-54318)_  


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Add security advisories for Android https://github.com/home-assistant/core/security/advisories/GHSA-77r5-pw5w-mgj3

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
