### PR TITLE
Document SwitchBot Cloud webhook reachability and cloudhook for push devices

### DIFF
--- a/source/_integrations/switchbot_cloud.markdown
+++ b/source/_integrations/switchbot_cloud.markdown
@@ -520,7 +520,12 @@ For IR Appliances, the state is inferred from previous commands in Home Assistan
 
 ## Webhook support
 
-For vacuums, the states are updated from SwitchBot's cloud.
+SwitchBot's cloud pushes state updates to Home Assistant through a webhook. This is how vacuums, along with the water leak, contact, motion, and presence sensors, receive their state updates. For SwitchBot's cloud to deliver this webhook, your Home Assistant instance must be reachable from the internet, which requires one of the following:
+
+- A publicly reachable [`external_url`](/integrations/homeassistant/), or
+- A [Home Assistant Cloud](/integrations/cloud/) subscription, in which case the webhook is delivered automatically through a cloudhook.
+
+On a local-only installation with neither of these, SwitchBot's cloud cannot deliver the webhook, and these devices do not receive updates.
 
 {% warning %}
 Only ONE webhook URL seems to be accepted by the SwitchBot's cloud. So, if you want several applications notified,  you need to use a “proxy” to re-dispatch the message to the other applications.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!--
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the
    additional information section.
-->

The `switchbot_cloud` push devices (water leak, contact, motion, and presence sensors) receive their state through a webhook that SwitchBot's cloud pushes to Home Assistant. That requires the Home Assistant instance to be reachable from the internet, but the integration page never documented this — it only covered polling and the single-webhook limitation. As a result, users on a local-only installation have no explanation for why these sensors never update.

This adds a note to the **Webhook support** section explaining that real-time updates for these devices require either a publicly reachable `external_url` or a Home Assistant Cloud subscription (delivered automatically through a cloudhook), and that a local-only install with neither will not receive updates.

Companion to the core PR adding Home Assistant Cloud cloudhook support to the `switchbot_cloud` webhook, which makes the cloudhook path work for local-only installs.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/174566
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
