### PR TITLE
Add ScorpionTrack integration page

### DIFF
--- a/source/_integrations/scorpiontrack.markdown
+++ b/source/_integrations/scorpiontrack.markdown
@@ -3,7 +3,7 @@ title: ScorpionTrack
 description: Instructions on how to integrate ScorpionTrack shared vehicle locations into Home Assistant.
 ha_category:
   - Device tracker
-ha_release: 2026.5
+ha_release: 2026.8
 ha_iot_class: Cloud Polling
 ha_domain: scorpiontrack
 ha_platforms:
@@ -49,17 +49,7 @@ Share URL or token:
 
 The **ScorpionTrack** integration creates one {% term "device tracker" %} for each vehicle included in the share.
 
-Each tracker is intended to represent the vehicle directly on the Home Assistant map and in zone logic. The tracker name uses the vehicle registration when available, and otherwise falls back to the vehicle name from the ScorpionTrack share.
-
-The following tracker attributes are exposed when available:
-
-- Vehicle registration, make, and model
-- Current address reported by ScorpionTrack
-- Heading and cardinal direction
-- Ignition state
-- Last reported timestamp
-- Position age and stale-state information
-- Speed in the distance units preferred by the share
+Each tracker represents the vehicle directly on the Home Assistant map and in zone logic, using the latest GPS location reported through the ScorpionTrack share. The tracker name uses the vehicle registration when available, and otherwise falls back to the vehicle name from the ScorpionTrack share.
 
 ## Data updates
 

--- a/source/_integrations/scorpiontrack.markdown
+++ b/source/_integrations/scorpiontrack.markdown
@@ -69,7 +69,7 @@ Make sure the shared-location link is still active in ScorpionTrack and that the
 
 ### No vehicles appear after setup
 
-Confirm that the ScorpionTrack share still includes vehicles and that the share has not expired. Home Assistant only creates entities for vehicles currently exposed by the share.
+Confirm that the ScorpionTrack share still includes vehicles and that the share has not expired. Home Assistant creates tracker entities for vehicles present in the share when the integration is set up or reloaded. If you add vehicles to the share later, reload or reconfigure the integration.
 
 ## Removing the integration
 

--- a/source/_integrations/scorpiontrack.markdown
+++ b/source/_integrations/scorpiontrack.markdown
@@ -42,7 +42,7 @@ You can paste either the full shared-location URL or just the token from that UR
 
 {% configuration_basic %}
 Share URL or token:
-  description: Paste the full ScorpionTrack shared-location URL or only the token from that URL.
+  description: "Paste the full ScorpionTrack shared-location URL or only the token from that URL."
 {% endconfiguration_basic %}
 
 ## Supported functionality

--- a/source/_integrations/scorpiontrack.markdown
+++ b/source/_integrations/scorpiontrack.markdown
@@ -1,0 +1,90 @@
+---
+title: ScorpionTrack
+description: Instructions on how to integrate ScorpionTrack shared vehicle locations into Home Assistant.
+ha_category:
+  - Device tracker
+ha_release: 2026.5
+ha_iot_class: Cloud Polling
+ha_domain: scorpiontrack
+ha_platforms:
+  - device_tracker
+ha_config_flow: true
+ha_integration_type: hub
+ha_codeowners:
+  - '@Herbertmt978'
+ha_quality_scale: bronze
+---
+
+The **ScorpionTrack** {% term integration %} lets Home Assistant follow vehicles that have been shared through a public ScorpionTrack location-share link.
+
+This integration is intentionally focused on the share-link workflow. It does not use your private ScorpionTrack account credentials. Instead, it reads the shared vehicle feed exposed by ScorpionTrack and creates Home Assistant map entities from that data.
+
+## Prerequisites
+
+Before setting up the integration, you need:
+
+- A valid ScorpionTrack shared-location link
+- At least one vehicle included in that share
+
+## Create a share link
+
+Create the share in the ScorpionTrack customer portal:
+
+- Open the ScorpionTrack location share page at [app.scorpiontrack.com/customer/locationshare](https://app.scorpiontrack.com/customer/locationshare)
+- Create a new shared-location entry
+- Add every vehicle you want Home Assistant to track
+- Choose a suitable expiry time for the share
+- Copy the generated share URL
+
+Home Assistant can accept either the full shared-location URL or just the token contained within it.
+
+{% include integrations/config_flow.md %}
+
+{% configuration_basic %}
+Share URL or token:
+  description: Paste the full ScorpionTrack shared-location URL or only the token from that URL.
+{% endconfiguration_basic %}
+
+## Supported functionality
+
+### Entities
+
+The **ScorpionTrack** integration creates one {% term device tracker %} for each vehicle included in the share.
+
+Each tracker is intended to represent the car directly on the Home Assistant map and in zone logic. The tracker name uses the vehicle registration when available, and otherwise falls back to the vehicle name from the ScorpionTrack share.
+
+The following tracker attributes are exposed when available:
+
+- Vehicle registration, make, and model
+- Current address reported by ScorpionTrack
+- Heading and cardinal direction
+- Ignition state
+- Last reported timestamp
+- Position age and stale-state information
+- Speed in the distance units preferred by the share
+
+## Data updates
+
+The **ScorpionTrack** integration {% term polling polls %} ScorpionTrack every 2 minutes for the latest shared vehicle position.
+
+## Known limitations
+
+- This integration only supports ScorpionTrack shared-location links.
+- If the share expires or is revoked, the entities will become unavailable until a valid share is configured again.
+- The update speed is limited by the polling interval and by how often ScorpionTrack updates the shared feed itself.
+
+## Troubleshooting
+
+### The integration says the share is invalid
+
+Make sure the shared-location link is still active in ScorpionTrack and that the token was copied correctly. If you pasted the full URL, verify that it is the actual share URL and not the customer portal page address.
+
+### No vehicles appear after setup
+
+Confirm that the ScorpionTrack share still includes vehicles and that the share has not expired. Home Assistant only creates entities for vehicles currently exposed by the share.
+
+## Removing the integration
+
+This integration follows standard integration removal.
+
+{% include integrations/remove_device_service.md %}

--- a/source/_integrations/scorpiontrack.markdown
+++ b/source/_integrations/scorpiontrack.markdown
@@ -30,11 +30,11 @@ Before setting up the integration, you need:
 
 Create the share in the ScorpionTrack customer portal:
 
-1. Open the ScorpionTrack location share page at [app.scorpiontrack.com/customer/locationshare](https://app.scorpiontrack.com/customer/locationshare)
-2. Create a new shared-location entry
-3. Add every vehicle you want Home Assistant to track
-4. Choose a suitable expiry time for the share
-5. Copy the generated share URL
+1. Open the ScorpionTrack location share page at [app.scorpiontrack.com/customer/locationshare](https://app.scorpiontrack.com/customer/locationshare).
+2. Create a new shared-location entry.
+3. Add every vehicle you want Home Assistant to track.
+4. Choose a suitable expiry time for the share.
+5. Copy the generated share URL.
 
 You can paste either the full shared-location URL or just the token from that URL.
 
@@ -46,8 +46,6 @@ Share URL or token:
 {% endconfiguration_basic %}
 
 ## Supported functionality
-
-### Entities
 
 The **ScorpionTrack** integration creates one {% term "device tracker" %} for each vehicle included in the share.
 

--- a/source/_integrations/scorpiontrack.markdown
+++ b/source/_integrations/scorpiontrack.markdown
@@ -17,7 +17,7 @@ ha_quality_scale: bronze
 
 The **ScorpionTrack** {% term integration %} lets Home Assistant follow vehicles that have been shared through a public ScorpionTrack location-share link.
 
-This integration is intentionally focused on the share-link workflow. It does not use your private ScorpionTrack account credentials. Instead, it reads the shared vehicle feed exposed by ScorpionTrack and creates Home Assistant map entities from that data.
+This integration is intentionally focused on the share-link workflow. It does not use your private ScorpionTrack account credentials. Instead, it reads the shared vehicle feed exposed by ScorpionTrack and creates `device_tracker` entities from that data, which appear on the Home Assistant map.
 
 ## Prerequisites
 
@@ -30,13 +30,13 @@ Before setting up the integration, you need:
 
 Create the share in the ScorpionTrack customer portal:
 
-- Open the ScorpionTrack location share page at [app.scorpiontrack.com/customer/locationshare](https://app.scorpiontrack.com/customer/locationshare)
-- Create a new shared-location entry
-- Add every vehicle you want Home Assistant to track
-- Choose a suitable expiry time for the share
-- Copy the generated share URL
+1. Open the ScorpionTrack location share page at [app.scorpiontrack.com/customer/locationshare](https://app.scorpiontrack.com/customer/locationshare)
+2. Create a new shared-location entry
+3. Add every vehicle you want Home Assistant to track
+4. Choose a suitable expiry time for the share
+5. Copy the generated share URL
 
-Home Assistant can accept either the full shared-location URL or just the token contained within it.
+You can paste either the full shared-location URL or just the token from that URL.
 
 {% include integrations/config_flow.md %}
 
@@ -49,9 +49,9 @@ Share URL or token:
 
 ### Entities
 
-The **ScorpionTrack** integration creates one {% term device tracker %} for each vehicle included in the share.
+The **ScorpionTrack** integration creates one {% term "device tracker" %} for each vehicle included in the share.
 
-Each tracker is intended to represent the car directly on the Home Assistant map and in zone logic. The tracker name uses the vehicle registration when available, and otherwise falls back to the vehicle name from the ScorpionTrack share.
+Each tracker is intended to represent the vehicle directly on the Home Assistant map and in zone logic. The tracker name uses the vehicle registration when available, and otherwise falls back to the vehicle name from the ScorpionTrack share.
 
 The following tracker attributes are exposed when available:
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
Add the documentation page for the new ScorpionTrack integration.

The page matches the initial Core submission scope: shared-location links only, one `device_tracker` per shared vehicle, and setup steps that mirror the public share workflow in the ScorpionTrack portal.

## Type of change
- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [x] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
- Link to parent pull request in the codebase: home-assistant/core#168737
- Link to parent pull request in the Brands repository: home-assistant/brands#10564
- This PR fixes or closes issue: n/a

## Checklist
- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards