### PR TITLE
Document the new sun triggers

### DIFF
--- a/source/_integrations/sun.markdown
+++ b/source/_integrations/sun.markdown
@@ -60,6 +60,10 @@ sun:
 
 ## Automation trigger
 
+Home Assistant provides a set of dedicated sun triggers for sunrise, sunset, dawn, dusk, solar noon, solar midnight, and the sun's elevation. See the [list of triggers](#list-of-triggers) below for the full set.
+
+The classic `sun` trigger described here is still supported and is the one to use when you need a fixed time offset before or after sunrise or sunset.
+
 The sun's event listener performs the action when the sun rises or sets, with an optional offset.
 
 The sun trigger needs the trigger type `sun`, an event (`sunset` or `sunrise`), and an optional offset:
@@ -91,6 +95,8 @@ Because the duration of twilight varies throughout the year, a fixed offset is n
 | --------------- | ---------------------------------- |
 | `above_horizon` | When the sun is above the horizon. |
 | `below_horizon` | When the sun is below the horizon. |
+
+{% include integrations/triggers.md %}
 
 ## Sensors
 

--- a/source/_triggers/sun.dawn.markdown
+++ b/source/_triggers/sun.dawn.markdown
@@ -1,0 +1,109 @@
+---
+title: "Dawn"
+trigger: sun.dawn
+domain: sun
+description: "Triggers at dawn, when civil, nautical, or astronomical twilight begins."
+related_triggers:
+  - sun.dusk
+  - sun.sunrise
+  - sun.elevation_crossed_threshold
+---
+
+The **Dawn** trigger fires at dawn, the moment the morning twilight begins and the sky starts to brighten before the sun rises. You choose how dark "dawn" is with the twilight type: civil, nautical, or astronomical. Home Assistant calculates the exact time for every day from your [home location](/docs/configuration/basic/).
+
+Use it to start a gentle wake-up routine, raise blinds before the sun is up, or switch off lights that ran through the night, all timed to the first light rather than a fixed clock time.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include triggers/ui_header.md %}
+
+To use this trigger in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **When** section, select **Add trigger**.
+4. From the search box, search for and select **Sun: Dawn**.
+5. Under **Twilight type**, select **Civil**, **Nautical**, or **Astronomical** to choose how dark the start of dawn is.
+6. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Twilight type:
+  description: |
+    The phase of twilight that marks the start of dawn:
+
+    - **Civil**: the sun is 6° below the horizon. The brightest twilight, with enough light for most outdoor activities. This is the default.
+    - **Nautical**: the sun is 12° below the horizon. The horizon is still faintly visible at sea.
+    - **Astronomical**: the sun is 18° below the horizon. The sky is, for most purposes, fully dark.
+{% endoptions_ui %}
+
+{% include triggers/yaml_header.md %}
+
+In YAML, refer to this trigger as `sun.dawn`. A basic example looks like this:
+
+{% example %}
+trigger: |
+  trigger: sun.dawn
+{% endexample %}
+
+This fires at civil dawn every day. To pick a different twilight phase, add the `type` option:
+
+{% example %}
+trigger: |
+  trigger: sun.dawn
+  options:
+    type: astronomical
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+type:
+  description: >
+    The phase of twilight that marks the start of dawn. Accepts `civil` (sun 6° below the horizon), `nautical` (12° below), or `astronomical` (18° below).
+  required: false
+  type: string
+  default: civil
+{% endoptions_yaml %}
+
+## Good to know
+
+- This trigger does not use a target. It applies to the sun at your configured home location.
+- Dawn always happens before sunrise. Astronomical dawn is the earliest, then nautical, then civil, then [Sunrise](/triggers/sun.sunrise/).
+- The length of twilight changes through the year and with your latitude. Near the poles, a twilight phase can fail to occur on some days. When that happens, the trigger does not fire for that day.
+- For the matching moment in the evening, use [Dusk](/triggers/sun.dusk/).
+
+{% include triggers/try_it.md %}
+
+For this trigger, there is no target entity to change. To test it, wait for the next dawn, or temporarily switch to a trigger you can control while you build the rest of the automation.
+
+{% include triggers/more_examples.md %}
+
+### Automation: raise the bedroom blinds at dawn
+
+When civil dawn breaks, raise the bedroom blinds so the room wakes up with the morning light.
+
+- **Trigger**: Dawn
+  - **Twilight type**: Civil
+- **Action**: Open cover
+  - **Target**: Bedroom blinds
+
+{% details "YAML example for raising blinds at dawn" %}
+
+{% example %}
+automation: |
+  alias: "Raise bedroom blinds at dawn"
+  triggers:
+    - trigger: sun.dawn
+  actions:
+    - action: cover.open_cover
+      target:
+        entity_id: cover.bedroom_blinds
+{% endexample %}
+
+{% enddetails %}
+
+{% include triggers/stuck.md %}
+
+{% include triggers/related.md %}

