### PR TITLE
Document Sonarr calendar entity

### DIFF
--- a/source/_integrations/sonarr.markdown
+++ b/source/_integrations/sonarr.markdown
@@ -10,6 +10,7 @@ ha_config_flow: true
 ha_codeowners:
   - '@ctalkington'
 ha_platforms:
+  - calendar
   - sensor
 ha_integration_type: service
 ---
@@ -24,6 +25,10 @@ URL:
 API Key:
   description: Your Sonarr API key. To find it, open your Sonarr web interface and navigate to **Settings** > **General**. The API key is listed under the **Security** section.
 {% endconfiguration_basic %}
+
+## Calendar
+
+A {% term calendar %} entity is created that shows your upcoming episodes. Each event is titled with the series name, the season and episode number, and the episode title, such as `Bob's Burgers - S04E11 - Easy Com-mercial, Easy Go-mercial`. Events are timed using the episode's air time and the series runtime.
 
 ## Sensors
 


### PR DESCRIPTION
## Proposed change

Documents the new calendar entity added to the Sonarr integration. A calendar
entity is created that shows upcoming episodes, with events titled using the
series name, season and episode number, and episode title (for example,
`Bob's Burgers - S04E11 - Easy Com-mercial, Easy Go-mercial`). Events are timed
using the episode's air time and the series runtime.

Companion to home-assistant/core#174506.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: home-assistant/core#174506
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards