### PR TITLE
Add plug (outlet) support to Cync integration docs

### DIFF
--- a/source/_integrations/cync.markdown
+++ b/source/_integrations/cync.markdown
@@ -5,12 +5,14 @@ ha_release: '2025.10'
 ha_iot_class: Cloud Push
 ha_category:
   - light
+  - switch
 ha_codeowners:
   - '@Kinachi249'
 ha_domain: cync
 ha_integration_type: hub
 ha_platforms:
   - light
+  - switch
 ha_quality_scale: bronze
 ha_config_flow: true
 ---
@@ -47,6 +49,13 @@ The **Cync** integration provides the following entities.
 
 *If supported by device.
 
+### Switches
+
+Cync smart plug/outlet devices are exposed as switch entities with the **outlet** device class.
+
+- Supported operations:
+  - On/Off
+
 ## Known limitations
 
 - The following lighting features are not yet supported:
@@ -54,6 +63,7 @@ The **Cync** integration provides the following entities.
   - Light shows
   - Music shows
   - LED strip segment control
+- Plug (outlet) devices report unknown state on startup; state is updated after the first on/off command is issued.
 - Cync servers only allow one instance of your account to connect at a time. If you open the Cync app while Home Assistant is running, the integration will briefly lose its connection. It will automatically reconnect after a 10 second waiting period.
 
 ## Removing the integration


### PR DESCRIPTION
## Proposed change

Updates the Cync integration documentation to reflect the addition of smart plug/outlet support (added in the companion core PR home-assistant/core#174302.

Changes:
- Add `switch` to `ha_platforms` and `ha_category` front matter
- Document the new **Switches** section under Supported functionality
- Add a known limitation noting that plug state is unknown until the first command is issued (pycync 0.5.0 limitation)

## Additional information

- Companion core PR: home-assistant/core#174302

## Checklist

- [x] This PR fixes or closes issue (uses fixes/closes): N/A
- [x] Link to relevant PR in the core repo has been added
- [x] Documentation added/updated
- [ ] The documentation follows the [documentation standards](https://developers.home-assistant.io/docs/documenting/standards)