--- a/source/_triggers/sun.dusk.markdown
+++ b/source/_triggers/sun.dusk.markdown
@@ -1,0 +1,109 @@
+---
+title: "Dusk"
+trigger: sun.dusk
+domain: sun
+description: "Triggers at dusk, when civil, nautical, or astronomical twilight ends."
+related_triggers:
+  - sun.dawn
+  - sun.sunset
+  - sun.elevation_crossed_threshold
+---
+
+The **Dusk** trigger fires at dusk, the moment the evening twilight ends and the last daylight fades after the sun has set. You choose how dark "dusk" is with the twilight type: civil, nautical, or astronomical. Home Assistant calculates the exact time for every day from your [home location](/docs/configuration/basic/).
+
+Use it to close blinds for the night, switch to evening lighting, or arm a routine once it is genuinely dark outside rather than at a fixed clock time.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include triggers/ui_header.md %}
+
+To use this trigger in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **When** section, select **Add trigger**.
+4. From the search box, search for and select **Sun: Dusk**.
+5. Under **Twilight type**, select **Civil**, **Nautical**, or **Astronomical** to choose how dark the end of dusk is.
+6. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Twilight type:
+  description: |
+    The phase of twilight that marks the end of dusk:
+
+    - **Civil**: the sun is 6° below the horizon. The brightest twilight, with enough light for most outdoor activities. This is the default.
+    - **Nautical**: the sun is 12° below the horizon. The horizon is still faintly visible at sea.
+    - **Astronomical**: the sun is 18° below the horizon. The sky is, for most purposes, fully dark.
+{% endoptions_ui %}
+
+{% include triggers/yaml_header.md %}
+
+In YAML, refer to this trigger as `sun.dusk`. A basic example looks like this:
+
+{% example %}
+trigger: |
+  trigger: sun.dusk
+{% endexample %}
+
+This fires at civil dusk every day. To pick a different twilight phase, add the `type` option:
+
+{% example %}
+trigger: |
+  trigger: sun.dusk
+  options:
+    type: astronomical
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+type:
+  description: >
+    The phase of twilight that marks the end of dusk. Accepts `civil` (sun 6° below the horizon), `nautical` (12° below), or `astronomical` (18° below).
+  required: false
+  type: string
+  default: civil
+{% endoptions_yaml %}
+
+## Good to know
+
+- This trigger does not use a target. It applies to the sun at your configured home location.
+- Dusk always happens after sunset. [Sunset](/triggers/sun.sunset/) comes first, then civil dusk, then nautical, then astronomical dusk last.
+- The length of twilight changes through the year and with your latitude. Near the poles, a twilight phase can fail to occur on some days. When that happens, the trigger does not fire for that day.
+- For the matching moment in the morning, use [Dawn](/triggers/sun.dawn/).
+
+{% include triggers/try_it.md %}
+
+For this trigger, there is no target entity to change. To test it, wait for the next dusk, or temporarily switch to a trigger you can control while you build the rest of the automation.
+
+{% include triggers/more_examples.md %}
+
+### Automation: close the blinds at dusk
+
+When civil dusk falls, close the blinds throughout the house for the evening.
+
+- **Trigger**: Dusk
+  - **Twilight type**: Civil
+- **Action**: Close cover
+  - **Target**: All blinds (label)
+
+{% details "YAML example for closing blinds at dusk" %}
+
+{% example %}
+automation: |
+  alias: "Close blinds at dusk"
+  triggers:
+    - trigger: sun.dusk
+  actions:
+    - action: cover.close_cover
+      target:
+        label_id: blinds
+{% endexample %}
+
+{% enddetails %}
+
+{% include triggers/stuck.md %}
+
+{% include triggers/related.md %}

