### PR TITLE
Align trigger, condition, and action names and descriptions with core

### DIFF
--- a/source/_actions/media_player.play_media.markdown
+++ b/source/_actions/media_player.play_media.markdown
@@ -1,5 +1,5 @@
 ---
-title: "Play media"
+title: "Play specified media"
 action: media_player.play_media
 domain: media_player
 description: "Plays specific media on a media player."
@@ -20,7 +20,7 @@ To play media from an automation or a script:
 3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
 4. In the **Then do** section, select **Add action**.
 5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the media player you want to control.
-6. From the actions shown for that target, select **Play media**.
+6. From the actions shown for that target, select **Play specified media**.
 7. Select the **Media** you want to play, and set the other options if you need them.
 8. Select **Save**.
 

--- a/source/_conditions/humidity.is_value.markdown
+++ b/source/_conditions/humidity.is_value.markdown
@@ -2,7 +2,7 @@
 title: "Relative humidity"
 condition: humidity.is_value
 domain: humidity
-description: "Tests if a relative humidity value is above a threshold, below a threshold, or in a range of values."
+description: "Tests the relative humidity of one or more entities."
 ---
 
 The **Relative humidity** condition passes when a humidity reading meets a threshold you define. You can check that humidity is above, below, or within a specific range. The condition works with humidity sensors, climate devices, humidifiers, and weather entities. Use it to run an automation only when the bedroom feels too damp, or only when the air is dry enough to need attention.

--- a/source/_conditions/illuminance.is_detected.markdown
+++ b/source/_conditions/illuminance.is_detected.markdown
@@ -1,14 +1,14 @@
 ---
-title: "Light is detected"
+title: "Light level is detected"
 condition: illuminance.is_detected
 domain: illuminance
-description: "Tests if light is currently detected."
+description: "Tests if one or more light sensors are detecting light."
 related_conditions:
   - illuminance.is_not_detected
   - illuminance.is_value
 ---
 
-The **Light is detected** condition passes when one or more light binary sensors are currently detecting light. Use it to gate an automation on a lit area, like only running a routine while a closet light is still on, or only sending a reminder if a room is currently bright.
+The **Light level is detected** condition passes when one or more light binary sensors are currently detecting light. Use it to gate an automation on a lit area, like only running a routine while a closet light is still on, or only sending a reminder if a room is currently bright.
 
 {% include integrations/labs_entity_triggers_note.md %}
 
@@ -19,7 +19,7 @@ To use this condition in an automation:
 1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
 2. Open an existing automation, or select **Create automation** > **Create new automation**.
 3. In the **And if** section, select **Add condition**.
