### PR TITLE
Fix broken next build from dangling Labs note include in sun triggers

### DIFF
--- a/source/_triggers/sun.dawn.markdown
+++ b/source/_triggers/sun.dawn.markdown
@@ -13,8 +13,6 @@ The **Dawn** trigger fires at dawn, the moment the morning twilight begins and t
 
 Use it to start a gentle wake-up routine, raise blinds before the sun is up, or switch off lights that ran through the night, all timed to the first light rather than a fixed clock time.
 
-{% include integrations/labs_entity_triggers_note.md %}
-
 {% include triggers/ui_header.md %}
 
 To use this trigger in an automation:

--- a/source/_triggers/sun.dusk.markdown
+++ b/source/_triggers/sun.dusk.markdown
@@ -13,8 +13,6 @@ The **Dusk** trigger fires at dusk, the moment the evening twilight ends and the
 
 Use it to close blinds for the night, switch to evening lighting, or arm a routine once it is genuinely dark outside rather than at a fixed clock time.
 
-{% include integrations/labs_entity_triggers_note.md %}
-
 {% include triggers/ui_header.md %}
 
 To use this trigger in an automation:

--- a/source/_triggers/sun.elevation_changed.markdown
+++ b/source/_triggers/sun.elevation_changed.markdown
@@ -13,8 +13,6 @@ The **Sun elevation changed** trigger fires when the sun's elevation changes. El
 
 Use the threshold type to filter which changes matter. You can react to any change, or only to changes that land above an angle, below an angle, inside a range, or outside a range. This is handy for logging the sun's path or for automations that should respond while the sun stays in a particular part of the sky.
 
-{% include integrations/labs_entity_triggers_note.md %}
-
 {% include triggers/ui_header.md %}
 
 To use this trigger in an automation:

--- a/source/_triggers/sun.elevation_crossed_threshold.markdown
+++ b/source/_triggers/sun.elevation_crossed_threshold.markdown
@@ -13,8 +13,6 @@ The **Sun elevation crossed threshold** trigger fires when the sun's elevation c
 
 Because elevation tracks the real position of the sun, it adapts to the seasons in a way a fixed sunset offset cannot. Use it to turn on lights as the sun gets low, close blinds against a low winter sun, or run solar-aware automations that respond to how high the sun actually is.
 
-{% include integrations/labs_entity_triggers_note.md %}
-
 {% include triggers/ui_header.md %}
 
 To use this trigger in an automation:

--- a/source/_triggers/sun.solar_midnight.markdown
+++ b/source/_triggers/sun.solar_midnight.markdown
@@ -13,8 +13,6 @@ The **Solar midnight** trigger fires when the sun reaches its lowest point below
 
 Use it as a reliable "deep night" marker: run a nightly maintenance task, reset daily counters, or make sure everything is switched off at the darkest point of the night.
 
-{% include integrations/labs_entity_triggers_note.md %}
-
 {% include triggers/ui_header.md %}
 
 To use this trigger in an automation:

--- a/source/_triggers/sun.solar_noon.markdown
+++ b/source/_triggers/sun.solar_noon.markdown
@@ -13,8 +13,6 @@ The **Solar noon** trigger fires when the sun reaches its highest point in the s
 
 Use it to act when the sun is at its strongest: close blinds against the midday glare, run the most demanding loads while solar production peaks, or check in on a south-facing room.
 
-{% include integrations/labs_entity_triggers_note.md %}
-
 {% include triggers/ui_header.md %}
 
 To use this trigger in an automation:

--- a/source/_triggers/sun.sunrise.markdown
+++ b/source/_triggers/sun.sunrise.markdown
@@ -13,8 +13,6 @@ The **Sunrise** trigger fires the moment the sun rises above the horizon at your
 
 Use it to open blinds, turn off outdoor or night lighting, or start your morning routine the moment the day begins.
 
-{% include integrations/labs_entity_triggers_note.md %}
-
 {% include triggers/ui_header.md %}
 
 To use this trigger in an automation:

--- a/source/_triggers/sun.sunset.markdown
+++ b/source/_triggers/sun.sunset.markdown
@@ -13,8 +13,6 @@ The **Sunset** trigger fires the moment the sun sets below the horizon at your l
 
 Use it to turn on lights, close blinds, or arm an evening routine the moment the day ends.
 
-{% include integrations/labs_entity_triggers_note.md %}
-
 {% include triggers/ui_header.md %}
 
 To use this trigger in an automation:


### PR DESCRIPTION
## Proposed change

Fixes the broken `next` build. The Jekyll build fails with:

`Could not locate the included file 'integrations/labs_entity_triggers_note.md'`

That include was removed in #46413 ("Delete triggers & conditions Labs note"), but the sun trigger pages added in #46419 still referenced it, leaving eight dangling includes that break the build. This removes those references from the sun trigger pages, matching the decision in #46413.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to: #46413, #46419

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