--- a/source/_triggers/sun.elevation_changed.markdown
+++ b/source/_triggers/sun.elevation_changed.markdown
@@ -1,0 +1,137 @@
+---
+title: "Sun elevation changed"
+trigger: sun.elevation_changed
+domain: sun
+description: "Triggers whenever the sun's elevation changes, optionally limited to a threshold or range you set."
+related_triggers:
+  - sun.elevation_crossed_threshold
+  - sun.solar_noon
+  - sun.solar_midnight
+---
+
+The **Sun elevation changed** trigger fires when the sun's elevation changes. Elevation is the angle between the sun and the horizon: 0° is right at the horizon, positive values are above it, and negative values are below it. Home Assistant recalculates the elevation continuously as the sun moves through the sky.
+
+Use the threshold type to filter which changes matter. You can react to any change, or only to changes that land above an angle, below an angle, inside a range, or outside a range. This is handy for logging the sun's path or for automations that should respond while the sun stays in a particular part of the sky.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include triggers/ui_header.md %}
+
+To use this trigger in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **When** section, select **Add trigger**.
+4. From the search box, search for and select **Sun: Sun elevation changed**.
+5. Under **Threshold type**, configure which changes fire the trigger:
+   - Select **Any change** to fire on every elevation change, regardless of value.
+   - Select **Above** or **Below** and enter an angle in degrees to fire only when the new elevation is above or below that angle.
+   - Select **In range** and enter a lower and upper angle to fire only when the new elevation falls inside the range.
+   - Select **Outside range** and enter a lower and upper angle to fire only when the new elevation is outside the range.
+   - For each option except **Any change**, you can enter a fixed angle in degrees, or reference a sensor entity or a [number helper](/integrations/input_number/) entity that holds the angle.
+6. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Threshold type:
+  description: |
+    Controls which changes fire the trigger. Angles are in degrees, where 0° is the horizon, positive is above, and negative is below.
+
+    - **Any change**: fires on any elevation change, regardless of value.
+    - **Above** or **Below** (exclusive): fires only when the new elevation is strictly above or below the angle.
+    - **In range** (exclusive): fires only when the new elevation is strictly between the two angles.
+    - **Outside range** (inclusive): fires when the new elevation is at or below the lower angle, or at or above the upper angle.
+
+    For each mode except **Any change** you can enter a fixed angle in degrees, or reference a sensor entity or a [number helper](/integrations/input_number/) entity.
+{% endoptions_ui %}
+
+{% include triggers/yaml_header.md %}
+
+In YAML, refer to this trigger as `sun.elevation_changed`. A basic example looks like this:
+
+{% example %}
+trigger: |
+  trigger: sun.elevation_changed
+  options:
+    threshold:
+      type: any
+{% endexample %}
+
+This fires on every elevation change. To fire only while the new elevation is above an angle, use `type: above` with a value:
+
+{% example %}
+trigger: |
+  trigger: sun.elevation_changed
+  options:
+    threshold:
+      type: above
+      value:
+        number: 30
+{% endexample %}
+
+### Options in YAML
+
+YAML sometimes provides additional options for more complex use cases that are not available through the UI.
+
+{% options_yaml %}
+threshold:
+  description: |
+    A mapping that defines which kind of change fires the trigger. Angles are in degrees.
+
+    - `type: any`: Fires on any change (no additional keys needed).
+    - `type: above` (exclusive): Fires when the new elevation is strictly above `value`. Provide `value` with a `number` key (a fixed angle in degrees) or an `entity` key (an `input_number`, `number`, or `sensor` entity).
+    - `type: below` (exclusive): Fires when the new elevation is strictly below `value`. Provide `value` with a `number` key (a fixed angle in degrees) or an `entity` key (an `input_number`, `number`, or `sensor` entity).
+    - `type: between` (exclusive): Fires when the new elevation is strictly between `value_min` and `value_max`. Provide both, each with a `number` key (a fixed angle in degrees) or an `entity` key.
+    - `type: outside` (inclusive): Fires when the new elevation is at or below `value_min`, or at or above `value_max`. Provide both, each with a `number` key (a fixed angle in degrees) or an `entity` key.
+  required: true
+  type: map
+{% endoptions_yaml %}
+
+## Good to know
+
+- This trigger does not use a target. It always watches the sun at your configured home location.
+- Elevation updates often, so **Any change** and the threshold types fire repeatedly while the sun is moving. If you want to react only to a single crossing of an angle, use [Sun elevation crossed threshold](/triggers/sun.elevation_crossed_threshold/) instead.
+- The maximum elevation the sun reaches depends on your latitude and the time of year, so pick threshold angles that the sun actually reaches at your location.
+- To work with named twilight phases rather than raw angles, use [Dawn](/triggers/sun.dawn/) and [Dusk](/triggers/sun.dusk/).
+
+{% include triggers/try_it.md %}
+
+For this trigger, there is no target entity to change. To test it, wait for the sun to move, or temporarily set a threshold the sun is about to pass.
+
+{% include triggers/more_examples.md %}
+
+### Automation: dim the lights while the sun is high
+
+While the sun's elevation stays above 30°, keep the living room lights dimmed to save energy when there is plenty of daylight.
+
+- **Trigger**: Sun elevation changed
+  - **Threshold type**: Above (30°)
+- **Action**: Turn on light (brightness 30%)
+  - **Target**: Living room lights
+
+{% details "YAML example for dimming lights while the sun is high" %}
+
+{% example %}
+automation: |
+  alias: "Dim lights while the sun is high"
+  triggers:
+    - trigger: sun.elevation_changed
+      options:
+        threshold:
+          type: above
+          value:
+            number: 30
+  actions:
+    - action: light.turn_on
+      target:
+        entity_id: light.living_room
+      data:
+        brightness_pct: 30
+{% endexample %}
+
+{% enddetails %}
+
+{% include triggers/stuck.md %}
+
+{% include triggers/related.md %}

--- a/source/_triggers/sun.elevation_crossed_threshold.markdown
+++ b/source/_triggers/sun.elevation_crossed_threshold.markdown
@@ -1,0 +1,168 @@
+---
+title: "Sun elevation crossed threshold"
+trigger: sun.elevation_crossed_threshold
+domain: sun
+description: "Triggers when the sun's elevation crosses a threshold you set."
+related_triggers:
+  - sun.elevation_changed
+  - sun.sunrise
+  - sun.sunset
+---
+
+The **Sun elevation crossed threshold** trigger fires when the sun's elevation crosses an angle you define. Elevation is the angle between the sun and the horizon: 0° is right at the horizon, positive values are above it, and negative values are below it. The sun climbs to its highest elevation at solar noon and reaches its lowest below the horizon at solar midnight.
+
+Because elevation tracks the real position of the sun, it adapts to the seasons in a way a fixed sunset offset cannot. Use it to turn on lights as the sun gets low, close blinds against a low winter sun, or run solar-aware automations that respond to how high the sun actually is.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include triggers/ui_header.md %}
+
+To use this trigger in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **When** section, select **Add trigger**.
+4. From the search box, search for and select **Sun: Sun elevation crossed threshold**.
+5. Under **Threshold type**, configure which crossing fires the trigger:
+   - Select **Above** or **Below** and enter an angle in degrees to fire when the elevation crosses that angle.
+   - Select **In range** and enter a lower and upper angle to fire when the elevation crosses into that range.
+   - Select **Outside range** and enter a lower and upper angle to fire when the elevation crosses out of that range.
+   - For each option, you can enter a fixed angle in degrees, or reference a sensor entity or a [number helper](/integrations/input_number/) entity that holds the angle.
+6. Optionally, under **For at least**, enter how long the elevation must stay past the threshold before the trigger fires.
+7. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Threshold type:
+  description: |
+    Controls which threshold crossing fires the trigger. Angles are in degrees, where 0° is the horizon, positive is above, and negative is below.
+
+    - **Above** (exclusive): fires when the elevation crosses to strictly above the angle.
+    - **Below** (exclusive): fires when the elevation crosses to strictly below the angle.
+    - **In range** (exclusive): fires when the elevation crosses into the range.
+    - **Outside range** (inclusive): fires when the elevation crosses out of the range.
+
+    For each mode you can enter a fixed angle in degrees, or reference a sensor entity or a [number helper](/integrations/input_number/) entity.
+For at least:
+  description: How long the elevation must stay past the threshold before the trigger fires. Useful to avoid firing on brief fluctuations. For example, set it to `0:05:00` to fire only after the elevation has stayed past the threshold for 5 minutes. Default is `0` (fires immediately).
+{% endoptions_ui %}
+
+{% include triggers/yaml_header.md %}
+
+In YAML, refer to this trigger as `sun.elevation_crossed_threshold`. A basic example looks like this:
+
+{% example %}
+trigger: |
+  trigger: sun.elevation_crossed_threshold
+  options:
+    threshold:
+      type: below
+      value:
+        number: 4
+{% endexample %}
+
+This fires when the sun drops below 4° of elevation, a common stand-in for "it's getting dark." To fire when the sun climbs above an angle instead, use `type: above`.
+
+### Options in YAML
+
+YAML sometimes provides additional options for more complex use cases that are not available through the UI.
+
+{% options_yaml %}
+threshold:
+  description: |
+    A mapping that defines the elevation crossing that fires the trigger. Angles are in degrees.
+
+    - `type: above` (exclusive): Fires when the elevation crosses to strictly above `value`. Provide `value` with a `number` key (a fixed angle in degrees) or an `entity` key (an `input_number`, `number`, or `sensor` entity).
+    - `type: below` (exclusive): Fires when the elevation crosses to strictly below `value`. Provide `value` with a `number` key (a fixed angle in degrees) or an `entity` key (an `input_number`, `number`, or `sensor` entity).
+    - `type: between` (exclusive): Fires when the elevation crosses into the range. Provide `value_min` and `value_max`, each with a `number` key (a fixed angle in degrees) or an `entity` key.
+    - `type: outside` (inclusive): Fires when the elevation crosses out of the range. Provide `value_min` and `value_max`, each with a `number` key (a fixed angle in degrees) or an `entity` key.
+  required: true
+  type: map
+for:
+  description: >
+    How long the elevation must stay past the threshold before the trigger fires. Accepts a duration string in `HH:MM:SS` format. For example, `00:05:00` fires only after the elevation has stayed past the threshold for 5 minutes.
+  required: false
+  type: string
+  default: "00:00:00"
+{% endoptions_yaml %}
+
+## Good to know
+
+- This trigger does not use a target. It always watches the sun at your configured home location.
+- The trigger fires only on the crossing moment. Once the elevation is above your threshold, it does not fire again until the elevation drops back below it and then crosses up again.
+- A threshold around 0° corresponds roughly to sunrise and sunset. Negative angles like -6° correspond to civil twilight. Use [Dawn](/triggers/sun.dawn/) and [Dusk](/triggers/sun.dusk/) if you prefer to work with named twilight phases instead of raw angles.
+- The maximum elevation the sun reaches depends on your latitude and the time of year, so pick threshold angles that the sun actually reaches at your location.
+- To react to every elevation change rather than a single crossing, use [Sun elevation changed](/triggers/sun.elevation_changed/).
+
+{% include triggers/try_it.md %}
+
+For this trigger, there is no target entity to change. To test it, wait for the sun to cross your threshold, or temporarily set the threshold to an angle the sun is about to pass.
+
+{% include triggers/more_examples.md %}
+
+### Automation: turn on lights when the sun gets low
+
+When the sun drops below 4° of elevation, turn on the living room lights. This tracks the real position of the sun, so it stays sensible through every season.
+
+- **Trigger**: Sun elevation crossed threshold
+  - **Threshold type**: Below (4°)
+- **Action**: Turn on light
+  - **Target**: Living room lights
+
+{% details "YAML example for turning on lights when the sun is low" %}
+
+{% example %}
+automation: |
+  alias: "Lights on when the sun is low"
+  triggers:
+    - trigger: sun.elevation_crossed_threshold
+      options:
+        threshold:
+          type: below
+          value:
+            number: 4
+  actions:
+    - action: light.turn_on
+      target:
+        entity_id: light.living_room
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: close blinds against a low winter sun
+
+When the sun sits low in the sky, between 0° and 15° of elevation, close the west-facing blinds to keep the low glare out. The **For at least** delay avoids reacting to brief readings.
+
+- **Trigger**: Sun elevation crossed threshold
+  - **Threshold type**: In range (0-15°)
+  - **For at least**: 2 minutes
+- **Action**: Close cover
+  - **Target**: West-facing blinds
+
+{% details "YAML example for blinds against a low sun" %}
+
+{% example %}
+automation: |
+  alias: "Close blinds against low sun"
+  triggers:
+    - trigger: sun.elevation_crossed_threshold
+      options:
+        threshold:
+          type: between
+          value_min:
+            number: 0
+          value_max:
+            number: 15
+        for: "00:02:00"
+  actions:
+    - action: cover.close_cover
+      target:
+        entity_id: cover.west_blinds
+{% endexample %}
+
+{% enddetails %}
+
+{% include triggers/stuck.md %}
+
+{% include triggers/related.md %}