-4. From the search box, search for and select **Light is detected**.
+4. From the search box, search for and select **Light level is detected**.
 5. Under **Targets** (see [Targets](#targets)), select one or more light sensors, devices, an area, a floor, or a label.
 6. If you selected more than one target, under **Condition passes if**, pick **Any** or **All**.
 7. Under **For at least**, you can set how long the sensors must keep detecting light before the condition passes. Leave it at zero for the condition to pass as soon as light is detected.
@@ -75,7 +75,7 @@ for:
 - This condition works with binary sensors that have the **light** device class. The sensor's threshold for what counts as "light detected" is set on the device itself.
 - Sensors that are `unavailable` or `unknown` are skipped for **Any** and fail for **All**.
 - For numeric illuminance readings (in lux), use [Illuminance](/conditions/illuminance.is_value/) instead.
-- To check the opposite state, use [Light is not detected](/conditions/illuminance.is_not_detected/).
+- To check the opposite state, use [Light level is not detected](/conditions/illuminance.is_not_detected/).
 
 {% include conditions/try_it.md %}
 
@@ -86,7 +86,7 @@ for:
 When the daily 23:00 evening check runs, send a notification only if the closet light sensor has been detecting light for at least 10 minutes, so a brief visit doesn't trigger an alert.
 
 - **Trigger**: Time: 23:00
-- **Condition**: Light is detected
+- **Condition**: Light level is detected
   - **Target**: Closet light sensor
   - **For at least**: 00:10:00
 - **Action**: Send a notification message

--- a/source/_conditions/illuminance.is_not_detected.markdown
+++ b/source/_conditions/illuminance.is_not_detected.markdown
@@ -1,14 +1,14 @@
 ---
-title: "Light is not detected"
+title: "Light level is not detected"
 condition: illuminance.is_not_detected
 domain: illuminance
-description: "Tests if light is currently not detected."
+description: "Tests if one or more light sensors are not detecting light."
 related_conditions:
   - illuminance.is_detected
   - illuminance.is_value
 ---
 
-The **Light is not detected** condition passes when one or more light binary sensors are currently dark. Use it to gate an automation on a dark area, like only running a wake-up routine if the bedroom is still dark, or only turning on hallway lights when an outdoor sensor reports no daylight.
+The **Light level is not detected** condition passes when one or more light binary sensors are currently dark. Use it to gate an automation on a dark area, like only running a wake-up routine if the bedroom is still dark, or only turning on hallway lights when an outdoor sensor reports no daylight.
 
 {% include integrations/labs_entity_triggers_note.md %}
 
@@ -19,7 +19,7 @@ To use this condition in an automation:
 1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
 2. Open an existing automation, or select **Create automation** > **Create new automation**.
 3. In the **And if** section, select **Add condition**.
-4. From the search box, search for and select **Light is not detected**.
+4. From the search box, search for and select **Light level is not detected**.
 5. Under **Targets** (see [Targets](#targets)), select one or more light sensors, devices, an area, a floor, or a label.
 6. If you selected more than one target, under **Condition passes if**, pick **Any** or **All**.
 7. Under **For at least**, you can set how long the sensors must remain dark before the condition passes.
@@ -75,7 +75,7 @@ for:
 - This condition works with binary sensors that have the **light** device class. The sensor's threshold for what counts as "no light detected" is set on the device itself.
 - Sensors that are `unavailable` or `unknown` are skipped for **Any** and fail for **All**.
 - For numeric illuminance readings (in lux), use [Illuminance](/conditions/illuminance.is_value/) instead.
-- To check for the opposite state, use [Light is detected](/conditions/illuminance.is_detected/).
+- To check for the opposite state, use [Light level is detected](/conditions/illuminance.is_detected/).
 
 {% include conditions/try_it.md %}
 
@@ -86,7 +86,7 @@ for:
 When motion is detected in the hallway, only turn on the hallway light if the outdoor light sensor has been dark for at least 5 minutes.
 
 - **Trigger**: Motion detected (hallway sensor)
-- **Condition**: Light is not detected
+- **Condition**: Light level is not detected
   - **Target**: Outdoor light sensor
   - **For at least**: 00:05:00
 - **Action**: Turn on light

--- a/source/_conditions/illuminance.is_value.markdown
+++ b/source/_conditions/illuminance.is_value.markdown
@@ -2,7 +2,7 @@
 title: "Illuminance"
 condition: illuminance.is_value
 domain: illuminance
-description: "Tests if an illuminance value is above a threshold, below a threshold, or in a range of values."
+description: "Tests the illuminance of one or more entities."
 related_conditions:
   - illuminance.is_detected
   - illuminance.is_not_detected
@@ -138,7 +138,7 @@ for:
 ## Good to know
 
 - Illuminance is measured in lux (lx). For reference: a brightly lit office is around 500 lx, indirect daylight is several thousand lx, and direct sunlight can exceed 100,000 lx.
-- This condition works with sensors that have the **illuminance** device class. For binary light/dark sensors, use [Light is detected](/conditions/illuminance.is_detected/) or [Light is not detected](/conditions/illuminance.is_not_detected/) instead.
+- This condition works with sensors that have the **illuminance** device class. For binary light/dark sensors, use [Light level is detected](/conditions/illuminance.is_detected/) or [Light level is not detected](/conditions/illuminance.is_not_detected/) instead.
 - Entities that are `unavailable` or `unknown` are skipped for **Any** and fail for **All**.
 - When you use a sensor as a dynamic threshold, its value is read at the moment the condition runs. The threshold is not continuously tracked; it is re-evaluated each time the automation runs.
 

--- a/source/_conditions/media_player.is_volume.markdown
+++ b/source/_conditions/media_player.is_volume.markdown
@@ -1,5 +1,5 @@
 ---
-title: "Volume"
+title: "Media player volume"
 condition: media_player.is_volume
 domain: media_player
 description: "Tests the volume of one or more media players."
@@ -8,21 +8,21 @@ related_conditions:
   - media_player.is_playing
 ---
 
-The **Volume** condition passes when a media player's volume matches the threshold rule you define. Use it when an automation should continue only if volume is above, below, within, or outside a range.
+The **Media player volume** condition passes when a media player's volume matches the threshold rule you define. Use it when an automation should continue only if volume is above, below, within, or outside a range.
 
-Use **Volume** to protect quiet hours, to allow a routine only when the room is already loud enough, or to branch based on the current listening level.
+Use **Media player volume** to protect quiet hours, to allow a routine only when the room is already loud enough, or to branch based on the current listening level.
 
 {% include integrations/labs_entity_triggers_note.md %}
 
 {% include conditions/ui_header.md %}
 
-To use **Volume** in an automation:
+To use **Media player volume** in an automation:
 
 1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
 2. Open an existing automation, or select **Create automation** > **Create new automation**.
 3. In the **And if** section, select **Add condition**.
 4. Select what you want to check. Under **By target** (see [Targets](#targets)), pick the media player you want to evaluate. You can also select an area, a floor, a device, or a label.
-5. From the conditions shown for that target, select **Volume**.
+5. From the conditions shown for that target, select **Media player volume**.
 6. Under **Threshold**, set the volume level or range the condition should check.
 7. Under **Condition passes if** (see [Behavior](#behavior-with-multiple-targets)), choose how multiple targeted media players should behave. The default is **Any**.
 8. Under **For at least**, enter how long the volume must meet the threshold before the condition passes. The default is `0`.
@@ -126,7 +126,7 @@ for:
 When the washer finishes, send a spoken announcement only if the receiver volume is below 35%.
 
 - **Trigger**: Washer finished
-- **Condition**: Volume
+- **Condition**: Media player volume
   - **Target**: Living room receiver
   - **Threshold**: Below 35%
 - **Action**: Play media
@@ -166,7 +166,7 @@ automation: |
 When everyone leaves home, start the robot vacuum only if every targeted media player downstairs is below 20% volume.
 
 - **Trigger**: Person leaves home
-- **Condition**: Volume
+- **Condition**: Media player volume
   - **Target**: Downstairs
   - **Threshold**: Below 20%
   - **Condition passes if**: All

--- a/source/_conditions/select.is_option_selected.markdown
+++ b/source/_conditions/select.is_option_selected.markdown
@@ -1,11 +1,11 @@
 ---
-title: "Option is selected"
+title: "Dropdown option is selected"
 condition: select.is_option_selected
 domain: select
 description: "Tests if one or more dropdowns have a specific option selected."
 ---
 
-The **Option is selected** condition passes when a dropdown {% term entity %} is currently set to a specific option. It works with both **Select** entities provided by integrations and the **Dropdown helper** ("input_select") you create yourself. Use it to gate automations on the current choice of a dropdown, such as only running a routine when **House mode** is set to "Home" or "Guest".
+The **Dropdown option is selected** condition passes when a dropdown {% term entity %} is currently set to a specific option. It works with both **Select** entities provided by integrations and the **Dropdown helper** ("input_select") you create yourself. Use it to gate automations on the current choice of a dropdown, such as only running a routine when **House mode** is set to "Home" or "Guest".
 
 When you target more than one dropdown, the **Condition passes if** option controls how the check combines results. You can require any targeted dropdown to be on the selected option, or demand that all of them are.
 
@@ -13,13 +13,13 @@ When you target more than one dropdown, the **Condition passes if** option contr
 
 {% include conditions/ui_header.md %}
 
-To use **Option is selected** in an automation:
+To use **Dropdown option is selected** in an automation:
 
 1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
 2. Open an existing automation, or select **Create automation** > **Create new automation**.
 3. In the **And if** section, select **Add condition**.
 4. Select what you want to check. Under **By target** (see [Targets](#targets)), pick the dropdown entity you want to check. You can also select an area, a device, or a label.
-5. From the conditions shown for that target, select **Option is selected**.
+5. From the conditions shown for that target, select **Dropdown option is selected**.
 6. Under **Option**, select one or more options to check for. Only options available on the targeted dropdown are shown.
 7. Under **Condition passes if** (see [Behavior](#behavior-with-multiple-targets)), pick **Any** or **All** to control how the check behaves when multiple dropdowns are targeted.
 8. Under **For at least**, set how long the dropdown must have been on the selected option before the condition passes. Leave it at zero to pass immediately.
@@ -104,9 +104,9 @@ for:
 
 Some media players expose their sound mode as a select entity, for example `select.living_room_soundbar_sound_mode` with options like **Music**, **Movie**, and **Night**. When someone starts a movie, dim the lights for a cinema feel.
 
-- **Trigger**: Selection changed
+- **Trigger**: Dropdown selection changed
   - **Target**: Living room soundbar sound mode
-- **Condition**: Option is selected
+- **Condition**: Dropdown option is selected
   - **Target**: Living room soundbar sound mode
   - **Option**: Movie
 - **Action**: Turn on light

--- a/source/_conditions/zone.occupancy_is_detected.markdown
+++ b/source/_conditions/zone.occupancy_is_detected.markdown
@@ -2,7 +2,7 @@
 title: "Zone occupancy is detected"
 condition: zone.occupancy_is_detected
 domain: zone
-description: "Tests if a zone is occupied."
+description: "Tests if one or more zones are occupied."
 related_conditions:
   - zone.occupancy_is_not_detected
   - zone.in_zone

--- a/source/_conditions/zone.occupancy_is_not_detected.markdown
+++ b/source/_conditions/zone.occupancy_is_not_detected.markdown
@@ -2,7 +2,7 @@
 title: "Zone occupancy is not detected"
 condition: zone.occupancy_is_not_detected
 domain: zone
-description: "Tests if a zone is empty."
+description: "Tests if one or more zones are unoccupied."
 related_conditions:
   - zone.occupancy_is_detected
   - zone.not_in_zone

--- a/source/_integrations/zone.markdown
+++ b/source/_integrations/zone.markdown
@@ -148,7 +148,7 @@ These examples show how you can use zone triggers and conditions in automations.
 
 When Nina enters the work zone, this automation sends a notification to your phone.
 
-- **Trigger**: Entered zone
+- **Trigger**: Zone entered
   - **Target**: Nina (`person.nina`)
   - **Zone**: Work (`zone.work`)
 - **Action**: Send a notification message

--- a/source/_triggers/air_quality.co2_changed.markdown
+++ b/source/_triggers/air_quality.co2_changed.markdown
@@ -2,7 +2,7 @@
 title: "Carbon dioxide level changed"
 trigger: air_quality.co2_changed
 domain: air_quality
-description: "Triggers after one or more carbon dioxide levels change."
+description: "Triggers when one or more carbon dioxide levels change."
 related_triggers:
   - air_quality.co2_crossed_threshold
 ---

--- a/source/_triggers/air_quality.co2_crossed_threshold.markdown
+++ b/source/_triggers/air_quality.co2_crossed_threshold.markdown
@@ -2,7 +2,7 @@
 title: "Carbon dioxide level crossed threshold"
 trigger: air_quality.co2_crossed_threshold
 domain: air_quality
-description: "Triggers after one or more carbon dioxide levels cross a threshold."
+description: "Triggers when one or more carbon dioxide levels cross a threshold."
 related_triggers:
   - air_quality.co2_changed
 ---

--- a/source/_triggers/air_quality.co_changed.markdown
+++ b/source/_triggers/air_quality.co_changed.markdown
@@ -2,7 +2,7 @@
 title: "Carbon monoxide level changed"
 trigger: air_quality.co_changed
 domain: air_quality
-description: "Triggers after one or more carbon monoxide levels change."
+description: "Triggers when one or more carbon monoxide levels change."
 related_triggers:
   - air_quality.co_crossed_threshold
 ---

--- a/source/_triggers/air_quality.co_cleared.markdown
+++ b/source/_triggers/air_quality.co_cleared.markdown
@@ -2,7 +2,7 @@
 title: "Carbon monoxide cleared"
 trigger: air_quality.co_cleared
 domain: air_quality
-description: "Triggers after one or more carbon monoxide sensors stop detecting carbon monoxide."
+description: "Triggers when one or more carbon monoxide sensors stop detecting carbon monoxide."
 related_triggers:
   - air_quality.co_detected
 ---

--- a/source/_triggers/air_quality.co_crossed_threshold.markdown
+++ b/source/_triggers/air_quality.co_crossed_threshold.markdown
@@ -2,7 +2,7 @@
 title: "Carbon monoxide level crossed threshold"
 trigger: air_quality.co_crossed_threshold
 domain: air_quality
-description: "Triggers after one or more carbon monoxide levels cross a threshold."
+description: "Triggers when one or more carbon monoxide levels cross a threshold."
 related_triggers:
   - air_quality.co_changed
 ---

--- a/source/_triggers/air_quality.co_detected.markdown
+++ b/source/_triggers/air_quality.co_detected.markdown
@@ -2,7 +2,7 @@
 title: "Carbon monoxide detected"
 trigger: air_quality.co_detected
 domain: air_quality
-description: "Triggers after one or more carbon monoxide sensors start detecting carbon monoxide."
+description: "Triggers when one or more carbon monoxide sensors start detecting carbon monoxide."
 related_triggers:
   - air_quality.co_cleared
 ---

--- a/source/_triggers/air_quality.gas_cleared.markdown
+++ b/source/_triggers/air_quality.gas_cleared.markdown
@@ -2,7 +2,7 @@
 title: "Gas cleared"
 trigger: air_quality.gas_cleared
 domain: air_quality
-description: "Triggers after one or more gas sensors stop detecting gas."
+description: "Triggers when one or more gas sensors stop detecting gas."
 related_triggers:
   - air_quality.gas_detected
 ---

--- a/source/_triggers/air_quality.gas_detected.markdown
+++ b/source/_triggers/air_quality.gas_detected.markdown
@@ -2,7 +2,7 @@
 title: "Gas detected"
 trigger: air_quality.gas_detected
 domain: air_quality
-description: "Triggers after one or more gas sensors start detecting gas."
+description: "Triggers when one or more gas sensors start detecting gas."
 related_triggers:
   - air_quality.gas_cleared
 ---

--- a/source/_triggers/air_quality.n2o_changed.markdown
+++ b/source/_triggers/air_quality.n2o_changed.markdown
@@ -2,7 +2,7 @@
 title: "Nitrous oxide level changed"
 trigger: air_quality.n2o_changed
 domain: air_quality
-description: "Triggers after one or more nitrous oxide levels change."
+description: "Triggers when one or more nitrous oxide levels change."
 related_triggers:
   - air_quality.n2o_crossed_threshold
 ---

--- a/source/_triggers/air_quality.n2o_crossed_threshold.markdown
+++ b/source/_triggers/air_quality.n2o_crossed_threshold.markdown
@@ -2,7 +2,7 @@
 title: "Nitrous oxide level crossed threshold"
 trigger: air_quality.n2o_crossed_threshold
 domain: air_quality
-description: "Triggers after one or more nitrous oxide levels cross a threshold."
+description: "Triggers when one or more nitrous oxide levels cross a threshold."
 related_triggers:
   - air_quality.n2o_changed
 ---

--- a/source/_triggers/air_quality.no2_changed.markdown
+++ b/source/_triggers/air_quality.no2_changed.markdown
@@ -2,7 +2,7 @@
 title: "Nitrogen dioxide level changed"
 trigger: air_quality.no2_changed
 domain: air_quality
-description: "Triggers after one or more nitrogen dioxide levels change."
+description: "Triggers when one or more nitrogen dioxide levels change."
 related_triggers:
   - air_quality.no2_crossed_threshold
 ---

--- a/source/_triggers/air_quality.no2_crossed_threshold.markdown
+++ b/source/_triggers/air_quality.no2_crossed_threshold.markdown
@@ -2,7 +2,7 @@
 title: "Nitrogen dioxide level crossed threshold"
 trigger: air_quality.no2_crossed_threshold
 domain: air_quality
-description: "Triggers after one or more nitrogen dioxide levels cross a threshold."
+description: "Triggers when one or more nitrogen dioxide levels cross a threshold."
 related_triggers:
   - air_quality.no2_changed
 ---

--- a/source/_triggers/air_quality.no_changed.markdown
+++ b/source/_triggers/air_quality.no_changed.markdown
@@ -2,7 +2,7 @@
 title: "Nitrogen monoxide level changed"
 trigger: air_quality.no_changed
 domain: air_quality
-description: "Triggers after one or more nitrogen monoxide levels change."
+description: "Triggers when one or more nitrogen monoxide levels change."
 related_triggers:
   - air_quality.no_crossed_threshold
 ---

--- a/source/_triggers/air_quality.no_crossed_threshold.markdown
+++ b/source/_triggers/air_quality.no_crossed_threshold.markdown
@@ -2,7 +2,7 @@
 title: "Nitrogen monoxide level crossed threshold"
 trigger: air_quality.no_crossed_threshold
 domain: air_quality
-description: "Triggers after one or more nitrogen monoxide levels cross a threshold."
+description: "Triggers when one or more nitrogen monoxide levels cross a threshold."
 related_triggers:
   - air_quality.no_changed
 ---

--- a/source/_triggers/air_quality.ozone_changed.markdown
+++ b/source/_triggers/air_quality.ozone_changed.markdown
@@ -2,7 +2,7 @@
 title: "Ozone level changed"
 trigger: air_quality.ozone_changed
 domain: air_quality
-description: "Triggers after one or more ozone levels change."
+description: "Triggers when one or more ozone levels change."
 related_triggers:
   - air_quality.ozone_crossed_threshold
 ---

--- a/source/_triggers/air_quality.ozone_crossed_threshold.markdown
+++ b/source/_triggers/air_quality.ozone_crossed_threshold.markdown
@@ -2,7 +2,7 @@
 title: "Ozone level crossed threshold"
 trigger: air_quality.ozone_crossed_threshold
 domain: air_quality
-description: "Triggers after one or more ozone levels cross a threshold."
+description: "Triggers when one or more ozone levels cross a threshold."
 related_triggers:
   - air_quality.ozone_changed
 ---

--- a/source/_triggers/air_quality.pm10_changed.markdown
+++ b/source/_triggers/air_quality.pm10_changed.markdown
@@ -2,7 +2,7 @@
 title: "PM10 level changed"
 trigger: air_quality.pm10_changed
 domain: air_quality
-description: "Triggers after one or more PM10 levels change."
+description: "Triggers when one or more PM10 levels change."
 related_triggers:
   - air_quality.pm10_crossed_threshold
 ---

--- a/source/_triggers/air_quality.pm10_crossed_threshold.markdown
+++ b/source/_triggers/air_quality.pm10_crossed_threshold.markdown
@@ -2,7 +2,7 @@
 title: "PM10 level crossed threshold"
 trigger: air_quality.pm10_crossed_threshold
 domain: air_quality
-description: "Triggers after one or more PM10 levels cross a threshold."
+description: "Triggers when one or more PM10 levels cross a threshold."
 related_triggers:
   - air_quality.pm10_changed
 ---

--- a/source/_triggers/air_quality.pm1_changed.markdown
+++ b/source/_triggers/air_quality.pm1_changed.markdown
@@ -2,7 +2,7 @@
 title: "PM1 level changed"
 trigger: air_quality.pm1_changed
 domain: air_quality
-description: "Triggers after one or more PM1 levels change."
+description: "Triggers when one or more PM1 levels change."
 related_triggers:
   - air_quality.pm1_crossed_threshold
 ---

--- a/source/_triggers/air_quality.pm1_crossed_threshold.markdown
+++ b/source/_triggers/air_quality.pm1_crossed_threshold.markdown
@@ -2,7 +2,7 @@
 title: "PM1 level crossed threshold"
 trigger: air_quality.pm1_crossed_threshold
 domain: air_quality
-description: "Triggers after one or more PM1 levels cross a threshold."
+description: "Triggers when one or more PM1 levels cross a threshold."
 related_triggers:
   - air_quality.pm1_changed
 ---

--- a/source/_triggers/air_quality.pm25_changed.markdown
+++ b/source/_triggers/air_quality.pm25_changed.markdown
@@ -2,7 +2,7 @@
 title: "PM2.5 level changed"
 trigger: air_quality.pm25_changed
 domain: air_quality
-description: "Triggers after one or more PM2.5 levels change."
+description: "Triggers when one or more PM2.5 levels change."
 related_triggers:
   - air_quality.pm25_crossed_threshold
 ---

--- a/source/_triggers/air_quality.pm25_crossed_threshold.markdown
+++ b/source/_triggers/air_quality.pm25_crossed_threshold.markdown
@@ -2,7 +2,7 @@
 title: "PM2.5 level crossed threshold"
 trigger: air_quality.pm25_crossed_threshold
 domain: air_quality
-description: "Triggers after one or more PM2.5 levels cross a threshold."
+description: "Triggers when one or more PM2.5 levels cross a threshold."
 related_triggers:
   - air_quality.pm25_changed
 ---

--- a/source/_triggers/air_quality.pm4_changed.markdown
+++ b/source/_triggers/air_quality.pm4_changed.markdown
@@ -2,7 +2,7 @@
 title: "PM4 level changed"
 trigger: air_quality.pm4_changed
 domain: air_quality
-description: "Triggers after one or more PM4 levels change."
+description: "Triggers when one or more PM4 levels change."
 related_triggers:
   - air_quality.pm4_crossed_threshold
 ---

--- a/source/_triggers/air_quality.pm4_crossed_threshold.markdown
+++ b/source/_triggers/air_quality.pm4_crossed_threshold.markdown
@@ -2,7 +2,7 @@
 title: "PM4 level crossed threshold"
 trigger: air_quality.pm4_crossed_threshold
 domain: air_quality
-description: "Triggers after one or more PM4 levels cross a threshold."
+description: "Triggers when one or more PM4 levels cross a threshold."
 related_triggers:
   - air_quality.pm4_changed
 ---

--- a/source/_triggers/air_quality.smoke_cleared.markdown
+++ b/source/_triggers/air_quality.smoke_cleared.markdown
@@ -2,7 +2,7 @@
 title: "Smoke cleared"
 trigger: air_quality.smoke_cleared
 domain: air_quality
-description: "Triggers after one or more smoke sensors stop detecting smoke."
+description: "Triggers when one or more smoke sensors stop detecting smoke."
 related_triggers:
   - air_quality.smoke_detected
 ---

--- a/source/_triggers/air_quality.smoke_detected.markdown
+++ b/source/_triggers/air_quality.smoke_detected.markdown
@@ -2,7 +2,7 @@
 title: "Smoke detected"
 trigger: air_quality.smoke_detected
 domain: air_quality
-description: "Triggers after one or more smoke sensors start detecting smoke."
+description: "Triggers when one or more smoke sensors start detecting smoke."
 related_triggers:
   - air_quality.smoke_cleared
 ---

--- a/source/_triggers/air_quality.so2_changed.markdown
+++ b/source/_triggers/air_quality.so2_changed.markdown
@@ -2,7 +2,7 @@
 title: "Sulphur dioxide level changed"
 trigger: air_quality.so2_changed
 domain: air_quality
-description: "Triggers after one or more sulphur dioxide levels change."
+description: "Triggers when one or more sulphur dioxide levels change."
 related_triggers:
   - air_quality.so2_crossed_threshold
 ---

--- a/source/_triggers/air_quality.so2_crossed_threshold.markdown
+++ b/source/_triggers/air_quality.so2_crossed_threshold.markdown
@@ -2,7 +2,7 @@
 title: "Sulphur dioxide level crossed threshold"
 trigger: air_quality.so2_crossed_threshold
 domain: air_quality
-description: "Triggers after one or more sulphur dioxide levels cross a threshold."
+description: "Triggers when one or more sulphur dioxide levels cross a threshold."
 related_triggers:
   - air_quality.so2_changed
 ---

--- a/source/_triggers/air_quality.voc_changed.markdown
+++ b/source/_triggers/air_quality.voc_changed.markdown
@@ -2,7 +2,7 @@
 title: "Volatile organic compounds level changed"
 trigger: air_quality.voc_changed
 domain: air_quality
-description: "Triggers after one or more volatile organic compound levels change."
+description: "Triggers when one or more volatile organic compound levels change."
 related_triggers:
   - air_quality.voc_crossed_threshold
 ---

--- a/source/_triggers/air_quality.voc_crossed_threshold.markdown
+++ b/source/_triggers/air_quality.voc_crossed_threshold.markdown
@@ -2,7 +2,7 @@
 title: "Volatile organic compounds level crossed threshold"
 trigger: air_quality.voc_crossed_threshold
 domain: air_quality
-description: "Triggers after one or more volatile organic compounds levels cross a threshold."
+description: "Triggers when one or more volatile organic compounds levels cross a threshold."
 related_triggers:
   - air_quality.voc_changed
 ---

--- a/source/_triggers/air_quality.voc_ratio_changed.markdown
+++ b/source/_triggers/air_quality.voc_ratio_changed.markdown
@@ -2,7 +2,7 @@
 title: "Volatile organic compounds ratio changed"
 trigger: air_quality.voc_ratio_changed
 domain: air_quality
-description: "Triggers after one or more volatile organic compound ratios change."
+description: "Triggers when one or more volatile organic compound ratios change."
 related_triggers:
   - air_quality.voc_ratio_crossed_threshold
 ---

--- a/source/_triggers/air_quality.voc_ratio_crossed_threshold.markdown
+++ b/source/_triggers/air_quality.voc_ratio_crossed_threshold.markdown
@@ -2,7 +2,7 @@
 title: "Volatile organic compounds ratio crossed threshold"
 trigger: air_quality.voc_ratio_crossed_threshold
 domain: air_quality
-description: "Triggers after one or more volatile organic compounds ratios cross a threshold."
+description: "Triggers when one or more volatile organic compounds ratios cross a threshold."
 related_triggers:
   - air_quality.voc_ratio_changed
 ---

--- a/source/_triggers/alarm_control_panel.armed.markdown
+++ b/source/_triggers/alarm_control_panel.armed.markdown
@@ -2,7 +2,7 @@
 title: "Alarm armed"
 trigger: alarm_control_panel.armed
 domain: alarm_control_panel
-description: "Triggers after one or more alarms become armed, regardless of the mode."
+description: "Triggers when one or more alarms become armed, regardless of the mode."
 related_triggers:
   - alarm_control_panel.armed_away
   - alarm_control_panel.armed_home

--- a/source/_triggers/alarm_control_panel.armed_away.markdown
+++ b/source/_triggers/alarm_control_panel.armed_away.markdown
@@ -2,7 +2,7 @@
 title: "Alarm armed away"
 trigger: alarm_control_panel.armed_away
 domain: alarm_control_panel
-description: "Triggers after one or more alarms become armed in away mode."
+description: "Triggers when one or more alarms become armed in away mode."
 related_triggers:
   - alarm_control_panel.armed
   - alarm_control_panel.disarmed

--- a/source/_triggers/alarm_control_panel.armed_home.markdown
+++ b/source/_triggers/alarm_control_panel.armed_home.markdown
@@ -2,7 +2,7 @@
 title: "Alarm armed home"
 trigger: alarm_control_panel.armed_home
 domain: alarm_control_panel
-description: "Triggers after one or more alarms become armed in home mode."
+description: "Triggers when one or more alarms become armed in home mode."
 related_triggers:
   - alarm_control_panel.armed
   - alarm_control_panel.disarmed

--- a/source/_triggers/alarm_control_panel.armed_night.markdown
+++ b/source/_triggers/alarm_control_panel.armed_night.markdown
@@ -2,7 +2,7 @@
 title: "Alarm armed night"
 trigger: alarm_control_panel.armed_night
 domain: alarm_control_panel
-description: "Triggers after one or more alarms become armed in night mode."
+description: "Triggers when one or more alarms become armed in night mode."
 related_triggers:
   - alarm_control_panel.armed
   - alarm_control_panel.disarmed

--- a/source/_triggers/alarm_control_panel.armed_vacation.markdown
+++ b/source/_triggers/alarm_control_panel.armed_vacation.markdown
@@ -2,7 +2,7 @@
 title: "Alarm armed vacation"
 trigger: alarm_control_panel.armed_vacation
 domain: alarm_control_panel
-description: "Triggers after one or more alarms become armed in vacation mode."
+description: "Triggers when one or more alarms become armed in vacation mode."
 related_triggers:
   - alarm_control_panel.armed
   - alarm_control_panel.disarmed

--- a/source/_triggers/alarm_control_panel.disarmed.markdown
+++ b/source/_triggers/alarm_control_panel.disarmed.markdown
@@ -2,7 +2,7 @@
 title: "Alarm disarmed"
 trigger: alarm_control_panel.disarmed
 domain: alarm_control_panel
-description: "Triggers after one or more alarms become disarmed."
+description: "Triggers when one or more alarms become disarmed."
 related_triggers:
   - alarm_control_panel.armed
   - alarm_control_panel.triggered

--- a/source/_triggers/alarm_control_panel.triggered.markdown
+++ b/source/_triggers/alarm_control_panel.triggered.markdown
@@ -2,7 +2,7 @@
 title: "Alarm triggered"
 trigger: alarm_control_panel.triggered
 domain: alarm_control_panel
-description: "Triggers after one or more alarms become triggered."
+description: "Triggers when one or more alarms become triggered."
 related_triggers:
   - alarm_control_panel.disarmed
   - alarm_control_panel.armed

--- a/source/_triggers/assist_satellite.idle.markdown
+++ b/source/_triggers/assist_satellite.idle.markdown
@@ -2,7 +2,7 @@
 title: Satellite became idle
 trigger: assist_satellite.idle
 domain: assist_satellite
-description: Triggers after one or more Assist satellites return to the idle state.
+description: "Triggers when one or more Assist satellites become idle after having processed a command."
 related_triggers:
   - assist_satellite.started_listening
   - assist_satellite.started_processing

--- a/source/_triggers/battery.level_changed.markdown
+++ b/source/_triggers/battery.level_changed.markdown
@@ -2,7 +2,7 @@
 title: "Battery level changed"
 trigger: battery.level_changed
 domain: battery
-description: "Triggers after one or more battery level readings change."
+description: "Triggers when the battery level of one or more batteries changes."
 related_triggers:
   - battery.level_crossed
 ---

--- a/source/_triggers/battery.started_charging.markdown
+++ b/source/_triggers/battery.started_charging.markdown
@@ -2,7 +2,7 @@
 title: "Battery started charging"
 trigger: battery.started_charging
 domain: battery
-description: "Triggers after one or more battery-powered devices start charging."
+description: "Triggers when one or more batteries start charging."
 related_triggers:
   - battery.stopped_charging
   - battery.level_changed

--- a/source/_triggers/battery.stopped_charging.markdown
+++ b/source/_triggers/battery.stopped_charging.markdown
@@ -2,7 +2,7 @@
 title: "Battery stopped charging"
 trigger: battery.stopped_charging
 domain: battery
-description: "Triggers when one or more batteries stop charging."
+description: "Triggers when one or more battery-powered devices stop charging."
 related_triggers:
   - battery.started_charging
   - battery.level_changed

--- a/source/_triggers/battery.stopped_charging.markdown
+++ b/source/_triggers/battery.stopped_charging.markdown
@@ -2,7 +2,7 @@
 title: "Battery stopped charging"
 trigger: battery.stopped_charging
 domain: battery
-description: "Triggers after one or more battery-powered devices stop charging."
+description: "Triggers when one or more batteries stop charging."
 related_triggers:
   - battery.started_charging
   - battery.level_changed

--- a/source/_triggers/button.pressed.markdown
+++ b/source/_triggers/button.pressed.markdown
@@ -2,7 +2,7 @@
 title: "Button pressed"
 trigger: button.pressed
 domain: button
-description: "Runs when a button entity is pressed."
+description: "Triggers when one or more buttons are pressed."
 ---
 
 Use this trigger when you want an automation to run every time a button entity is pressed. This is useful when a button starts a task on a device and you also want Home Assistant to take a follow-up action.

--- a/source/_triggers/calendar.event_ended.markdown
+++ b/source/_triggers/calendar.event_ended.markdown
@@ -2,7 +2,7 @@
 title: "Calendar event ended"
 trigger: calendar.event_ended
 domain: calendar
-description: "Triggers when a calendar event ends."
+description: "Triggers when one or more calendar events end."
 related_triggers:
   - calendar.event_started
 ---

--- a/source/_triggers/calendar.event_started.markdown
+++ b/source/_triggers/calendar.event_started.markdown
@@ -2,7 +2,7 @@
 title: "Calendar event started"
 trigger: calendar.event_started
 domain: calendar
-description: "Triggers when a calendar event starts."
+description: "Triggers when one or more calendar events start."
 related_triggers:
   - calendar.event_ended
 ---

--- a/source/_triggers/climate.hvac_mode_changed.markdown
+++ b/source/_triggers/climate.hvac_mode_changed.markdown
@@ -2,7 +2,7 @@
 title: "Thermostat mode changed"
 trigger: climate.hvac_mode_changed
 domain: climate
-description: "Triggers after the HVAC mode of one or more climate devices changes."
+description: "Triggers when the mode of one or more thermostats changes."
 related_triggers:
   - climate.turned_on
   - climate.turned_off

--- a/source/_triggers/climate.started_cooling.markdown
+++ b/source/_triggers/climate.started_cooling.markdown
@@ -2,7 +2,7 @@
 title: "Thermostat started cooling"
 trigger: climate.started_cooling
 domain: climate
-description: "Triggers after one or more thermostats start cooling."
+description: "Triggers when one or more thermostats start cooling."
 related_triggers:
   - climate.started_heating
   - climate.started_drying

--- a/source/_triggers/climate.started_drying.markdown
+++ b/source/_triggers/climate.started_drying.markdown
@@ -2,7 +2,7 @@
 title: "Thermostat started drying"
 trigger: climate.started_drying
 domain: climate
-description: "Triggers after one or more thermostats start drying."
+description: "Triggers when one or more thermostats start drying."
 related_triggers:
   - climate.started_heating
   - climate.started_cooling

--- a/source/_triggers/climate.started_heating.markdown
+++ b/source/_triggers/climate.started_heating.markdown
@@ -2,7 +2,7 @@
 title: "Thermostat started heating"
 trigger: climate.started_heating
 domain: climate
-description: "Triggers after one or more thermostats start heating."
+description: "Triggers when one or more thermostats start heating."
 related_triggers:
   - climate.started_cooling
   - climate.started_drying

--- a/source/_triggers/climate.target_humidity_changed.markdown
+++ b/source/_triggers/climate.target_humidity_changed.markdown
@@ -2,7 +2,7 @@
 title: "Thermostat target humidity changed"
 trigger: climate.target_humidity_changed
 domain: climate
-description: "Triggers after the humidity setpoint of one or more thermostats changes."
+description: "Triggers when the humidity setpoint of one or more thermostats changes."
 related_triggers:
   - climate.target_humidity_crossed_threshold
   - climate.target_temperature_changed

--- a/source/_triggers/climate.target_humidity_crossed_threshold.markdown
+++ b/source/_triggers/climate.target_humidity_crossed_threshold.markdown
@@ -2,7 +2,7 @@
 title: "Thermostat target humidity crossed threshold"
 trigger: climate.target_humidity_crossed_threshold
 domain: climate
-description: "Triggers after the humidity setpoint of one or more thermostats crosses a threshold."
+description: "Triggers when the humidity setpoint of one or more thermostats crosses a threshold."
 related_triggers:
   - climate.target_humidity_changed
   - climate.target_temperature_crossed_threshold

--- a/source/_triggers/climate.target_temperature_changed.markdown
+++ b/source/_triggers/climate.target_temperature_changed.markdown
@@ -2,7 +2,7 @@
 title: "Thermostat target temperature changed"
 trigger: climate.target_temperature_changed
 domain: climate
-description: "Triggers after the temperature setpoint of one or more thermostats changes."
+description: "Triggers when the temperature setpoint of one or more thermostats changes."
 related_triggers:
   - climate.target_temperature_crossed_threshold
   - climate.target_humidity_changed

--- a/source/_triggers/climate.target_temperature_crossed_threshold.markdown
+++ b/source/_triggers/climate.target_temperature_crossed_threshold.markdown
@@ -2,7 +2,7 @@
 title: "Thermostat target temperature crossed threshold"
 trigger: climate.target_temperature_crossed_threshold
 domain: climate
-description: "Triggers after the temperature setpoint of one or more thermostats crosses a threshold."
+description: "Triggers when the temperature setpoint of one or more thermostats crosses a threshold."
 related_triggers:
   - climate.target_temperature_changed
   - climate.target_humidity_crossed_threshold

--- a/source/_triggers/climate.turned_off.markdown
+++ b/source/_triggers/climate.turned_off.markdown
@@ -2,7 +2,7 @@
 title: "Thermostat turned off"
 trigger: climate.turned_off
 domain: climate
-description: "Triggers after one or more climate devices turn off."
+description: "Triggers when one or more thermostats turn off."
 related_triggers:
   - climate.turned_on
   - climate.hvac_mode_changed

--- a/source/_triggers/climate.turned_on.markdown
+++ b/source/_triggers/climate.turned_on.markdown
@@ -2,7 +2,7 @@
 title: "Thermostat turned on"
 trigger: climate.turned_on
 domain: climate
-description: "Triggers after one or more climate devices turn on, regardless of the mode."
+description: "Triggers when one or more thermostats turn on, regardless of the mode."
 related_triggers:
   - climate.turned_off
   - climate.hvac_mode_changed

--- a/source/_triggers/counter.decremented.markdown
+++ b/source/_triggers/counter.decremented.markdown
@@ -2,7 +2,7 @@
 title: "Counter decremented"
 trigger: counter.decremented
 domain: counter
-description: "Triggers after one or more counters decrement."
+description: "Triggers when one or more counters decrement."
 related_triggers:
   - counter.incremented
   - counter.minimum_reached

--- a/source/_triggers/counter.incremented.markdown
+++ b/source/_triggers/counter.incremented.markdown
@@ -2,7 +2,7 @@
 title: "Counter incremented"
 trigger: counter.incremented
 domain: counter
-description: "Triggers after one or more counters increment."
+description: "Triggers when one or more counters increment."
 related_triggers:
   - counter.decremented
   - counter.maximum_reached

--- a/source/_triggers/counter.maximum_reached.markdown
+++ b/source/_triggers/counter.maximum_reached.markdown
@@ -2,7 +2,7 @@
 title: "Counter reached maximum"
 trigger: counter.maximum_reached
 domain: counter
-description: "Triggers after one or more counters reach their maximum value."
+description: "Triggers when one or more counters reach their maximum value."
 related_triggers:
   - counter.incremented
   - counter.minimum_reached

--- a/source/_triggers/counter.minimum_reached.markdown
+++ b/source/_triggers/counter.minimum_reached.markdown
@@ -2,7 +2,7 @@
 title: "Counter reached minimum"
 trigger: counter.minimum_reached
 domain: counter
-description: "Triggers after one or more counters reach their minimum value."
+description: "Triggers when one or more counters reach their minimum value."
 related_triggers:
   - counter.decremented
   - counter.maximum_reached

--- a/source/_triggers/counter.reset.markdown
+++ b/source/_triggers/counter.reset.markdown
@@ -2,7 +2,7 @@
 title: "Counter reset"
 trigger: counter.reset
 domain: counter
-description: "Triggers after one or more counters are reset."
+description: "Triggers when one or more counters are reset."
 related_triggers:
   - counter.incremented
   - counter.decremented

--- a/source/_triggers/cover.awning_closed.markdown
+++ b/source/_triggers/cover.awning_closed.markdown
@@ -2,7 +2,7 @@
 title: "Awning closed"
 trigger: cover.awning_closed
 domain: cover
-description: "Triggers after one or more awnings close."
+description: "Triggers when one or more awnings close."
 related_triggers:
   - cover.awning_opened
 ---

--- a/source/_triggers/cover.awning_opened.markdown
+++ b/source/_triggers/cover.awning_opened.markdown
@@ -2,7 +2,7 @@
 title: "Awning opened"
 trigger: cover.awning_opened
 domain: cover
-description: "Triggers after one or more awnings open."
+description: "Triggers when one or more awnings open."
 related_triggers:
   - cover.awning_closed
 ---

--- a/source/_triggers/cover.blind_closed.markdown
+++ b/source/_triggers/cover.blind_closed.markdown
@@ -2,7 +2,7 @@
 title: "Blind closed"
 trigger: cover.blind_closed
 domain: cover
-description: "Triggers after one or more blinds close."
+description: "Triggers when one or more blinds close."
 related_triggers:
   - cover.blind_opened
 ---

--- a/source/_triggers/cover.blind_opened.markdown
+++ b/source/_triggers/cover.blind_opened.markdown
@@ -2,7 +2,7 @@
 title: "Blind opened"
 trigger: cover.blind_opened
 domain: cover
-description: "Triggers after one or more blinds open."
+description: "Triggers when one or more blinds open."
 related_triggers:
   - cover.blind_closed
 ---

--- a/source/_triggers/cover.curtain_closed.markdown
+++ b/source/_triggers/cover.curtain_closed.markdown
@@ -2,7 +2,7 @@
 title: "Curtain closed"
 trigger: cover.curtain_closed
 domain: cover
-description: "Triggers after one or more curtains close."
+description: "Triggers when one or more curtains close."
 related_triggers:
   - cover.curtain_opened
 ---

--- a/source/_triggers/cover.curtain_opened.markdown
+++ b/source/_triggers/cover.curtain_opened.markdown
@@ -2,7 +2,7 @@
 title: "Curtain opened"
 trigger: cover.curtain_opened
 domain: cover
-description: "Triggers after one or more curtains open."
+description: "Triggers when one or more curtains open."
 related_triggers:
   - cover.curtain_closed
 ---

--- a/source/_triggers/cover.shade_closed.markdown
+++ b/source/_triggers/cover.shade_closed.markdown
@@ -2,7 +2,7 @@
 title: "Shade closed"
 trigger: cover.shade_closed
 domain: cover
-description: "Triggers after one or more shades close."
+description: "Triggers when one or more shades close."
 related_triggers:
   - cover.shade_opened
 ---

--- a/source/_triggers/cover.shade_opened.markdown
+++ b/source/_triggers/cover.shade_opened.markdown
@@ -2,7 +2,7 @@
 title: "Shade opened"
 trigger: cover.shade_opened
 domain: cover
-description: "Triggers after one or more shades open."
+description: "Triggers when one or more shades open."
 related_triggers:
   - cover.shade_closed
 ---

--- a/source/_triggers/cover.shutter_closed.markdown
+++ b/source/_triggers/cover.shutter_closed.markdown
@@ -2,7 +2,7 @@
 title: "Shutter closed"
 trigger: cover.shutter_closed
 domain: cover
-description: "Triggers after one or more shutters close."
+description: "Triggers when one or more shutters close."
 related_triggers:
   - cover.shutter_opened
 ---

--- a/source/_triggers/cover.shutter_opened.markdown
+++ b/source/_triggers/cover.shutter_opened.markdown
@@ -2,7 +2,7 @@
 title: "Shutter opened"
 trigger: cover.shutter_opened
 domain: cover
-description: "Triggers after one or more shutters open."
+description: "Triggers when one or more shutters open."
 related_triggers:
   - cover.shutter_closed
 ---

--- a/source/_triggers/door.closed.markdown
+++ b/source/_triggers/door.closed.markdown
@@ -2,7 +2,7 @@
 title: "Door closed"
 trigger: door.closed
 domain: door
-description: "Triggers after one or more doors close."
+description: "Triggers when one or more doors close."
 related_triggers:
   - door.opened
 ---

--- a/source/_triggers/door.opened.markdown
+++ b/source/_triggers/door.opened.markdown
@@ -2,7 +2,7 @@
 title: "Door opened"
 trigger: door.opened
 domain: door
-description: "Triggers after one or more doors open."
+description: "Triggers when one or more doors open."
 related_triggers:
   - door.closed
 ---

--- a/source/_triggers/event.received.markdown
+++ b/source/_triggers/event.received.markdown
@@ -2,7 +2,7 @@
 title: "Event received"
 trigger: event.received
 domain: event
-description: "Triggers when one or more event entities receive a matching event type."
+description: "Triggers when one or more event entities receive a matching event."
 related_triggers:
   - event
   - state

--- a/source/_triggers/event.received.markdown
+++ b/source/_triggers/event.received.markdown
@@ -2,7 +2,7 @@
 title: "Event received"
 trigger: event.received
 domain: event
-description: "Triggers when one or more event entities receive a matching event."
+description: "Triggers when one or more event entities receive a matching event type."
 related_triggers:
   - event
   - state

--- a/source/_triggers/fan.turned_off.markdown
+++ b/source/_triggers/fan.turned_off.markdown
@@ -2,7 +2,7 @@
 title: "Fan turned off"
 trigger: fan.turned_off
 domain: fan
-description: "Triggers after one or more fans turn off."
+description: "Triggers when one or more fans turn off."
 related_triggers:
   - fan.turned_on
 ---

--- a/source/_triggers/fan.turned_on.markdown
+++ b/source/_triggers/fan.turned_on.markdown
@@ -2,7 +2,7 @@
 title: "Fan turned on"
 trigger: fan.turned_on
 domain: fan
-description: "Triggers after one or more fans turn on."
+description: "Triggers when one or more fans turn on."
 related_triggers:
   - fan.turned_off
 ---

--- a/source/_triggers/garage_door.closed.markdown
+++ b/source/_triggers/garage_door.closed.markdown
@@ -2,7 +2,7 @@
 title: "Garage door closed"
 trigger: garage_door.closed
 domain: garage_door
-description: "Triggers after one or more garage doors close."
+description: "Triggers when one or more garage doors close."
 related_triggers:
   - garage_door.opened
 ---

--- a/source/_triggers/garage_door.opened.markdown
+++ b/source/_triggers/garage_door.opened.markdown
@@ -2,7 +2,7 @@
 title: "Garage door opened"
 trigger: garage_door.opened
 domain: garage_door
-description: "Triggers after one or more garage doors open."
+description: "Triggers when one or more garage doors open."
 related_triggers:
   - garage_door.closed
 ---

--- a/source/_triggers/gate.closed.markdown
+++ b/source/_triggers/gate.closed.markdown
@@ -2,7 +2,7 @@
 title: "Gate closed"
 trigger: gate.closed
 domain: gate
-description: "Triggers after one or more gates close."
+description: "Triggers when one or more gates close."
 related_triggers:
   - gate.opened
 ---

--- a/source/_triggers/gate.opened.markdown
+++ b/source/_triggers/gate.opened.markdown
@@ -2,7 +2,7 @@
 title: "Gate opened"
 trigger: gate.opened
 domain: gate
-description: "Triggers after one or more gates open."
+description: "Triggers when one or more gates open."
 related_triggers:
   - gate.closed
 ---

--- a/source/_triggers/humidifier.mode_changed.markdown
+++ b/source/_triggers/humidifier.mode_changed.markdown
@@ -2,7 +2,7 @@
 title: "Humidifier mode changed"
 trigger: humidifier.mode_changed
 domain: humidifier
-description: "Triggers when the operation mode of one or more humidifiers changes."
+description: "Triggers when the mode of one or more humidifiers changes."
 related_triggers:
   - humidifier.turned_on
   - humidifier.turned_off

--- a/source/_triggers/humidifier.mode_changed.markdown
+++ b/source/_triggers/humidifier.mode_changed.markdown
@@ -2,7 +2,7 @@
 title: "Humidifier mode changed"
 trigger: humidifier.mode_changed
 domain: humidifier
-description: "Triggers after the mode of one or more humidifiers changes."
+description: "Triggers when the operation mode of one or more humidifiers changes."
 related_triggers:
   - humidifier.turned_on
   - humidifier.turned_off

--- a/source/_triggers/humidifier.started_drying.markdown
+++ b/source/_triggers/humidifier.started_drying.markdown
@@ -2,7 +2,7 @@
 title: "Humidifier started drying"
 trigger: humidifier.started_drying
 domain: humidifier
-description: "Triggers after one or more humidifiers start actively drying (dehumidifying)."
+description: "Triggers when one or more humidifiers start drying."
 related_triggers:
   - humidifier.turned_on
   - humidifier.started_humidifying

--- a/source/_triggers/humidifier.started_humidifying.markdown
+++ b/source/_triggers/humidifier.started_humidifying.markdown
@@ -2,7 +2,7 @@
 title: "Humidifier started humidifying"
 trigger: humidifier.started_humidifying
 domain: humidifier
-description: "Triggers after one or more humidifiers start actively humidifying."
+description: "Triggers when one or more humidifiers start humidifying."
 related_triggers:
   - humidifier.turned_on
   - humidifier.started_drying

--- a/source/_triggers/humidifier.turned_off.markdown
+++ b/source/_triggers/humidifier.turned_off.markdown
@@ -2,7 +2,7 @@
 title: "Humidifier turned off"
 trigger: humidifier.turned_off
 domain: humidifier
-description: "Triggers after one or more humidifiers turn off."
+description: "Triggers when one or more humidifiers turn off."
 related_triggers:
   - humidifier.turned_on
   - humidifier.started_humidifying

--- a/source/_triggers/humidifier.turned_on.markdown
+++ b/source/_triggers/humidifier.turned_on.markdown
@@ -2,7 +2,7 @@
 title: "Humidifier turned on"
 trigger: humidifier.turned_on
 domain: humidifier
-description: "Triggers after one or more humidifiers turn on."
+description: "Triggers when one or more humidifiers turn on."
 related_triggers:
   - humidifier.turned_off
   - humidifier.started_humidifying

--- a/source/_triggers/humidity.changed.markdown
+++ b/source/_triggers/humidity.changed.markdown
@@ -2,7 +2,7 @@
 title: "Relative humidity changed"
 trigger: humidity.changed
 domain: humidity
-description: "Triggers after one or more relative humidity readings change."
+description: "Triggers when one or more relative humidity values change."
 related_triggers:
   - humidity.crossed_threshold
 ---

--- a/source/_triggers/humidity.crossed_threshold.markdown
+++ b/source/_triggers/humidity.crossed_threshold.markdown
@@ -2,7 +2,7 @@
 title: "Relative humidity crossed threshold"
 trigger: humidity.crossed_threshold
 domain: humidity
-description: "Triggers after one or more relative humidity readings cross a threshold."
+description: "Triggers when one or more relative humidity values cross a threshold."
 related_triggers:
   - humidity.changed
 ---

--- a/source/_triggers/illuminance.changed.markdown
+++ b/source/_triggers/illuminance.changed.markdown
@@ -2,7 +2,7 @@
 title: "Illuminance changed"
 trigger: illuminance.changed
 domain: illuminance
-description: "Triggers after one or more illuminance values change."
+description: "Triggers when one or more illuminance values change."
 related_triggers:
   - illuminance.crossed_threshold
   - illuminance.detected

--- a/source/_triggers/illuminance.cleared.markdown
+++ b/source/_triggers/illuminance.cleared.markdown
@@ -1,15 +1,15 @@
 ---
-title: "Light cleared"
+title: "Light level cleared"
 trigger: illuminance.cleared
 domain: illuminance
-description: "Triggers after one or more light sensors stop detecting light."
+description: "Triggers when one or more light sensors stop detecting light."
 related_triggers:
   - illuminance.detected
   - illuminance.changed
   - illuminance.crossed_threshold
 ---
 
-The **Light cleared** trigger fires when one or more light sensors stop detecting light.
+The **Light level cleared** trigger fires when one or more light sensors stop detecting light.
 
 Use it to automate actions when an area becomes dark, like turning on hallway lights at dusk when an outdoor sensor reports no more daylight, or sending a notification when a room sensor stops detecting light.
 
@@ -22,7 +22,7 @@ To use this trigger in an automation:
 1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
 2. Open an existing automation, or select **Create automation** > **Create new automation**.
 3. In the **When** section, select **Add trigger**.
-4. From the search box, search for and select **Light cleared**.
+4. From the search box, search for and select **Light level cleared**.
 5. Select **Add target** (see [Targets](#targets)) and pick the light sensor that you want to watch. You can also select an area, a floor, a device, or a label.
 6. Under **Trigger when** (see [Behavior](#behavior-with-multiple-targets)), pick **Each**, **First**, or **All** to control how the trigger behaves when multiple sensors are targeted.
 7. Under **For at least**, you can set how long the sensor must remain dark before the trigger fires. Leave it at zero to fire immediately.
@@ -101,7 +101,7 @@ for:
 
 When the outdoor light sensor reports no more daylight for at least 5 minutes, turn on the hallway lights.
 
-- **Trigger**: Light cleared
+- **Trigger**: Light level cleared
   - **Target**: Outdoor light sensor
   - **For at least**: 00:05:00
 - **Action**: Turn on light

--- a/source/_triggers/illuminance.crossed_threshold.markdown
+++ b/source/_triggers/illuminance.crossed_threshold.markdown
@@ -2,7 +2,7 @@
 title: "Illuminance crossed threshold"
 trigger: illuminance.crossed_threshold
 domain: illuminance
-description: "Triggers after one or more illuminance values cross a threshold."
+description: "Triggers when one or more illuminance values cross a threshold."
 related_triggers:
   - illuminance.changed
   - illuminance.detected

--- a/source/_triggers/illuminance.detected.markdown
+++ b/source/_triggers/illuminance.detected.markdown
@@ -1,15 +1,15 @@
 ---
-title: "Light detected"
+title: "Light level detected"
 trigger: illuminance.detected
 domain: illuminance
-description: "Triggers after one or more light sensors start detecting light."
+description: "Triggers when one or more light sensors start detecting light."
 related_triggers:
   - illuminance.cleared
   - illuminance.changed
   - illuminance.crossed_threshold
 ---
 
-The **Light detected** trigger fires when one or more light sensors start detecting light.
+The **Light level detected** trigger fires when one or more light sensors start detecting light.
 
 Use it to automate actions when a dark area becomes lit, like sending a notification when a closet light is accidentally left on, or turning off a night light at dawn when an outdoor sensor first picks up daylight.
 
@@ -22,7 +22,7 @@ To use this trigger in an automation:
 1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
 2. Open an existing automation, or select **Create automation** > **Create new automation**.
 3. In the **When** section, select **Add trigger**.
-4. From the search box, search for and select **Light detected**.
+4. From the search box, search for and select **Light level detected**.
 5. Select **Add target** (see [Targets](#targets)) and pick the light sensor that you want to watch. You can also select an area, a floor, a device, or a label.
 6. Under **Trigger when** (see [Behavior](#behavior-with-multiple-targets)), pick **Each**, **First**, or **All** to control how the trigger behaves when multiple sensors are targeted.
 7. Under **For at least**, you can set how long the sensor must keep detecting light before the trigger fires. Leave it at zero to fire immediately.
@@ -101,7 +101,7 @@ for:
 
 When the closet light sensor detects light for more than 10 minutes, send a notification so a light left on by mistake doesn't go unnoticed.
 
-- **Trigger**: Light detected
+- **Trigger**: Light level detected
   - **Target**: Closet light sensor
   - **For at least**: 00:10:00
 - **Action**: Send a notification message

--- a/source/_triggers/lawn_mower.errored.markdown
+++ b/source/_triggers/lawn_mower.errored.markdown
@@ -2,7 +2,7 @@
 title: "Lawn mower encountered an error"
 trigger: lawn_mower.errored
 domain: lawn_mower
-description: "Triggers after one or more lawn mowers encounter an error."
+description: "Triggers when one or more lawn mowers encounter an error."
 ---
 
 The **Lawn mower encountered an error** trigger fires when a mower reports a problem while it is working.

--- a/source/_triggers/lawn_mower.paused_mowing.markdown
+++ b/source/_triggers/lawn_mower.paused_mowing.markdown
@@ -2,7 +2,7 @@
 title: "Lawn mower paused mowing"
 trigger: lawn_mower.paused_mowing
 domain: lawn_mower
-description: "Triggers after one or more lawn mowers pause mowing."
+description: "Triggers when one or more lawn mowers pause mowing."
 ---
 
 The **Lawn mower paused mowing** trigger fires when a mower stops in the middle of a run without docking.

--- a/source/_triggers/lawn_mower.started_mowing.markdown
+++ b/source/_triggers/lawn_mower.started_mowing.markdown
@@ -2,7 +2,7 @@
 title: "Lawn mower started mowing"
 trigger: lawn_mower.started_mowing
 domain: lawn_mower
-description: "Triggers after one or more lawn mowers start mowing."
+description: "Triggers when one or more lawn mowers start mowing."
 ---
 
 The **Lawn mower started mowing** trigger fires when a mower begins a mowing run.

--- a/source/_triggers/lawn_mower.started_returning.markdown
+++ b/source/_triggers/lawn_mower.started_returning.markdown
@@ -2,7 +2,7 @@
 title: "Lawn mower started returning to dock"
 trigger: lawn_mower.started_returning
 domain: lawn_mower
-description: "Triggers after one or more lawn mowers start returning to dock."
+description: "Triggers when one or more lawn mowers start returning to dock."
 ---
 
 The **Lawn mower started returning to dock** trigger fires when a mower stops mowing and starts returning to its dock.

--- a/source/_triggers/light.brightness_changed.markdown
+++ b/source/_triggers/light.brightness_changed.markdown
@@ -2,7 +2,7 @@
 title: "Light brightness changed"
 trigger: light.brightness_changed
 domain: light
-description: "Triggers after the brightness of one or more lights changes."
+description: "Triggers when the brightness of one or more lights changes."
 related_triggers:
   - light.brightness_crossed_threshold
   - light.turned_on

--- a/source/_triggers/light.brightness_crossed_threshold.markdown
+++ b/source/_triggers/light.brightness_crossed_threshold.markdown
@@ -2,7 +2,7 @@
 title: "Light brightness crossed threshold"
 trigger: light.brightness_crossed_threshold
 domain: light
-description: "Triggers after the brightness of one or more lights crosses a threshold."
+description: "Triggers when the brightness of one or more lights crosses a threshold."
 related_triggers:
   - light.brightness_changed
   - light.turned_on

--- a/source/_triggers/light.turned_off.markdown
+++ b/source/_triggers/light.turned_off.markdown
@@ -2,7 +2,7 @@
 title: "Light turned off"
 trigger: light.turned_off
 domain: light
-description: "Triggers after one or more lights turn off."
+description: "Triggers when one or more lights turn off."
 related_triggers:
   - light.turned_on
   - light.brightness_changed

--- a/source/_triggers/light.turned_on.markdown
+++ b/source/_triggers/light.turned_on.markdown
@@ -2,7 +2,7 @@
 title: "Light turned on"
 trigger: light.turned_on
 domain: light
-description: "Triggers after one or more lights turn on."
+description: "Triggers when one or more lights turn on."
 related_triggers:
   - light.turned_off
   - light.brightness_changed

--- a/source/_triggers/lock.jammed.markdown
+++ b/source/_triggers/lock.jammed.markdown
@@ -2,7 +2,7 @@
 title: "Lock jammed"
 trigger: lock.jammed
 domain: lock
-description: "Triggers after one or more locks jam."
+description: "Triggers when one or more locks jam."
 related_triggers:
   - lock.locked
 ---

--- a/source/_triggers/lock.locked.markdown
+++ b/source/_triggers/lock.locked.markdown
@@ -2,7 +2,7 @@
 title: "Lock locked"
 trigger: lock.locked
 domain: lock
-description: "Triggers after one or more locks lock."
+description: "Triggers when one or more locks lock."
 related_triggers:
   - lock.unlocked
 ---

--- a/source/_triggers/lock.opened.markdown
+++ b/source/_triggers/lock.opened.markdown
@@ -2,7 +2,7 @@
 title: "Lock opened"
 trigger: lock.opened
 domain: lock
-description: "Triggers after one or more locks open."
+description: "Triggers when one or more locks open."
 related_triggers:
   - lock.locked
 ---

--- a/source/_triggers/lock.unlocked.markdown
+++ b/source/_triggers/lock.unlocked.markdown
@@ -2,7 +2,7 @@
 title: "Lock unlocked"
 trigger: lock.unlocked
 domain: lock
-description: "Triggers after one or more locks unlock."
+description: "Triggers when one or more locks unlock."
 related_triggers:
   - lock.locked
 ---

--- a/source/_triggers/media_player.muted.markdown
+++ b/source/_triggers/media_player.muted.markdown
@@ -2,7 +2,7 @@
 title: "Media player muted"
 trigger: media_player.muted
 domain: media_player
-description: "Triggers after one or more media players are muted."
+description: "Triggers when one or more media players are muted."
 related_triggers:
   - media_player.unmuted
   - media_player.volume_changed

--- a/source/_triggers/media_player.paused_playing.markdown
+++ b/source/_triggers/media_player.paused_playing.markdown
@@ -2,7 +2,7 @@
 title: "Media player paused playing"
 trigger: media_player.paused_playing
 domain: media_player
-description: "Triggers after one or more media players pause playing."
+description: "Triggers when one or more media players pause playing."
 related_triggers:
   - media_player.started_playing
   - media_player.stopped_playing

--- a/source/_triggers/media_player.started_playing.markdown
+++ b/source/_triggers/media_player.started_playing.markdown
@@ -2,7 +2,7 @@
 title: "Media player started playing"
 trigger: media_player.started_playing
 domain: media_player
-description: "Triggers after one or more media players start playing."
+description: "Triggers when one or more media players start playing."
 related_triggers:
   - media_player.paused_playing
   - media_player.stopped_playing

--- a/source/_triggers/media_player.stopped_playing.markdown
+++ b/source/_triggers/media_player.stopped_playing.markdown
@@ -2,7 +2,7 @@
 title: "Media player stopped playing"
 trigger: media_player.stopped_playing
 domain: media_player
-description: "Triggers after one or more media players stop playing."
+description: "Triggers when one or more media players stop playing."
 related_triggers:
   - media_player.paused_playing
   - media_player.started_playing

--- a/source/_triggers/media_player.turned_off.markdown
+++ b/source/_triggers/media_player.turned_off.markdown
@@ -2,7 +2,7 @@
 title: "Media player turned off"
 trigger: media_player.turned_off
 domain: media_player
-description: "Triggers after one or more media players turn off."
+description: "Triggers when one or more media players turn off."
 related_triggers:
   - media_player.turned_on
   - media_player.stopped_playing

--- a/source/_triggers/media_player.turned_on.markdown
+++ b/source/_triggers/media_player.turned_on.markdown
@@ -2,7 +2,7 @@
 title: "Media player turned on"
 trigger: media_player.turned_on
 domain: media_player
-description: "Triggers after one or more media players turn on."
+description: "Triggers when one or more media players turn on."
 related_triggers:
   - media_player.turned_off
   - media_player.started_playing

--- a/source/_triggers/media_player.unmuted.markdown
+++ b/source/_triggers/media_player.unmuted.markdown
@@ -2,7 +2,7 @@
 title: "Media player unmuted"
 trigger: media_player.unmuted
 domain: media_player
-description: "Triggers after one or more media players are unmuted."
+description: "Triggers when one or more media players are unmuted."
 related_triggers:
   - media_player.muted
   - media_player.started_playing

--- a/source/_triggers/media_player.volume_changed.markdown
+++ b/source/_triggers/media_player.volume_changed.markdown
@@ -2,7 +2,7 @@
 title: "Media player volume changed"
 trigger: media_player.volume_changed
 domain: media_player
-description: "Triggers after the volume of one or more media players changes."
+description: "Triggers when the volume of one or more media players changes."
 related_triggers:
   - media_player.volume_crossed_threshold
   - media_player.started_playing

--- a/source/_triggers/media_player.volume_crossed_threshold.markdown
+++ b/source/_triggers/media_player.volume_crossed_threshold.markdown
@@ -2,7 +2,7 @@
 title: "Media player volume crossed threshold"
 trigger: media_player.volume_crossed_threshold
 domain: media_player
-description: "Triggers after the volume of one or more media players crosses a threshold."
+description: "Triggers when the volume of one or more media players crosses a threshold."
 related_triggers:
   - media_player.volume_changed
   - media_player.muted

--- a/source/_triggers/moisture.changed.markdown
+++ b/source/_triggers/moisture.changed.markdown
@@ -2,7 +2,7 @@
 title: "Moisture content changed"
 trigger: moisture.changed
 domain: moisture
-description: "Triggers after one or more moisture content values change."
+description: "Triggers when one or more moisture content values change."
 related_triggers:
   - moisture.crossed_threshold
   - moisture.detected

--- a/source/_triggers/moisture.cleared.markdown
+++ b/source/_triggers/moisture.cleared.markdown
@@ -2,7 +2,7 @@
 title: "Moisture cleared"
 trigger: moisture.cleared
 domain: moisture
-description: "Triggers after one or more moisture sensors stop detecting moisture."
+description: "Triggers when one or more moisture sensors stop detecting moisture."
 related_triggers:
   - moisture.detected
   - moisture.changed

--- a/source/_triggers/moisture.crossed_threshold.markdown
+++ b/source/_triggers/moisture.crossed_threshold.markdown
@@ -2,7 +2,7 @@
 title: "Moisture content crossed threshold"
 trigger: moisture.crossed_threshold
 domain: moisture
-description: "Triggers after one or more moisture content values cross a threshold."
+description: "Triggers when one or more moisture content values cross a threshold."
 related_triggers:
   - moisture.changed
   - moisture.detected

--- a/source/_triggers/moisture.detected.markdown
+++ b/source/_triggers/moisture.detected.markdown
@@ -2,7 +2,7 @@
 title: "Moisture detected"
 trigger: moisture.detected
 domain: moisture
-description: "Triggers after one or more moisture sensors start detecting moisture."
+description: "Triggers when one or more moisture sensors start detecting moisture."
 related_triggers:
   - moisture.cleared
   - moisture.changed

--- a/source/_triggers/motion.cleared.markdown
+++ b/source/_triggers/motion.cleared.markdown
@@ -2,7 +2,7 @@
 title: "Motion cleared"
 trigger: motion.cleared
 domain: motion
-description: "Triggers after one or more motion sensors stop detecting motion."
+description: "Triggers when one or more motion sensors stop detecting motion."
 related_triggers:
   - motion.detected
 ---

--- a/source/_triggers/motion.detected.markdown
+++ b/source/_triggers/motion.detected.markdown
@@ -2,7 +2,7 @@
 title: "Motion detected"
 trigger: motion.detected
 domain: motion
-description: "Triggers after one or more motion sensors start detecting motion."
+description: "Triggers when one or more motion sensors start detecting motion."
 related_triggers:
   - motion.cleared
 ---

--- a/source/_triggers/occupancy.cleared.markdown
+++ b/source/_triggers/occupancy.cleared.markdown
@@ -2,7 +2,7 @@
 title: "Occupancy cleared"
 trigger: occupancy.cleared
 domain: occupancy
-description: "Triggers after one or more occupancy sensors report that a space is no longer occupied."
+description: "Triggers when one or more occupancy sensors stop detecting occupancy."
 related_triggers:
   - occupancy.detected
 ---

--- a/source/_triggers/occupancy.detected.markdown
+++ b/source/_triggers/occupancy.detected.markdown
@@ -2,7 +2,7 @@
 title: "Occupancy detected"
 trigger: occupancy.detected
 domain: occupancy
-description: "Triggers after one or more occupancy sensors detect that a space is occupied."
+description: "Triggers when one or more occupancy sensors start detecting occupancy."
 related_triggers:
   - occupancy.cleared
 ---

--- a/source/_triggers/power.changed.markdown
+++ b/source/_triggers/power.changed.markdown
@@ -2,7 +2,7 @@
 title: "Power changed"
 trigger: power.changed
 domain: power
-description: "Triggers after one or more power values change."
+description: "Triggers when one or more power values change."
 related_triggers:
   - power.crossed_threshold
 ---

--- a/source/_triggers/power.crossed_threshold.markdown
+++ b/source/_triggers/power.crossed_threshold.markdown
@@ -2,7 +2,7 @@
 title: "Power crossed threshold"
 trigger: power.crossed_threshold
 domain: power
-description: "Triggers after one or more power values cross a threshold."
+description: "Triggers when one or more power values cross a threshold."
 related_triggers:
   - power.changed
 ---

--- a/source/_triggers/scene.activated.markdown
+++ b/source/_triggers/scene.activated.markdown
@@ -2,7 +2,7 @@
 title: "Scene activated"
 trigger: scene.activated
 domain: scene
-description: "Runs when a scene is activated."
+description: "Triggers when one or more scenes are activated."
 ---
 
 Use this trigger when you want an automation to run every time a scene is activated. This is useful when activating a scene should also kick off follow-up actions, such as sending a notification, starting media playback, or adjusting devices that are not part of the scene itself.

--- a/source/_triggers/select.selection_changed.markdown
+++ b/source/_triggers/select.selection_changed.markdown
@@ -1,25 +1,25 @@
 ---
-title: "Selection changed"
+title: "Dropdown selection changed"
 trigger: select.selection_changed
 domain: select
-description: "Triggers after the selected option of one or more dropdowns changes."
+description: "Triggers when the selected option of one or more dropdowns changes."
 ---
 
-The **Selection changed** trigger fires after the selected option of a dropdown {% term entity %} changes. It works with both **Select** entities provided by integrations and the **Dropdown helper** ("input_select") you create yourself. Use it to react when someone switches modes, scenes, presets, or any other choice you have set up as a dropdown.
+The **Dropdown selection changed** trigger fires after the selected option of a dropdown {% term entity %} changes. It works with both **Select** entities provided by integrations and the **Dropdown helper** ("input_select") you create yourself. Use it to react when someone switches modes, scenes, presets, or any other choice you have set up as a dropdown.
 
-This trigger fires when the selected option changes from one valid option to another. To run only when the dropdown is set to a specific option, combine it with the [Option is selected](/conditions/select.is_option_selected/) condition.
+This trigger fires when the selected option changes from one valid option to another. To run only when the dropdown is set to a specific option, combine it with the [Dropdown option is selected](/conditions/select.is_option_selected/) condition.
 
 {% include integrations/labs_entity_triggers_note.md %}
 
 {% include triggers/ui_header.md %}
 
-To use **Selection changed** in an automation:
+To use **Dropdown selection changed** in an automation:
 
 1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
 2. Open an existing automation, or select **Create automation** > **Create new automation**.
 3. In the **When** section, select **Add trigger**.
 4. Select what you want to monitor. Under **By target** (see [Targets](#targets)), pick the dropdown entity you want to watch. You can also select an area, a device, or a label.
-5. From the triggers shown for that target, select **Selection changed**.
+5. From the triggers shown for that target, select **Dropdown selection changed**.
 6. Select **Save**.
 
 {% include triggers/yaml_header.md %}
@@ -40,7 +40,7 @@ This fires every time the selected option of the washing machine program dropdow
 ## Good to know
 
 - This trigger works with both **Select** entities provided by integrations (domain `select`) and **Dropdown helpers** you create yourself (domain `input_select`).
-- The trigger does not filter by which option was selected. To run only on a specific option, add an [Option is selected](/conditions/select.is_option_selected/) condition, or use a [State trigger](/docs/automation/trigger/#state-trigger) with the `to` option.
+- The trigger does not filter by which option was selected. To run only on a specific option, add an [Dropdown option is selected](/conditions/select.is_option_selected/) condition, or use a [State trigger](/docs/automation/trigger/#state-trigger) with the `to` option.
 - The trigger only fires when switching between two valid options. It does not fire when the dropdown becomes `unknown` or `unavailable`, or when it changes from `unknown` or `unavailable` to a valid option. To react to those cases, use a [State trigger](/docs/automation/trigger/#state-trigger).
 
 {% include triggers/try_it.md %}
@@ -51,7 +51,7 @@ This fires every time the selected option of the washing machine program dropdow
 
 Some media players expose their sound mode as a select entity, for example `select.living_room_soundbar_sound_mode` with options like **Music**, **Movie**, and **Night**. When the sound mode changes, announce the new mode on the living room speaker so everyone knows what the soundbar is set to.
 
-- **Trigger**: Selection changed
+- **Trigger**: Dropdown selection changed
   - **Target**: Living room soundbar sound mode
 - **Action**: Send TTS message
   - **Target**: Living room speaker

--- a/source/_triggers/select.selection_changed.markdown
+++ b/source/_triggers/select.selection_changed.markdown
@@ -5,7 +5,7 @@ domain: select
 description: "Triggers when the selected option of one or more dropdowns changes."
 ---
 
-The **Dropdown selection changed** trigger fires after the selected option of a dropdown {% term entity %} changes. It works with both **Select** entities provided by integrations and the **Dropdown helper** ("input_select") you create yourself. Use it to react when someone switches modes, scenes, presets, or any other choice you have set up as a dropdown.
+The **Dropdown selection changed** trigger fires when the selected option of a dropdown {% term entity %} changes. It works with both **Select** entities provided by integrations and the **Dropdown helper** ("input_select") you create yourself. Use it to react when someone switches modes, scenes, presets, or any other choice you have set up as a dropdown.
 
 This trigger fires when the selected option changes from one valid option to another. To run only when the dropdown is set to a specific option, combine it with the [Dropdown option is selected](/conditions/select.is_option_selected/) condition.
 
@@ -40,7 +40,7 @@ This fires every time the selected option of the washing machine program dropdow
 ## Good to know
 
 - This trigger works with both **Select** entities provided by integrations (domain `select`) and **Dropdown helpers** you create yourself (domain `input_select`).
-- The trigger does not filter by which option was selected. To run only on a specific option, add an [Dropdown option is selected](/conditions/select.is_option_selected/) condition, or use a [State trigger](/docs/automation/trigger/#state-trigger) with the `to` option.
+- The trigger does not filter by which option was selected. To run only on a specific option, add a [Dropdown option is selected](/conditions/select.is_option_selected/) condition, or use a [State trigger](/docs/automation/trigger/#state-trigger) with the `to` option.
 - The trigger only fires when switching between two valid options. It does not fire when the dropdown becomes `unknown` or `unavailable`, or when it changes from `unknown` or `unavailable` to a valid option. To react to those cases, use a [State trigger](/docs/automation/trigger/#state-trigger).
 
 {% include triggers/try_it.md %}

--- a/source/_triggers/siren.turned_off.markdown
+++ b/source/_triggers/siren.turned_off.markdown
@@ -2,7 +2,7 @@
 title: "Siren turned off"
 trigger: siren.turned_off
 domain: siren
-description: "Triggers after one or more sirens turn off."
+description: "Triggers when one or more sirens turn off."
 related_triggers:
   - siren.turned_on
 ---

--- a/source/_triggers/siren.turned_on.markdown
+++ b/source/_triggers/siren.turned_on.markdown
@@ -2,7 +2,7 @@
 title: "Siren turned on"
 trigger: siren.turned_on
 domain: siren
-description: "Triggers after one or more sirens turn on."
+description: "Triggers when one or more sirens turn on."
 related_triggers:
   - siren.turned_off
 ---

--- a/source/_triggers/switch.turned_off.markdown
+++ b/source/_triggers/switch.turned_off.markdown
@@ -2,7 +2,7 @@
 title: "Switch turned off"
 trigger: switch.turned_off
 domain: switch
-description: "Triggers after one or more switches turn off."
+description: "Triggers when one or more switches turn off."
 related_triggers:
   - switch.turned_on
 ---

--- a/source/_triggers/switch.turned_on.markdown
+++ b/source/_triggers/switch.turned_on.markdown
@@ -2,7 +2,7 @@
 title: "Switch turned on"
 trigger: switch.turned_on
 domain: switch
-description: "Triggers after one or more switches turn on."
+description: "Triggers when one or more switches turn on."
 related_triggers:
   - switch.turned_off
 ---

--- a/source/_triggers/temperature.changed.markdown
+++ b/source/_triggers/temperature.changed.markdown
@@ -2,7 +2,7 @@
 title: "Temperature changed"
 trigger: temperature.changed
 domain: temperature
-description: "Triggers after one or more temperature readings change."
+description: "Triggers when one or more temperatures change."
 related_triggers:
   - temperature.crossed_threshold
 ---

--- a/source/_triggers/temperature.changed.markdown
+++ b/source/_triggers/temperature.changed.markdown
@@ -2,7 +2,7 @@
 title: "Temperature changed"
 trigger: temperature.changed
 domain: temperature
-description: "Triggers when one or more temperatures change."
+description: "Triggers when one or more temperature readings change."
 related_triggers:
   - temperature.crossed_threshold
 ---

--- a/source/_triggers/temperature.crossed_threshold.markdown
+++ b/source/_triggers/temperature.crossed_threshold.markdown
@@ -2,7 +2,7 @@
 title: "Temperature crossed threshold"
 trigger: temperature.crossed_threshold
 domain: temperature
-description: "Triggers after one or more temperature readings cross a threshold."
+description: "Triggers when one or more temperatures cross a threshold."
 related_triggers:
   - temperature.changed
 ---

--- a/source/_triggers/temperature.crossed_threshold.markdown
+++ b/source/_triggers/temperature.crossed_threshold.markdown
@@ -2,7 +2,7 @@
 title: "Temperature crossed threshold"
 trigger: temperature.crossed_threshold
 domain: temperature
-description: "Triggers when one or more temperatures cross a threshold."
+description: "Triggers when one or more temperature readings cross a threshold."
 related_triggers:
   - temperature.changed
 ---

--- a/source/_triggers/text.changed.markdown
+++ b/source/_triggers/text.changed.markdown
@@ -2,7 +2,7 @@
 title: "Text changed"
 trigger: text.changed
 domain: text
-description: "Triggers after the value of one or more text entities changes."
+description: "Triggers when one or more texts change."
 ---
 
 The **Text changed** trigger fires after the value of a text {% term entity %} changes. It works with both [Text](/integrations/text/) entities exposed by your devices and integrations, and with [Text helpers](/integrations/input_text/). Use it to react when someone enters a new shopping list note, when a device reports a new status string, or when an automation updates a stored value.

--- a/source/_triggers/text.changed.markdown
+++ b/source/_triggers/text.changed.markdown
@@ -2,10 +2,10 @@
 title: "Text changed"
 trigger: text.changed
 domain: text
-description: "Triggers when one or more texts change."
+description: "Triggers when the value of one or more text entities changes."
 ---
 
-The **Text changed** trigger fires after the value of a text {% term entity %} changes. It works with both [Text](/integrations/text/) entities exposed by your devices and integrations, and with [Text helpers](/integrations/input_text/). Use it to react when someone enters a new shopping list note, when a device reports a new status string, or when an automation updates a stored value.
+The **Text changed** trigger fires when the value of a text {% term entity %} changes. It works with both [Text](/integrations/text/) entities exposed by your devices and integrations, and with [Text helpers](/integrations/input_text/). Use it to react when someone enters a new shopping list note, when a device reports a new status string, or when an automation updates a stored value.
 
 {% include integrations/labs_entity_triggers_note.md %}
 

--- a/source/_triggers/todo.item_added.markdown
+++ b/source/_triggers/todo.item_added.markdown
@@ -2,7 +2,7 @@
 title: "To-do item added"
 trigger: todo.item_added
 domain: todo
-description: "Triggers when a to-do item is added to a list."
+description: "Triggers when one or more to-do items are added to a list."
 related_triggers:
   - todo.item_completed
   - todo.item_removed

--- a/source/_triggers/todo.item_completed.markdown
+++ b/source/_triggers/todo.item_completed.markdown
@@ -2,7 +2,7 @@
 title: "To-do item completed"
 trigger: todo.item_completed
 domain: todo
-description: "Triggers when a to-do item is marked as done."
+description: "Triggers when one or more to-do items are marked as done."
 related_triggers:
   - todo.item_added
   - todo.item_removed

--- a/source/_triggers/todo.item_removed.markdown
+++ b/source/_triggers/todo.item_removed.markdown
@@ -2,7 +2,7 @@
 title: "To-do item removed"
 trigger: todo.item_removed
 domain: todo
-description: "Triggers when a to-do item is removed from a list."
+description: "Triggers when one or more to-do items are removed from a list."
 related_triggers:
   - todo.item_added
   - todo.item_completed

--- a/source/_triggers/vacuum.errored.markdown
+++ b/source/_triggers/vacuum.errored.markdown
@@ -1,14 +1,14 @@
 ---
-title: "Vacuum encountered an error"
+title: "Vacuum cleaner encountered an error"
 trigger: vacuum.errored
 domain: vacuum
-description: "Triggers when a vacuum cleaner reports an error."
+description: "Triggers when one or more vacuum cleaners encounter an error."
 related_triggers:
   - vacuum.paused_cleaning
   - vacuum.docked
 ---
 
-The **Vacuum encountered an error** trigger fires as soon as your vacuum reports an error state.
+The **Vacuum cleaner encountered an error** trigger fires as soon as your vacuum reports an error state.
 You can use it to create alerts, notifications, or proactive automations when something interrupts a cleaning session.
 
 This is useful when you want to know right away that the robot is tangled, blocked, out of water, or needs another kind of manual help before it can continue.
@@ -22,7 +22,7 @@ To use this trigger in an automation:
 1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
 2. Open an existing automation or select **Create automation** > **Create new automation**.
 3. In the **When** section, select **Add trigger**.
-4. From the search box, search for and select **Vacuum: Vacuum encountered an error**.
+4. From the search box, search for and select **Vacuum: Vacuum cleaner encountered an error**.
 5. Under **Targets**, pick the vacuum entities (or an area/floor) you want to monitor.
 6. Under **Trigger when**, pick **Each**, **First**, or **All** to control group behavior.
 7. Under **For at least**, enter how long the vacuum must remain in the error state before the trigger fires.
@@ -92,7 +92,7 @@ for:
 
 When the vacuum enters an error state, send a notification right away so you can clear the problem before the cleaning run is abandoned for the rest of the day.
 
-- **Trigger**: Vacuum encountered an error
+- **Trigger**: Vacuum cleaner encountered an error
   - **Target**: Upstairs vacuum
 - **Action**: Send a notification message
   - **Target**: My Device (`notify.my_device`)

--- a/source/_triggers/vacuum.paused_cleaning.markdown
+++ b/source/_triggers/vacuum.paused_cleaning.markdown
@@ -2,7 +2,7 @@
 title: "Vacuum paused cleaning"
 trigger: vacuum.paused_cleaning
 domain: vacuum
-description: "Triggers when a vacuum cleaner pauses cleaning."
+description: "Triggers when one or more vacuum cleaners pause cleaning."
 related_triggers:
   - vacuum.started_cleaning
   - vacuum.started_returning

--- a/source/_triggers/vacuum.started_cleaning.markdown
+++ b/source/_triggers/vacuum.started_cleaning.markdown
@@ -2,7 +2,7 @@
 title: "Vacuum started cleaning"
 trigger: vacuum.started_cleaning
 domain: vacuum
-description: "Triggers when a vacuum cleaner begins a cleaning task."
+description: "Triggers when one or more vacuum cleaners start cleaning."
 related_triggers:
   - vacuum.paused_cleaning
   - vacuum.docked

--- a/source/_triggers/vacuum.started_returning.markdown
+++ b/source/_triggers/vacuum.started_returning.markdown
@@ -2,7 +2,7 @@
 title: "Vacuum started returning to dock"
 trigger: vacuum.started_returning
 domain: vacuum
-description: "Triggers when a vacuum cleaner begins returning to its dock."
+description: "Triggers when one or more vacuum cleaners start returning to dock."
 related_triggers:
   - vacuum.docked
   - vacuum.started_cleaning

--- a/source/_triggers/valve.closed.markdown
+++ b/source/_triggers/valve.closed.markdown
@@ -2,7 +2,7 @@
 title: "Valve closed"
 trigger: valve.closed
 domain: valve
-description: "Triggers after one or more valves close."
+description: "Triggers when one or more valves close."
 related_triggers:
   - valve.opened
 ---

--- a/source/_triggers/valve.opened.markdown
+++ b/source/_triggers/valve.opened.markdown
@@ -2,7 +2,7 @@
 title: "Valve opened"
 trigger: valve.opened
 domain: valve
-description: "Triggers after one or more valves open."
+description: "Triggers when one or more valves open."
 related_triggers:
   - valve.closed
 ---

--- a/source/_triggers/water_heater.operation_mode_changed.markdown
+++ b/source/_triggers/water_heater.operation_mode_changed.markdown
@@ -2,7 +2,7 @@
 title: "Water heater operation mode changed"
 trigger: water_heater.operation_mode_changed
 domain: water_heater
-description: "Triggers after the operation mode of one or more water heaters changes to a specific mode."
+description: "Triggers when the operation mode of one or more water heaters changes to a specific mode."
 related_triggers:
   - water_heater.turned_on
   - water_heater.turned_off

--- a/source/_triggers/water_heater.target_temperature_changed.markdown
+++ b/source/_triggers/water_heater.target_temperature_changed.markdown
@@ -2,7 +2,7 @@
 title: "Water heater target temperature changed"
 trigger: water_heater.target_temperature_changed
 domain: water_heater
-description: "Triggers after the temperature setpoint of one or more water heaters changes."
+description: "Triggers when the temperature setpoint of one or more water heaters changes."
 related_triggers:
   - water_heater.target_temperature_crossed_threshold
   - water_heater.operation_mode_changed

--- a/source/_triggers/water_heater.target_temperature_crossed_threshold.markdown
+++ b/source/_triggers/water_heater.target_temperature_crossed_threshold.markdown
@@ -2,7 +2,7 @@
 title: "Water heater target temperature crossed threshold"
 trigger: water_heater.target_temperature_crossed_threshold
 domain: water_heater
-description: "Triggers after the temperature setpoint of one or more water heaters crosses a threshold."
+description: "Triggers when the temperature setpoint of one or more water heaters crosses a threshold."
 related_triggers:
   - water_heater.target_temperature_changed
   - water_heater.operation_mode_changed

--- a/source/_triggers/water_heater.turned_off.markdown
+++ b/source/_triggers/water_heater.turned_off.markdown
@@ -2,7 +2,7 @@
 title: "Water heater turned off"
 trigger: water_heater.turned_off
 domain: water_heater
-description: "Triggers after one or more water heaters turn off."
+description: "Triggers when one or more water heaters turn off."
 related_triggers:
   - water_heater.turned_on
   - water_heater.operation_mode_changed

--- a/source/_triggers/water_heater.turned_on.markdown
+++ b/source/_triggers/water_heater.turned_on.markdown
@@ -2,7 +2,7 @@
 title: "Water heater turned on"
 trigger: water_heater.turned_on
 domain: water_heater
-description: "Triggers after one or more water heaters turn on, regardless of the operation mode."
+description: "Triggers when one or more water heaters turn on, regardless of the operation mode."
 related_triggers:
   - water_heater.turned_off
   - water_heater.operation_mode_changed

--- a/source/_triggers/window.closed.markdown
+++ b/source/_triggers/window.closed.markdown
@@ -2,7 +2,7 @@
 title: "Window closed"
 trigger: window.closed
 domain: window
-description: "Triggers after one or more windows close."
+description: "Triggers when one or more windows close."
 related_triggers:
   - window.opened
 ---

--- a/source/_triggers/window.opened.markdown
+++ b/source/_triggers/window.opened.markdown
@@ -2,7 +2,7 @@
 title: "Window opened"
 trigger: window.opened
 domain: window
-description: "Triggers after one or more windows open."
+description: "Triggers when one or more windows open."
 related_triggers:
   - window.closed
 ---

--- a/source/_triggers/zone.entered.markdown
+++ b/source/_triggers/zone.entered.markdown
@@ -1,5 +1,5 @@
 ---
-title: "Entered zone"
+title: "Zone entered"
 trigger: zone.entered
 domain: zone
 description: "Triggers when one or more people or device trackers enter a zone."
@@ -8,7 +8,7 @@ related_triggers:
   - zone.occupancy_detected
 ---
 
-The **Entered zone** trigger fires when a person or device tracker enters a selected zone. Use it to start an automation when someone arrives home, reaches work, or enters another place that you track with a zone.
+The **Zone entered** trigger fires when a person or device tracker enters a selected zone. Use it to start an automation when someone arrives home, reaches work, or enters another place that you track with a zone.
 
 When you target more than one person or device tracker, the **Trigger when** option controls whether the automation runs for each arrival, only the first arrival, or only after all selected targets are in the zone.
 
@@ -21,7 +21,7 @@ To use this trigger in an automation:
 1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
 2. Open an existing automation, or select **Create automation** > **Create new automation**.
 3. In the **When** section, select **Add trigger**.
-4. From the search box, search for and select **Entered zone**.
+4. From the search box, search for and select **Zone entered**.
 5. Select what you want to monitor. Under **By target**, choose one or more people or device trackers.
 6. Under **Zone**, select the zone to monitor.
 7. Under **Trigger when** (see [Behavior](#behavior-with-multiple-targets)), pick **Each**, **First**, or **All**.
@@ -99,7 +99,7 @@ You can also select different target types in one trigger.
 
 - This trigger uses the `in_zones` attribute reported by person and device tracker entities.
 - If the selected person or device tracker is `unknown` or `unavailable`, Home Assistant does not treat that state as entering the zone.
-- To react when a target leaves the same zone, use [Left zone](/triggers/zone.left/).
+- To react when a target leaves the same zone, use [Zone left](/triggers/zone.left/).
 
 {% include triggers/try_it.md %}
 
@@ -109,7 +109,7 @@ You can also select different target types in one trigger.
 
 When Nina enters the work zone, this automation sends a notification to your phone.
 
-- **Trigger**: Entered zone
+- **Trigger**: Zone entered
   - **Target**: Nina (`person.nina`)
   - **Zone**: Work (`zone.work`)
 - **Action**: Send a notification message
@@ -140,7 +140,7 @@ automation: |
 
 When the first selected person enters the home zone after sunset, this automation turns on the hallway light.
 
-- **Trigger**: Entered zone
+- **Trigger**: Zone entered
   - **Target**: Nina and Alex
   - **Zone**: Home (`zone.home`)
   - **Trigger when**: First

--- a/source/_triggers/zone.left.markdown
+++ b/source/_triggers/zone.left.markdown
@@ -1,5 +1,5 @@
 ---
-title: "Left zone"
+title: "Zone left"
 trigger: zone.left
 domain: zone
 description: "Triggers when one or more people or device trackers leave a zone."
@@ -8,7 +8,7 @@ related_triggers:
   - zone.occupancy_cleared
 ---
 
-The **Left zone** trigger fires when a person or device tracker leaves a selected zone. Use it to start an automation when someone leaves home, leaves work, or moves out of another zone you track.
+The **Zone left** trigger fires when a person or device tracker leaves a selected zone. Use it to start an automation when someone leaves home, leaves work, or moves out of another zone you track.
 
 When you target more than one person or device tracker, the **Trigger when** option controls whether the automation runs for each departure, only the first departure, or only after all selected targets have left the zone.
 
@@ -21,7 +21,7 @@ To use this trigger in an automation:
 1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
 2. Open an existing automation, or select **Create automation** > **Create new automation**.
 3. In the **When** section, select **Add trigger**.
-4. From the search box, search for and select **Left zone**.
+4. From the search box, search for and select **Zone left**.
 5. Select what you want to monitor. Under **By target**, choose one or more people or device trackers.
 6. Under **Zone**, select the zone to monitor.
 7. Under **Trigger when** (see [Behavior](#behavior-with-multiple-targets)), pick **Each**, **First**, or **All**.
@@ -99,7 +99,7 @@ You can also select different target types in one trigger.
 
 - This trigger uses the `in_zones` attribute reported by person and device tracker entities.
 - If the selected person or device tracker is `unknown` or `unavailable`, Home Assistant does not treat that state as leaving the zone.
-- To react when a target enters the same zone, use [Entered zone](/triggers/zone.entered/).
+- To react when a target enters the same zone, use [Zone entered](/triggers/zone.entered/).
 
 {% include triggers/try_it.md %}
 
@@ -109,7 +109,7 @@ You can also select different target types in one trigger.
 
 When all selected people have left the home zone for 5 minutes, this automation locks the front door.
 
-- **Trigger**: Left zone
+- **Trigger**: Zone left
   - **Target**: Nina and Alex
   - **Zone**: Home (`zone.home`)
   - **Trigger when**: All
@@ -144,7 +144,7 @@ automation: |
 
 When a tracked phone leaves the school zone, this automation sends a notification.
 
-- **Trigger**: Left zone
+- **Trigger**: Zone left
   - **Target**: Phone (`device_tracker.phone`)
   - **Zone**: School (`zone.school`)
 - **Action**: Send a notification message

--- a/source/_triggers/zone.occupancy_cleared.markdown
+++ b/source/_triggers/zone.occupancy_cleared.markdown
@@ -2,7 +2,7 @@
 title: "Zone occupancy cleared"
 trigger: zone.occupancy_cleared
 domain: zone
-description: "Triggers when a zone changes from occupied to empty."
+description: "Triggers when one or more zones transition from occupied to unoccupied."
 related_triggers:
   - zone.occupancy_detected
   - zone.left

--- a/source/_triggers/zone.occupancy_detected.markdown
+++ b/source/_triggers/zone.occupancy_detected.markdown
@@ -2,7 +2,7 @@
 title: "Zone occupancy detected"
 trigger: zone.occupancy_detected
 domain: zone
-description: "Triggers when a zone changes from empty to occupied."
+description: "Triggers when one or more zones become occupied."
 related_triggers:
   - zone.occupancy_cleared
   - zone.entered


### PR DESCRIPTION
## Proposed change

Aligns the trigger, condition, and action documentation pages with the naming consistency work done in the codebase. This updates the page titles and descriptions (and the in-page references to those names) so the docs match what users see in Home Assistant.

This covers the text changes only: standardized trigger descriptions (opening with "Triggers when"), reworded descriptions, and a number of renamed titles (for example "Selection changed" becomes "Dropdown selection changed", the illuminance triggers/conditions become "Light level …", and the media player `play_media` action becomes "Play specified media").

The key (identifier) renames are intentionally left out of this PR. Those change page URLs and need redirects, and will be made against the `next` branch after these changes have been merged.

This is part of a wider effort to make the naming of triggers, conditions, and actions consistent across Home Assistant. The naming review and reasoning is documented here: https://docs.google.com/document/d/18ZsosVR0OAOwkoQV1wmQ4FNSw18KV7EbPl0eNVP2uzA/edit?tab=t.0#heading=h.vwrsknoq58h0

The full sheet of proposed changes can be found here: https://docs.google.com/spreadsheets/d/1ahVHTWEZhk2-pwToI_ovHDBXIxHDmVqzRG41bwHGhMc/edit?gid=560897381#gid=560897381

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase:
  - home-assistant/core#174466 — Reword trigger descriptions for opening and closing entities
  - home-assistant/core#174467 — Reword trigger descriptions for presence and detection entities
  - home-assistant/core#174468 — Reword trigger descriptions for lights, switches, and output entities
  - home-assistant/core#174469 — Reword trigger descriptions for climate entities
  - home-assistant/core#174470 — Improve trigger and condition wording for numeric sensor entities
  - home-assistant/core#174471 — Reword trigger descriptions for air quality entities
  - home-assistant/core#174472 — Improve trigger wording for button, event, and helper entities
  - home-assistant/core#174473 — Improve trigger and condition wording for scene, select, and to-do list entities
  - home-assistant/core#174474 — Improve trigger and condition wording for media player entities
  - home-assistant/core#174475 — Reword trigger descriptions for Assist, alarm, calendar, and update entities
  - home-assistant/core#174476 — Improve zone trigger and condition wording
  - home-assistant/core#174477 — Improve trigger wording for lawn mower and vacuum entities
  - home-assistant/core#174480 — Clarify the media player play media action name
  - home-assistant/core#174463 — Rename entity trigger and condition keys for consistency (the key renames themselves are documented separately against the `next` branch)
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
