### PR TITLE
Add Yoto use cases, examples, and troubleshooting

### DIFF
--- a/source/_integrations/yoto.markdown
+++ b/source/_integrations/yoto.markdown
@@ -220,7 +220,7 @@ automation:
 
 The integration updates each Yoto player's data in three ways:
 
-- Media player and playback state is pushed live over MQTT, so play, pause, volume, and track changes appear in Home Assistant right away. A player going online or offline is pushed the same way, so its media player, sensors, and binary sensors switch to available or unavailable instantly.
+- Media player and playback state are pushed live over MQTT, so play, pause, volume, and track changes appear in Home Assistant right away. A player going online or offline is pushed the same way, so its media player, sensors, and binary sensors switch to available or unavailable instantly.
 - Sensor values are refreshed every minute, when the integration requests a status snapshot from each player.
 - Configuration, such as the day and night mode settings, is refreshed from the Yoto cloud through {% term polling %} every 5 minutes. This is also when newly linked players are added.
 

--- a/source/_integrations/yoto.markdown
+++ b/source/_integrations/yoto.markdown
@@ -29,7 +29,9 @@ ha_dhcp: true
 
 The **Yoto** {% term integration %} lets you control your [Yoto](https://yotoplay.com) audio players from Home Assistant. You can play and pause cards, change the volume, skip tracks, seek within a track, see what is currently playing, and browse your card library to start a specific card, chapter, or track. You can also monitor each player's battery level, what is loaded in the card slot, and its current day or night mode.
 
-The integration talks to the official Yoto cloud over OAuth2 and receives playback updates over MQTT, so changes that happen on the player show up in Home Assistant almost immediately. Online and offline detection still relies on the cloud API and can lag by up to 5 minutes.
+The integration talks to the official Yoto cloud over OAuth2 and receives playback updates over MQTT, so changes that happen on a player, including when it goes online or offline, show up in Home Assistant almost immediately.
+
+With your players connected, you can fold them into your everyday routines. For example, you can start a calming card at bedtime or pause playback automatically when everyone leaves the house. You can also get a notification when a player's battery is running low.
 
 ## Supported devices
 
@@ -69,7 +71,7 @@ For more details, see the [Yoto Developers documentation](https://yoto.dev/get-s
 
 {% include integrations/config_flow.md %}
 
-During setup, Home Assistant opens the Yoto authorization page so you can grant access. After you approve, Home Assistant creates one {% term device %} and one media player {% term entity %} for every Yoto player in your family.
+During setup, Home Assistant opens the Yoto authorization page so you can grant access. After you approve, Home Assistant creates one {% term device %} for every Yoto player in your family, each with its media player, sensors, and other {% term entity entities %}.
 
 ## Supported functionality
 
@@ -82,10 +84,9 @@ The integration provides one media player entity per Yoto player. Each entity su
 - Seek to a position within the current track
 - Set the volume directly, or step up and down in the 16 hardware steps the player uses
 - Show the currently playing track title, the card title and author, and the card cover art as media artwork
-- Show the player as _off_ when it is asleep or disconnected from the Yoto cloud
 - Browse your Yoto card library and start playback of a card, chapter, or track
 
-Yoto players cannot be powered on remotely. Home Assistant reports the player as _off_ when it is offline but cannot wake it up.
+Yoto players cannot be powered on or woken remotely. While a player is offline, its media player, sensors, and binary sensors show as unavailable. The day and night mode settings stay available, because they come from the Yoto cloud rather than the player.
 
 To browse your Yoto card library, open the more-info dialog of the Yoto player and select the browse media button. From there, you can select a card, chapter, or track to start playback.
 
@@ -145,16 +146,101 @@ Each Yoto player also provides several sensors:
 - **Card slot**: what is loaded in the player, such as a physical card or streaming content.
 - **Day mode**: the player's current mode (day or night).
 
+## Examples
+
+Here are a few ways to use your Yoto players in automations.
+
+### Play a card from a bedside button
+
+Pair a wireless button with a player so a card starts on demand, for example a bedtime story at the press of a button by the bed. The easiest way to set this up is in the automation editor: add your button as the trigger, then add the action that plays the card. The exact trigger depends on your button. The example below uses a button that exposes an event entity. Replace the card ID with one from your own library by browsing it in the media browser and copying the `media_content_id` of the card you want.
+
+```yaml
+automation:
+  - alias: "Play the bedtime card from the bedside button"
+    triggers:
+      - trigger: state
+        entity_id: event.bedside_button
+    actions:
+      - action: media_player.play_media
+        target:
+          entity_id: media_player.yoto_player
+        data:
+          media_content_type: "music"
+          media_content_id: "yoto://card/abc123"
+```
+
+### Set a later wake-up time on weekends
+
+Each player has a **Day mode start** time entity that controls when it switches to day mode. This automation changes that time so the player lights up later on weekends. Just after midnight, it sets the day mode start to 8:00 AM on Saturday and Sunday, and back to 7:00 AM on the other days.
+
+```yaml
+automation:
+  - alias: "Later wake-up on weekends"
+    triggers:
+      - trigger: time
+        at: "00:01:00"
+    actions:
+      - if:
+          - condition: time
+            weekday:
+              - sat
+              - sun
+        then:
+          - action: time.set_value
+            target:
+              entity_id: time.yoto_player_day_mode_start
+            data:
+              time: "08:00:00"
+        else:
+          - action: time.set_value
+            target:
+              entity_id: time.yoto_player_day_mode_start
+            data:
+              time: "07:00:00"
+```
+
+### Notify when the battery is low
+
+This automation sends a notification to your phone when a player's battery drops below 20%.
+
+```yaml
+automation:
+  - alias: "Notify when the Yoto battery is low"
+    triggers:
+      - trigger: numeric_state
+        entity_id: sensor.yoto_player_battery
+        below: 20
+    actions:
+      - action: notify.mobile_app_phone
+        data:
+          message: "The Yoto player battery is below 20%."
+```
+
 ## Data updates
 
-The integration receives real-time playback updates from each Yoto player over MQTT. To keep the reported status fresh even when the player has not changed state, the integration also requests a status snapshot from each player every 60 seconds.
+The integration updates each Yoto player's data in three ways:
 
-The player's online or offline state comes from the Yoto cloud REST API, which the integration {% term polling polls %} every 5 minutes. A player that loses power or network can take up to that long to show as _off_ in Home Assistant.
+- Media player and playback state is pushed live over MQTT, so play, pause, volume, and track changes appear in Home Assistant right away. A player going online or offline is pushed the same way, so its media player, sensors, and binary sensors switch to available or unavailable instantly.
+- Sensor values are refreshed every minute, when the integration requests a status snapshot from each player.
+- Configuration, such as the day and night mode settings, is refreshed from the Yoto cloud through {% term polling %} every 5 minutes. This is also when newly linked players are added.
 
 ## Known limitations
 
-- The online and offline state of a player can lag by up to 5 minutes because the Yoto cloud only exposes this through polling.
 - Yoto players cannot be powered on or off from Home Assistant.
+
+## Troubleshooting
+
+### The media player and sensors show as unavailable
+
+To save battery, a Yoto player turns itself off after a period of inactivity. While it is off, it disconnects from the Yoto cloud, so its media player, sensors, and binary sensors show as unavailable in Home Assistant. The day and night mode settings stay available. To bring the rest back, wake the player by pressing a button on it or inserting a card, or plug it into power to keep it awake.
+
+### Home Assistant asks you to sign in again
+
+Access to your Yoto account can expire or be revoked, for example if you change your Yoto password. When that happens, Home Assistant starts a reauthentication flow and shows a notification. Follow the prompts to sign in again and restore the connection.
+
+### Playback controls do not respond
+
+Yoto players cannot be powered on remotely, so playback actions have no effect while a player is off or disconnected. Wake the player by pressing a button on it or inserting a card, then try again.
 
 ## Removing the integration
 


### PR DESCRIPTION
Expand the Yoto documentation toward the Gold quality scale.

- Add concrete use cases to the introduction
- Add an Examples section: bedside button playback, weekend wake-up time, and low battery notification
- Restructure Data updates to describe the MQTT push alongside the config and sensor polls
- Add a Troubleshooting section
- Clarify which entities become unavailable when a player goes offline, and that the day and night mode settings stay available