### PR TITLE
Add shared post functionality using OHF proxy blog

### DIFF
--- a/plugins/crosspost_og.rb
+++ b/plugins/crosspost_og.rb
@@ -36,8 +36,7 @@ module Jekyll
 
       def fetch_og_image(site, url, redirects_left = 5)
         uri = URI.parse(url)
-        return nil unless uri.is_a?(URI::HTTP)
-
+        return nil unless uri.is_a?(URI::HTTPS)
         response = Net::HTTP.start(
           uri.host, uri.port,
           use_ssl: uri.scheme == 'https',

--- a/plugins/crosspost_og.rb
+++ b/plugins/crosspost_og.rb
@@ -34,7 +34,7 @@ module Jekyll
 
       private
 
-      def fetch_og_image(site, url, redirects_left = 5)
+      def fetch_og_image(_site, url, redirects_left = 5)
         uri = URI.parse(url)
         return nil unless uri.is_a?(URI::HTTPS)
         response = Net::HTTP.start(

--- a/plugins/crosspost_og.rb
+++ b/plugins/crosspost_og.rb
@@ -1,0 +1,77 @@
+require 'net/http'
+require 'uri'
+require 'nokogiri'
+
+module Jekyll
+  module HomeAssistant
+    # Crossposts link out to an article hosted on another site. So their social
+    # preview matches the source, this generator fetches the Open Graph image
+    # from the external URL at build time. That way we don't have to copy the
+    # source article's image into this repository.
+    #
+    # An explicitly set `og_image` in the post front matter always wins, and a
+    # failed fetch never breaks the build, it just falls back to the default
+    # social image like any other page.
+    class CrosspostOpenGraph < Generator
+      safe false
+      priority :low
+
+      def generate(site)
+        cache = {}
+        site.posts.docs.each do |post|
+          external_url = post.data['external_url']
+          next if external_url.nil? || external_url.to_s.empty?
+
+          # Respect an image that was set by hand in the front matter.
+          next unless post.data['og_image'].nil? || post.data['og_image'].to_s.empty?
+
+          image = cache.fetch(external_url) do
+            cache[external_url] = fetch_og_image(site, external_url)
+          end
+          post.data['og_image'] = image if image
+        end
+      end
+
+      private
+
+      def fetch_og_image(site, url, redirects_left = 5)
+        uri = URI.parse(url)
+        return nil unless uri.is_a?(URI::HTTP)
+
+        response = Net::HTTP.start(
+          uri.host, uri.port,
+          use_ssl: uri.scheme == 'https',
+          open_timeout: 10, read_timeout: 15
+        ) do |http|
+          http.get(uri.request_uri, 'User-Agent' => 'home-assistant.io build bot')
+        end
+
+        case response
+        when Net::HTTPRedirection
+          return nil if redirects_left <= 0
+
+          location = URI.join(url, response['location']).to_s
+          fetch_og_image(site, location, redirects_left - 1)
+        when Net::HTTPSuccess
+          extract_og_image(url, response.body)
+        else
+          Jekyll.logger.warn 'Crosspost:', "#{url} returned #{response.code}"
+          nil
+        end
+      rescue StandardError => e
+        Jekyll.logger.warn 'Crosspost:', "Could not fetch og:image from #{url} (#{e.message})"
+        nil
+      end
+
+      def extract_og_image(url, body)
+        doc = Nokogiri::HTML(body)
+        node = doc.at('meta[property="og:image"]') || doc.at('meta[name="og:image"]')
+        image = node && node['content']
+        return nil if image.nil? || image.empty?
+
+        # Resolve protocol-relative or path-relative images against the source.
+        URI.join(url, image).to_s
+      end
+    end
+  end
+end

--- a/sass/homeassistant/_overrides.scss
+++ b/sass/homeassistant/_overrides.scss
@@ -960,6 +960,10 @@ a.material-card:hover {
   .recent-posts {
     .blog-date {
       white-space: nowrap;
+
+      .shared-from {
+        white-space: normal;
+      }
     }
 
     ol {

--- a/sass/homeassistant/base/_post.scss
+++ b/sass/homeassistant/base/_post.scss
@@ -124,6 +124,38 @@ article {
     .entry-content {
       margin: 1em 0;
     }
+
+    .crosspost-badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      margin-top: 0.25em;
+      padding: 5px 14px;
+      border-radius: 16px;
+      background-color: $primary-color;
+      color: #fff;
+      font-family: $sans-serif;
+      font-size: 0.8125rem;
+      font-weight: 500;
+      line-height: 1.3;
+      text-decoration: none;
+      transition: background-color 0.3s;
+
+      &:hover {
+        background-color: color.adjust($primary-color, $lightness: -8%);
+        color: #fff;
+      }
+
+      iconify-icon {
+        flex-shrink: 0;
+      }
+    }
+
+    .crosspost-image img {
+      border: 0;
+      box-shadow: none;
+      margin-bottom: 0.5em;
+    }
     + hr {
       border: none;
       border-bottom: 2px solid $grayLighter;

--- a/source/_includes/blog/post/article.html
+++ b/source/_includes/blog/post/article.html
@@ -33,7 +33,7 @@
 
   {% if index %}
   <h1>
-    <a href="{{ post.url }}">{{ post.title }}</a>
+    <a href="{{ post.external_url | default: post.url }}"{% if post.external_url %} target="_blank" rel="noopener"{% endif %}>{{ post.title }}</a>
   </h1>
   {% else %}
   <h1>{{ page.title }}</h1>
@@ -44,20 +44,33 @@
     {% include post/author.html %}
     {% include blog/post/date.html %}{{ time }}
     {% include blog/post/tags.html %}
-    {% if page.comments != false and post.comments != false %}
+    {% if page.comments != false and post.comments != false and post.external_url == nil %}
       <a class='comments'
          href="{% if index %}{{ post.url }}{% endif %}#post-comments"
          >Comments</a>
     {% endif %}
   </div>
   {% endunless %}
+
+  {% if index and post.external_url %}
+  <a class="crosspost-badge" href="{{ post.external_url }}" target="_blank" rel="noopener">
+    {% icon "mdi:open-in-new" %} This article is shared from the {{ post.external_source | default: "original site" }}
+  </a>
+  {% endif %}
 </header>
 
 {% if index %}
   <div class="entry-content clearfix">
+    {% if post.external_url and post.og_image %}
+    <a class="crosspost-image" href="{{ post.external_url }}" target="_blank" rel="noopener">
+      <img src="{{ post.og_image }}" alt="{{ post.title | escape }}">
+    </a>
+    {% endif %}
     {% assign blog_post_link = 'href="' | append: post.url | append:"#" %}
     {{ post.excerpt | replace: 'href="#', blog_post_link }}
-    {% if post.content contains site.excerpt_separator %}
+    {% if post.external_url %}
+      <a class="btn pull-right" href="{{ post.external_url }}" target="_blank" rel="noopener">Read on {{ post.external_source | default: "the original site" }} &rarr;</a>
+    {% elsif post.content contains site.excerpt_separator %}
       <a class="btn pull-right" href="{{ post.url }}#read-more">{{ site.excerpt_link }}</a>
     {% endif %}
   </div>

--- a/source/_includes/blog/post/article.html
+++ b/source/_includes/blog/post/article.html
@@ -69,7 +69,7 @@
     {% assign blog_post_link = 'href="' | append: post.url | append:"#" %}
     {{ post.excerpt | replace: 'href="#', blog_post_link }}
     {% if post.external_url %}
-      <a class="btn pull-right" href="{{ post.external_url }}" target="_blank" rel="noopener">Read on {{ post.external_source | default: "the original site" }} &rarr;</a>
+      <a class="btn pull-right" href="{{ post.external_url }}" target="_blank" rel="noopener noreferrer">Read on {{ post.external_source | default: "the original site" }} &rarr;</a>
     {% elsif post.content contains site.excerpt_separator %}
       <a class="btn pull-right" href="{{ post.url }}#read-more">{{ site.excerpt_link }}</a>
     {% endif %}

--- a/source/_includes/blog/post/article.html
+++ b/source/_includes/blog/post/article.html
@@ -62,7 +62,7 @@
 {% if index %}
   <div class="entry-content clearfix">
     {% if post.external_url and post.og_image %}
-    <a class="crosspost-image" href="{{ post.external_url }}" target="_blank" rel="noopener">
+    <a class="crosspost-image" href="{{ post.external_url }}" target="_blank" rel="noopener noreferrer">
       <img src="{{ post.og_image }}" alt="{{ post.title | escape }}">
     </a>
     {% endif %}

--- a/source/_includes/blog/post/article.html
+++ b/source/_includes/blog/post/article.html
@@ -33,7 +33,7 @@
 
   {% if index %}
   <h1>
-    <a href="{{ post.external_url | default: post.url }}"{% if post.external_url %} target="_blank" rel="noopener"{% endif %}>{{ post.title }}</a>
+    <a href="{{ post.external_url | default: post.url }}"{% if post.external_url %} target="_blank" rel="noopener noreferrer"{% endif %}>{{ post.title }}</a>
   </h1>
   {% else %}
   <h1>{{ page.title }}</h1>

--- a/source/_includes/custom/news.html
+++ b/source/_includes/custom/news.html
@@ -84,7 +84,7 @@
       {% assign post.date_formatted = post_date_formatted %}
       <li class="post" style="display: grid; font-size: 16px">
         {% if post.external_url %}
-        <a href="{{ post.external_url }}" target="_blank" rel="noopener">{{ post.title }} {% icon "mdi:open-in-new" %}</a>
+        <a href="{{ post.external_url }}" target="_blank" rel="noopener noreferrer">{{ post.title }} {% icon "mdi:open-in-new" %}</a>
         {% else %}
         <a href="{{ post.url }}">{{ post.title }}</a>
         {% endif %}

--- a/source/_includes/custom/news.html
+++ b/source/_includes/custom/news.html
@@ -83,8 +83,12 @@
       {% assign post_date_formatted = post_date | date: "%B %d, %Y" %}
       {% assign post.date_formatted = post_date_formatted %}
       <li class="post" style="display: grid; font-size: 16px">
+        {% if post.external_url %}
+        <a href="{{ post.external_url }}" target="_blank" rel="noopener">{{ post.title }} {% icon "mdi:open-in-new" %}</a>
+        {% else %}
         <a href="{{ post.url }}">{{ post.title }}</a>
-        <small class="blog-date">{{ post.date_formatted }}</small>
+        {% endif %}
+        <small class="blog-date">{{ post.date_formatted }}{% if post.external_url %} · Shared from {{ post.external_source | default: "original site" }}{% endif %}</small>
       </li>
       {% endif %}
       {% endfor %}

--- a/source/_includes/custom/news.html
+++ b/source/_includes/custom/news.html
@@ -88,7 +88,7 @@
         {% else %}
         <a href="{{ post.url }}">{{ post.title }}</a>
         {% endif %}
-        <small class="blog-date">{{ post.date_formatted }}{% if post.external_url %} · Shared from {{ post.external_source | default: "original site" }}{% endif %}</small>
+        <small class="blog-date">{{ post.date_formatted }}{% if post.external_url %}<span class="shared-from"> · Shared from {{ post.external_source | default: "original site" }}</span>{% endif %}</small>
       </li>
       {% endif %}
       {% endfor %}

--- a/source/_includes/site/social_meta.html
+++ b/source/_includes/site/social_meta.html
@@ -11,7 +11,12 @@
 {% assign social_image = og_default %}
 {% endif %}
 {% else %}
-{% assign social_image = page.og_image | default: "/images/default-social.png" | prepend: site.url %}
+{% assign og_raw = page.og_image | default: "/images/default-social.png" %}
+{% if og_raw contains "://" %}
+{% assign social_image = og_raw %}
+{% else %}
+{% assign social_image = og_raw | prepend: site.url %}
+{% endif %}
 {% endif %}
 
 <meta property="fb:app_id" content="{{ site.social.facebook.app_id | escape_once }}">

--- a/source/_layouts/crosspost.html
+++ b/source/_layouts/crosspost.html
@@ -10,7 +10,7 @@ layout: none
   <meta name="robots" content="noindex, follow">
   <title>{{ page.title | escape_once }}</title>
   {% include site/social_meta.html %}
-  <script>window.location.replace("{{ page.external_url }}");</script>
+  <script>window.location.replace({{ page.external_url | jsonify }});</script>
 </head>
 <body>
   <p>This post is published on another site. If you are not redirected automatically, <a href="{{ page.external_url }}">continue to “{{ page.title }}”</a>.</p>

--- a/source/_layouts/crosspost.html
+++ b/source/_layouts/crosspost.html
@@ -13,6 +13,6 @@ layout: none
   <script>window.location.replace({{ page.external_url | jsonify }});</script>
 </head>
 <body>
-  <p>This post is published on another site. If you are not redirected automatically, <a href="{{ page.external_url }}">continue to “{{ page.title }}”</a>.</p>
+  <p>This post is published on another site. If you are not redirected automatically, <a href="{{ page.external_url | escape_once }}">continue to “{{ page.title }}”</a>.</p>
 </body>
 </html>

--- a/source/_layouts/crosspost.html
+++ b/source/_layouts/crosspost.html
@@ -5,10 +5,10 @@ layout: none
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <meta http-equiv="refresh" content="0; url={{ page.external_url }}">
-  <link rel="canonical" href="{{ page.external_url }}">
+  <meta http-equiv="refresh" content="0; url={{ page.external_url | escape_once }}">
+  <link rel="canonical" href="{{ page.external_url | escape_once }}">
   <meta name="robots" content="noindex, follow">
-  <title>{{ page.title }}</title>
+  <title>{{ page.title | escape_once }}</title>
   {% include site/social_meta.html %}
   <script>window.location.replace("{{ page.external_url }}");</script>
 </head>

--- a/source/_layouts/crosspost.html
+++ b/source/_layouts/crosspost.html
@@ -1,0 +1,18 @@
+---
+layout: none
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="refresh" content="0; url={{ page.external_url }}">
+  <link rel="canonical" href="{{ page.external_url }}">
+  <meta name="robots" content="noindex, follow">
+  <title>{{ page.title }}</title>
+  {% include site/social_meta.html %}
+  <script>window.location.replace("{{ page.external_url }}");</script>
+</head>
+<body>
+  <p>This post is published on another site. If you are not redirected automatically, <a href="{{ page.external_url }}">continue to “{{ page.title }}”</a>.</p>
+</body>
+</html>

--- a/source/_posts/2026-06-18-proxy-all-the-things-no-device-left-behind.markdown
+++ b/source/_posts/2026-06-18-proxy-all-the-things-no-device-left-behind.markdown
@@ -1,0 +1,14 @@
+---
+layout: crosspost
+title: "Proxy all the things: no device left behind"
+description: "Discover how Open Home Foundation projects can help you give your beloved old devices a new lease of life for a more sustainable smart home."
+date: 2026-06-18 00:00:01
+date_formatted: "June 18, 2026"
+author: Paulus Schoutsen
+comments: false
+categories: Technology
+external_url: "https://www.openhomefoundation.org/blog/proxy-all-the-things-no-device-left-behind/"
+external_source: "Open Home Foundation"
+---
+
+Every smart home has them: the older devices that still work perfectly well but no longer fit neatly into a modern setup. Instead of letting them gather dust in a drawer, the Open Home Foundation's projects can help you bring them back into the fold. Here's how a little proxying can give your beloved old gear a new lease of life, and keep your smart home that bit more sustainable.<!--more-->

--- a/source/atom.xml
+++ b/source/atom.xml
@@ -17,7 +17,7 @@ layout: none
   {% for post in site.posts limit: 20 %}
   <entry>
     <title type="html"><![CDATA[{{ post.title | cdata_escape }}]]></title>
-    <link href="{{ site.url }}{{ post.url }}"/>
+    {% if post.external_url %}<link href="{{ post.external_url }}"/>{% else %}<link href="{{ site.url }}{{ post.url }}"/>{% endif %}
     <updated>{{ post.date | date_to_xmlschema }}</updated>
     <id>{{ site.url }}{{ post.id }}</id>
     <content type="html"><![CDATA[{{ post.content | full_urls | cdata_escape }}]]></content>

--- a/source/atom.xml
+++ b/source/atom.xml
@@ -17,7 +17,7 @@ layout: none
   {% for post in site.posts limit: 20 %}
   <entry>
     <title type="html"><![CDATA[{{ post.title | cdata_escape }}]]></title>
-    {% if post.external_url %}<link href="{{ post.external_url }}"/>{% else %}<link href="{{ site.url }}{{ post.url }}"/>{% endif %}
+    {% if post.external_url %}<link href="{{ post.external_url | escape_once }}"/>{% else %}<link href="{{ site.url }}{{ post.url }}"/>{% endif %}
     <updated>{{ post.date | date_to_xmlschema }}</updated>
     <id>{{ site.url }}{{ post.id }}</id>
     <content type="html"><![CDATA[{{ post.content | full_urls | cdata_escape }}]]></content>


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Adds a **shared post** type: a blog post that shows a teaser on Home Assistant but links out to the full article on another site (here, the Open Home Foundation), instead of duplicating it.

Mark a post as shared by adding to its front matter:

```yaml
layout: crosspost
external_url: "https://www.openhomefoundation.org/blog/..."
external_source: "Open Home Foundation"
```

### Behavior

- **Blog list page** — title, "Read on" button, and thumbnail link out to the source article. A blue badge reads "This article is shared from the {source}", and the thumbnail reuses the source's Open Graph image.
- **Homepage card** — links out and shows "· Shared from {source}" next to the date.
- **The post's own URL** — redirects to the source article (`noindex` + canonical), so it never acts as a duplicate page, but still carries OG tags for link previews.
- **RSS feed** — links to the source article.
- **OG image** — a build-time plugin pulls the `og:image` from the source URL automatically, so no image needs copying into the repository.

### Files changed

- `plugins/crosspost_og.rb` *(new)* — fetches the source `og:image` at build time.
- `source/_layouts/crosspost.html` *(new)* — redirect layout for the post's own URL.
- `source/_includes/blog/post/article.html` — external links, thumbnail, and badge on the blog list.
- `source/_includes/custom/news.html` — external link and "Shared from" meta on the homepage card.
- `source/_includes/site/social_meta.html` — handle absolute (external) OG image URLs.
- `sass/homeassistant/base/_post.scss` — badge and thumbnail styling.
- `source/atom.xml` — RSS entry links to the source article.
- `source/_posts/2026-06-18-proxy-all-the-things-no-device-left-behind.markdown` *(new)* — the first shared post.



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