--- a/source/_triggers/sun.solar_midnight.markdown
+++ b/source/_triggers/sun.solar_midnight.markdown
@@ -1,0 +1,76 @@
+---
+title: "Solar midnight"
+trigger: sun.solar_midnight
+domain: sun
+description: "Triggers when the sun reaches its lowest point."
+related_triggers:
+  - sun.solar_noon
+  - sun.sunset
+  - sun.elevation_changed
+---
+
+The **Solar midnight** trigger fires when the sun reaches its lowest point below the horizon for the day. This is the astronomical midpoint between sunset and sunrise, and it rarely lands exactly at 00:00 on the clock. Home Assistant calculates the exact time from your [home location](/docs/configuration/basic/).
+
+Use it as a reliable "deep night" marker: run a nightly maintenance task, reset daily counters, or make sure everything is switched off at the darkest point of the night.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include triggers/ui_header.md %}
+
+To use this trigger in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **When** section, select **Add trigger**.
+4. From the search box, search for and select **Sun: Solar midnight**.
+5. Select **Save**.
+
+{% include triggers/yaml_header.md %}
+
+In YAML, refer to this trigger as `sun.solar_midnight`. It has no options:
+
+{% example %}
+trigger: |
+  trigger: sun.solar_midnight
+{% endexample %}
+
+This fires every day, the moment the sun reaches its lowest point.
+
+## Good to know
+
+- This trigger does not use a target. It applies to the sun at your configured home location.
+- Solar midnight is the moment the sun is opposite the meridian, not 00:00 on the clock. The clock time drifts through the year and depends on your longitude within your time zone.
+- To act on the opposite moment, when the sun is at its highest, use [Solar noon](/triggers/sun.solar_noon/).
+
+{% include triggers/try_it.md %}
+
+For this trigger, there is no target entity to change. To test it, wait for the next solar midnight, or temporarily switch to a trigger you can control while you build the rest of the automation.
+
+{% include triggers/more_examples.md %}
+
+### Automation: reset a daily counter at solar midnight
+
+At the darkest point of the night, reset a counter so it starts fresh for the new day.
+
+- **Trigger**: Solar midnight
+- **Action**: Reset counter
+  - **Target**: Daily counter
+
+{% details "YAML example for resetting a counter at solar midnight" %}
+
+{% example %}
+automation: |
+  alias: "Reset daily counter at solar midnight"
+  triggers:
+    - trigger: sun.solar_midnight
+  actions:
+    - action: counter.reset
+      target:
+        entity_id: counter.daily_runs
+{% endexample %}
+
+{% enddetails %}
+
+{% include triggers/stuck.md %}
+
+{% include triggers/related.md %}

--- a/source/_triggers/sun.solar_noon.markdown
+++ b/source/_triggers/sun.solar_noon.markdown
@@ -1,0 +1,76 @@
+---
+title: "Solar noon"
+trigger: sun.solar_noon
+domain: sun
+description: "Triggers when the sun reaches its highest point."
+related_triggers:
+  - sun.solar_midnight
+  - sun.sunrise
+  - sun.elevation_changed
+---
+
+The **Solar noon** trigger fires when the sun reaches its highest point in the sky for the day. This is the astronomical midpoint between sunrise and sunset, and it rarely lands exactly at 12:00 on the clock. Home Assistant calculates the exact time from your [home location](/docs/configuration/basic/).
+
+Use it to act when the sun is at its strongest: close blinds against the midday glare, run the most demanding loads while solar production peaks, or check in on a south-facing room.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include triggers/ui_header.md %}
+
+To use this trigger in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **When** section, select **Add trigger**.
+4. From the search box, search for and select **Sun: Solar noon**.
+5. Select **Save**.
+
+{% include triggers/yaml_header.md %}
+
+In YAML, refer to this trigger as `sun.solar_noon`. It has no options:
+
+{% example %}
+trigger: |
+  trigger: sun.solar_noon
+{% endexample %}
+
+This fires every day, the moment the sun reaches its highest point.
+
+## Good to know
+
+- This trigger does not use a target. It applies to the sun at your configured home location.
+- Solar noon is the moment the sun crosses the meridian, not 12:00 on the clock. The clock time drifts through the year and depends on your longitude within your time zone.
+- To act on the opposite moment, when the sun is at its lowest, use [Solar midnight](/triggers/sun.solar_midnight/).
+
+{% include triggers/try_it.md %}
+
+For this trigger, there is no target entity to change. To test it, wait for the next solar noon, or temporarily switch to a trigger you can control while you build the rest of the automation.
+
+{% include triggers/more_examples.md %}
+
+### Automation: close the blinds against the midday sun
+
+When the sun reaches its highest point, close the south-facing blinds to keep the room cool.
+
+- **Trigger**: Solar noon
+- **Action**: Close cover
+  - **Target**: Living room blinds
+
+{% details "YAML example for closing blinds at solar noon" %}
+
+{% example %}
+automation: |
+  alias: "Close blinds at solar noon"
+  triggers:
+    - trigger: sun.solar_noon
+  actions:
+    - action: cover.close_cover
+      target:
+        entity_id: cover.living_room_blinds
+{% endexample %}
+
+{% enddetails %}
+
+{% include triggers/stuck.md %}
+
+{% include triggers/related.md %}

--- a/source/_triggers/sun.sunrise.markdown
+++ b/source/_triggers/sun.sunrise.markdown
@@ -1,0 +1,76 @@
+---
+title: "Sunrise"
+trigger: sun.sunrise
+domain: sun
+description: "Triggers when the sun rises."
+related_triggers:
+  - sun.sunset
+  - sun.dawn
+  - sun.elevation_crossed_threshold
+---
+
+The **Sunrise** trigger fires the moment the sun rises above the horizon at your location. Home Assistant calculates the exact time for every day of the year from your [home location](/docs/configuration/basic/), so the trigger stays accurate as sunrise shifts through the seasons.
+
+Use it to open blinds, turn off outdoor or night lighting, or start your morning routine the moment the day begins.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include triggers/ui_header.md %}
+
+To use this trigger in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **When** section, select **Add trigger**.
+4. From the search box, search for and select **Sun: Sunrise**.
+5. Select **Save**.
+
+{% include triggers/yaml_header.md %}
+
+In YAML, refer to this trigger as `sun.sunrise`. It has no options:
+
+{% example %}
+trigger: |
+  trigger: sun.sunrise
+{% endexample %}
+
+This fires every day, the moment the sun rises above the horizon.
+
+## Good to know
+
+- This trigger does not use a target. It applies to the sun at your configured home location.
+- The trigger fires exactly at sunrise. To fire a fixed amount of time before or after sunrise, use the classic [sun trigger](/integrations/sun/#automation-trigger), which accepts an offset. For light-based timing that adapts to the seasons, use [Sun elevation crossed threshold](/triggers/sun.elevation_crossed_threshold/) instead.
+- To react to the first light before sunrise, use [Dawn](/triggers/sun.dawn/). To react when the sun goes down, use [Sunset](/triggers/sun.sunset/).
+
+{% include triggers/try_it.md %}
+
+For this trigger, there is no target entity to change. To test it, wait for the next sunrise, or temporarily switch to a trigger you can control while you build the rest of the automation.
+
+{% include triggers/more_examples.md %}
+
+### Automation: open the living room blinds at sunrise
+
+When the sun rises, open the living room blinds so the room fills with daylight.
+
+- **Trigger**: Sunrise
+- **Action**: Open cover
+  - **Target**: Living room blinds
+
+{% details "YAML example for opening blinds at sunrise" %}
+
+{% example %}
+automation: |
+  alias: "Open living room blinds at sunrise"
+  triggers:
+    - trigger: sun.sunrise
+  actions:
+    - action: cover.open_cover
+      target:
+        entity_id: cover.living_room_blinds
+{% endexample %}
+
+{% enddetails %}
+
+{% include triggers/stuck.md %}
+
+{% include triggers/related.md %}

--- a/source/_triggers/sun.sunset.markdown
+++ b/source/_triggers/sun.sunset.markdown
@@ -1,0 +1,76 @@
+---
+title: "Sunset"
+trigger: sun.sunset
+domain: sun
+description: "Triggers when the sun sets."
+related_triggers:
+  - sun.sunrise
+  - sun.dusk
+  - sun.elevation_crossed_threshold
+---
+
+The **Sunset** trigger fires the moment the sun sets below the horizon at your location. Home Assistant calculates the exact time for every day of the year from your [home location](/docs/configuration/basic/), so the trigger stays accurate as sunset shifts through the seasons.
+
+Use it to turn on lights, close blinds, or arm an evening routine the moment the day ends.
+
+{% include integrations/labs_entity_triggers_note.md %}
+
+{% include triggers/ui_header.md %}
+
+To use this trigger in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **When** section, select **Add trigger**.
+4. From the search box, search for and select **Sun: Sunset**.
+5. Select **Save**.
+
+{% include triggers/yaml_header.md %}
+
+In YAML, refer to this trigger as `sun.sunset`. It has no options:
+
+{% example %}
+trigger: |
+  trigger: sun.sunset
+{% endexample %}
+
+This fires every day, the moment the sun sets below the horizon.
+
+## Good to know
+
+- This trigger does not use a target. It applies to the sun at your configured home location.
+- The trigger fires exactly at sunset. To fire a fixed amount of time before or after sunset, use the classic [sun trigger](/integrations/sun/#automation-trigger), which accepts an offset. For light-based timing that adapts to the seasons, use [Sun elevation crossed threshold](/triggers/sun.elevation_crossed_threshold/) instead.
+- To react to the last light after sunset, use [Dusk](/triggers/sun.dusk/). To react when the sun comes up, use [Sunrise](/triggers/sun.sunrise/).
+
+{% include triggers/try_it.md %}
+
+For this trigger, there is no target entity to change. To test it, wait for the next sunset, or temporarily switch to a trigger you can control while you build the rest of the automation.
+
+{% include triggers/more_examples.md %}
+
+### Automation: turn on the porch light at sunset
+
+When the sun sets, turn on the porch light so the entrance stays lit through the evening.
+
+- **Trigger**: Sunset
+- **Action**: Turn on light
+  - **Target**: Porch light
+
+{% details "YAML example for turning on a light at sunset" %}
+
+{% example %}
+automation: |
+  alias: "Turn on porch light at sunset"
+  triggers:
+    - trigger: sun.sunset
+  actions:
+    - action: light.turn_on
+      target:
+        entity_id: light.porch
+{% endexample %}
+
+{% enddetails %}
+
+{% include triggers/stuck.md %}
+
+{% include triggers/related.md %}


### PR DESCRIPTION
## Proposed change

Documents the new sun triggers added in [home-assistant/core#174485](https://github.com/home-assistant/core/pull/174485): sunrise, sunset, solar noon, solar midnight, dawn, dusk, sun elevation changed, and sun elevation crossed threshold.

Each trigger gets a dedicated page following the modern trigger format. The Sun integration page now surfaces them through the list of triggers include, and keeps the classic `sun` trigger documented for the offset use case.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/174485
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
