### PR TITLE
Document the new sun conditions

### DIFF
--- a/source/_conditions/sun.elevation.markdown
+++ b/source/_conditions/sun.elevation.markdown
@@ -91,7 +91,8 @@ When the patio is occupied, close the west-facing blinds, but only while the sun
 
 - **Trigger**: Patio occupancy detected
 - **Condition**: Sun: Sun elevation (below 15°)
-- **Action**: Close cover (west-facing blinds)
+- **Action**: Close cover
+  - **Target**: West-facing blinds
 
 {% details "YAML example for glare-based blinds" %}
 

--- a/source/_conditions/sun.elevation.markdown
+++ b/source/_conditions/sun.elevation.markdown
@@ -1,0 +1,122 @@
+---
+title: "Sun elevation"
+condition: sun.elevation
+domain: sun
+description: "Tests the sun's elevation against a threshold you set."
+related_conditions:
+  - sun.is_up
+  - sun.is_set
+  - sun.is_night
+---
+
+The **Sun elevation** condition passes when the sun's elevation meets a threshold you set. Elevation is the angle between the sun and the horizon: 0° is right at the horizon, positive values are above it, and negative values are below it. Home Assistant works this out from your [home location](/docs/configuration/basic/).
+
+Because elevation tracks the real position of the sun, it adapts to the seasons in a way a fixed clock time cannot. Use it to gate an automation on how high or low the sun actually is, like only closing the blinds while the sun sits low enough to cause glare.
+
+{% include conditions/ui_header.md %}
+
+To use this condition in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **And if** section, select **Add condition**.
+4. From the search box, search for and select **Sun: Sun elevation**.
+5. Under **Threshold type**, choose how the elevation is compared:
+   - Select **Above** or **Below** and enter an angle in degrees.
+   - Select **In range** and enter a lower and upper angle.
+   - Select **Outside range** and enter a lower and upper angle.
+   - For each option, you can enter a fixed angle in degrees, or reference a sensor entity or a [number helper](/integrations/input_number/) entity that holds the angle.
+6. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Threshold type:
+  description: |
+    How the sun's elevation is compared. Angles are in degrees, where 0° is the horizon, positive is above, and negative is below.
+
+    - **Above** (exclusive): passes when the elevation is strictly above the angle.
+    - **Below** (exclusive): passes when the elevation is strictly below the angle.
+    - **In range** (exclusive): passes when the elevation is strictly between the two angles.
+    - **Outside range** (inclusive): passes when the elevation is at or beyond either angle.
+
+    For each mode you can enter a fixed angle in degrees, or reference a sensor entity or a [number helper](/integrations/input_number/) entity.
+{% endoptions_ui %}
+
+{% include conditions/yaml_header.md %}
+
+In YAML, refer to this condition as `sun.elevation`. A basic example looks like this:
+
+{% example %}
+condition: |
+  condition: sun.elevation
+  options:
+    threshold:
+      type: below
+      value:
+        number: 4
+{% endexample %}
+
+This passes while the sun is below 4° of elevation, a common stand-in for "it is getting dark."
+
+### Options in YAML
+
+{% options_yaml %}
+threshold:
+  description: |
+    How the sun's elevation is compared. Angles are in degrees.
+
+    - `type: above` (exclusive): Passes when the elevation is strictly above `value`. Provide `value` with a `number` key (a fixed angle in degrees) or an `entity` key (an `input_number`, `number`, or `sensor` entity).
+    - `type: below` (exclusive): Passes when the elevation is strictly below `value`. Provide `value` with a `number` key (a fixed angle in degrees) or an `entity` key (an `input_number`, `number`, or `sensor` entity).
+    - `type: between` (exclusive): Passes when the elevation is strictly between `value_min` and `value_max`. Provide both, each with a `number` key (a fixed angle in degrees) or an `entity` key.
+    - `type: outside` (inclusive): Passes when the elevation is at or beyond `value_min` or `value_max`. Provide both, each with a `number` key (a fixed angle in degrees) or an `entity` key.
+  required: true
+  type: map
+{% endoptions_yaml %}
+
+## Good to know
+
+- This condition does not use a target. It always checks the sun at your configured home location.
+- A threshold around 0° corresponds roughly to sunrise and sunset. For those, [Sun is up](/conditions/sun.is_up/) and [Sun is set](/conditions/sun.is_set/) are simpler. Reach for **Sun elevation** when you need a specific angle.
+- The maximum elevation the sun reaches depends on your latitude and the time of year, so pick angles the sun actually reaches at your location.
+- When you use an entity as the threshold, its value is read at the moment the condition runs. It is not tracked continuously; it is re-evaluated each time the automation fires.
+
+{% include conditions/try_it.md %}
+
+{% include conditions/more_examples.md %}
+
+### Automation: close blinds only while the sun is low
+
+When the patio is occupied, close the west-facing blinds, but only while the sun sits low in the sky (below 15° of elevation), where it causes the most glare.
+
+- **Trigger**: Patio occupancy detected
+- **Condition**: Sun elevation (below 15°)
+- **Action**: Close the west-facing blinds
+
+{% details "YAML example for glare-based blinds" %}
+
+{% example %}
+automation: |
+  alias: "Close blinds against low sun"
+  triggers:
+    - trigger: state
+      entity_id: binary_sensor.patio_occupancy
+      to: "on"
+  conditions:
+    - condition: sun.elevation
+      options:
+        threshold:
+          type: below
+          value:
+            number: 15
+  actions:
+    - action: cover.close_cover
+      target:
+        entity_id: cover.west_blinds
+{% endexample %}
+
+{% enddetails %}
+
+{% include conditions/stuck.md %}
+
+{% include conditions/related.md %}

--- a/source/_conditions/sun.elevation.markdown
+++ b/source/_conditions/sun.elevation.markdown
@@ -79,7 +79,7 @@ threshold:
 - This condition does not use a target. It always checks the sun at your configured home location.
 - A threshold around 0° corresponds roughly to sunrise and sunset. For those, [Sun is up](/conditions/sun.is_up/) and [Sun is set](/conditions/sun.is_set/) are simpler. Reach for **Sun elevation** when you need a specific angle.
 - The maximum elevation the sun reaches depends on your latitude and the time of year, so pick angles the sun actually reaches at your location.
-- When you use an entity as the threshold, its value is read at the moment the condition runs. It is not tracked continuously; it is re-evaluated each time the automation fires.
+- When you use an entity as the threshold, its value is read at the moment the condition runs. It is not tracked continuously. Instead, the entity value is re-evaluated each time the automation fires.
 
 {% include conditions/try_it.md %}
 
@@ -90,8 +90,8 @@ threshold:
 When the patio is occupied, close the west-facing blinds, but only while the sun sits low in the sky (below 15° of elevation), where it causes the most glare.
 
 - **Trigger**: Patio occupancy detected
-- **Condition**: Sun elevation (below 15°)
-- **Action**: Close the west-facing blinds
+- **Condition**: Sun: Sun elevation (below 15°)
+- **Action**: Close cover (west-facing blinds)
 
 {% details "YAML example for glare-based blinds" %}
 

--- a/source/_conditions/sun.is_ascending.markdown
+++ b/source/_conditions/sun.is_ascending.markdown
@@ -9,7 +9,7 @@ related_conditions:
   - sun.is_morning_twilight
 ---
 
-The **Sun is ascending** condition passes while the sun is climbing, the half of the day between solar midnight and solar noon when the sun's elevation is increasing. Home Assistant works this out from your [home location](/docs/configuration/basic/).
+The **Sun is ascending** condition passes while the sun is climbing. This happens during the half of the day between solar midnight and solar noon when the sun's elevation is increasing. Home Assistant works this out from your [home location](/docs/configuration/basic/).
 
 Use it to tell morning apart from afternoon without picking a clock time. For example, run a routine only while the sun is on its way up, regardless of the season.
 
@@ -49,8 +49,9 @@ This passes while the sun is rising toward solar noon.
 When the living room brightens past a threshold, raise the blinds, but only while the sun is still climbing, so an equally bright evening does not trigger it.
 
 - **Trigger**: Living room illuminance rises above a threshold
-- **Condition**: Sun is ascending
-- **Action**: Open the living room blinds
+- **Condition**: Sun: Sun is ascending
+- **Action**: Open cover
+  - **Target**: Living room blinds
 
 {% details "YAML example for morning-only blinds" %}
 

--- a/source/_conditions/sun.is_ascending.markdown
+++ b/source/_conditions/sun.is_ascending.markdown
@@ -1,0 +1,76 @@
+---
+title: "Sun is ascending"
+condition: sun.is_ascending
+domain: sun
+description: "Tests if the sun is ascending."
+related_conditions:
+  - sun.is_descending
+  - sun.is_up
+  - sun.is_morning_twilight
+---
+
+The **Sun is ascending** condition passes while the sun is climbing, the half of the day between solar midnight and solar noon when the sun's elevation is increasing. Home Assistant works this out from your [home location](/docs/configuration/basic/).
+
+Use it to tell morning apart from afternoon without picking a clock time. For example, run a routine only while the sun is on its way up, regardless of the season.
+
+{% include conditions/ui_header.md %}
+
+To use this condition in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **And if** section, select **Add condition**.
+4. From the search box, search for and select **Sun: Sun is ascending**.
+5. Select **Save**.
+
+{% include conditions/yaml_header.md %}
+
+In YAML, refer to this condition as `sun.is_ascending`. It has no options:
+
+{% example %}
+condition: |
+  condition: sun.is_ascending
+{% endexample %}
+
+This passes while the sun is rising toward solar noon.
+
+## Good to know
+
+- This condition does not use a target. It checks the sun at your configured home location.
+- Ascending covers the whole rising half of the day, from solar midnight up to solar noon, including the hours before sunrise. It is not limited to daylight. Combine it with [Sun is up](/conditions/sun.is_up/) if you only want the rising daytime hours.
+- For the opposite half of the day, use [Sun is descending](/conditions/sun.is_descending/).
+
+{% include conditions/try_it.md %}
+
+{% include conditions/more_examples.md %}
+
+### Automation: morning blinds only while the sun is rising
+
+When the living room brightens past a threshold, raise the blinds, but only while the sun is still climbing, so an equally bright evening does not trigger it.
+
+- **Trigger**: Living room illuminance rises above a threshold
+- **Condition**: Sun is ascending
+- **Action**: Open the living room blinds
+
+{% details "YAML example for morning-only blinds" %}
+
+{% example %}
+automation: |
+  alias: "Raise blinds on a bright morning"
+  triggers:
+    - trigger: numeric_state
+      entity_id: sensor.living_room_illuminance
+      above: 5000
+  conditions:
+    - condition: sun.is_ascending
+  actions:
+    - action: cover.open_cover
+      target:
+        entity_id: cover.living_room_blinds
+{% endexample %}
+
+{% enddetails %}
+
+{% include conditions/stuck.md %}
+
+{% include conditions/related.md %}

--- a/source/_conditions/sun.is_descending.markdown
+++ b/source/_conditions/sun.is_descending.markdown
@@ -9,7 +9,7 @@ related_conditions:
   - sun.is_evening_twilight
 ---
 
-The **Sun is descending** condition passes while the sun is sinking, the half of the day between solar noon and solar midnight when the sun's elevation is decreasing. Home Assistant works this out from your [home location](/docs/configuration/basic/).
+The **Sun is descending** condition passes while the sun is sinking. This happens during the half of the day between solar noon and solar midnight when the sun's elevation is decreasing. Home Assistant works this out from your [home location](/docs/configuration/basic/).
 
 Use it to tell afternoon and evening apart from the morning without picking a clock time. For example, run a routine only while the sun is on its way down, regardless of the season.
 
@@ -49,8 +49,9 @@ This passes while the sun is sinking toward solar midnight.
 When the patio gets hot, lower the awning, but only while the sun is descending, so it reacts to the afternoon sun rather than a warm morning.
 
 - **Trigger**: Patio temperature rises above a threshold
-- **Condition**: Sun is descending
-- **Action**: Close the patio awning
+- **Condition**: Sun: Sun is descending
+- **Action**: Close cover
+  - **Target**: Patio awning
 
 {% details "YAML example for afternoon-only awning" %}
 

--- a/source/_conditions/sun.is_descending.markdown
+++ b/source/_conditions/sun.is_descending.markdown
@@ -1,0 +1,76 @@
+---
+title: "Sun is descending"
+condition: sun.is_descending
+domain: sun
+description: "Tests if the sun is descending."
+related_conditions:
+  - sun.is_ascending
+  - sun.is_set
+  - sun.is_evening_twilight
+---
+
+The **Sun is descending** condition passes while the sun is sinking, the half of the day between solar noon and solar midnight when the sun's elevation is decreasing. Home Assistant works this out from your [home location](/docs/configuration/basic/).
+
+Use it to tell afternoon and evening apart from the morning without picking a clock time. For example, run a routine only while the sun is on its way down, regardless of the season.
+
+{% include conditions/ui_header.md %}
+
+To use this condition in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **And if** section, select **Add condition**.
+4. From the search box, search for and select **Sun: Sun is descending**.
+5. Select **Save**.
+
+{% include conditions/yaml_header.md %}
+
+In YAML, refer to this condition as `sun.is_descending`. It has no options:
+
+{% example %}
+condition: |
+  condition: sun.is_descending
+{% endexample %}
+
+This passes while the sun is sinking toward solar midnight.
+
+## Good to know
+
+- This condition does not use a target. It checks the sun at your configured home location.
+- Descending covers the whole sinking half of the day, from solar noon down to solar midnight, including the hours after sunset. It is not limited to daylight. Combine it with [Sun is up](/conditions/sun.is_up/) if you only want the descending daytime hours.
+- For the opposite half of the day, use [Sun is ascending](/conditions/sun.is_ascending/).
+
+{% include conditions/try_it.md %}
+
+{% include conditions/more_examples.md %}
+
+### Automation: lower the awning only in the afternoon
+
+When the patio gets hot, lower the awning, but only while the sun is descending, so it reacts to the afternoon sun rather than a warm morning.
+
+- **Trigger**: Patio temperature rises above a threshold
+- **Condition**: Sun is descending
+- **Action**: Close the patio awning
+
+{% details "YAML example for afternoon-only awning" %}
+
+{% example %}
+automation: |
+  alias: "Lower awning on a hot afternoon"
+  triggers:
+    - trigger: numeric_state
+      entity_id: sensor.patio_temperature
+      above: 28
+  conditions:
+    - condition: sun.is_descending
+  actions:
+    - action: cover.close_cover
+      target:
+        entity_id: cover.patio_awning
+{% endexample %}
+
+{% enddetails %}
+
+{% include conditions/stuck.md %}
+
+{% include conditions/related.md %}

--- a/source/_conditions/sun.is_evening_twilight.markdown
+++ b/source/_conditions/sun.is_evening_twilight.markdown
@@ -32,7 +32,7 @@ Twilight type:
     Which phase of evening twilight passes the condition:
 
     - **Any**: any twilight, from sunset down to the start of night. This is the default.
-    - **Civil**: the sun is between the horizon and 6° below it. The brightest twilight.
+    - **Civil**: the sun is between sunset and 6° below the horizon. The brightest twilight.
     - **Nautical**: the sun is between 6° and 12° below the horizon.
     - **Astronomical**: the sun is between 12° and 18° below the horizon. The darkest twilight, closest to night.
 {% endoptions_ui %}
@@ -60,7 +60,7 @@ condition: |
 {% options_yaml %}
 type:
   description: >
-    Which phase of evening twilight passes the condition. Accepts `any` (any twilight after sunset), `civil` (sun between the horizon and 6° below it), `nautical` (between 6° and 12° below), or `astronomical` (between 12° and 18° below).
+    Which phase of evening twilight passes the condition. Accepts `any` (any twilight after sunset), `civil` (sun between sunset and 6° below the horizon), `nautical` (between 6° and 12° below), or `astronomical` (between 12° and 18° below).
   required: false
   type: string
   default: any

--- a/source/_conditions/sun.is_evening_twilight.markdown
+++ b/source/_conditions/sun.is_evening_twilight.markdown
@@ -9,7 +9,7 @@ related_conditions:
   - sun.is_night
 ---
 
-The **It is evening twilight** condition passes during the gradually darkening period after sunset, while the sun is below the horizon but still sinking. You can match any evening twilight, or narrow it to a specific phase: civil, nautical, or astronomical. Home Assistant works this out from your [home location](/docs/configuration/basic/).
+The **It is evening twilight** condition passes during the gradually darkening period after sunset, while the sun is below the horizon but the sky is not yet completely dark. You can match any evening twilight, or narrow it to a specific phase: civil, nautical, or astronomical. Home Assistant works this out from your [home location](/docs/configuration/basic/).
 
 Use it to run an automation in that post-sunset window, like switching to evening lighting or closing the blinds as the sky fades.
 

--- a/source/_conditions/sun.is_evening_twilight.markdown
+++ b/source/_conditions/sun.is_evening_twilight.markdown
@@ -1,0 +1,111 @@
+---
+title: "It is evening twilight"
+condition: sun.is_evening_twilight
+domain: sun
+description: "Tests if it is evening twilight, optionally of a specific type."
+related_conditions:
+  - sun.is_morning_twilight
+  - sun.is_set
+  - sun.is_night
+---
+
+The **It is evening twilight** condition passes during the gradually darkening period after sunset, while the sun is below the horizon but still sinking. You can match any evening twilight, or narrow it to a specific phase: civil, nautical, or astronomical. Home Assistant works this out from your [home location](/docs/configuration/basic/).
+
+Use it to run an automation in that post-sunset window, like switching to evening lighting or closing the blinds as the sky fades.
+
+{% include conditions/ui_header.md %}
+
+To use this condition in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **And if** section, select **Add condition**.
+4. From the search box, search for and select **Sun: It is evening twilight**.
+5. Under **Twilight type**, select **Any**, **Civil**, **Nautical**, or **Astronomical**.
+6. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Twilight type:
+  description: |
+    Which phase of evening twilight passes the condition:
+
+    - **Any**: any twilight, from sunset down to the start of night. This is the default.
+    - **Civil**: the sun is between the horizon and 6° below it. The brightest twilight.
+    - **Nautical**: the sun is between 6° and 12° below the horizon.
+    - **Astronomical**: the sun is between 12° and 18° below the horizon. The darkest twilight, closest to night.
+{% endoptions_ui %}
+
+{% include conditions/yaml_header.md %}
+
+In YAML, refer to this condition as `sun.is_evening_twilight`. A basic example looks like this:
+
+{% example %}
+condition: |
+  condition: sun.is_evening_twilight
+{% endexample %}
+
+This passes during any evening twilight. To match a specific phase, add the `type` option:
+
+{% example %}
+condition: |
+  condition: sun.is_evening_twilight
+  options:
+    type: civil
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+type:
+  description: >
+    Which phase of evening twilight passes the condition. Accepts `any` (any twilight after sunset), `civil` (sun between the horizon and 6° below it), `nautical` (between 6° and 12° below), or `astronomical` (between 12° and 18° below).
+  required: false
+  type: string
+  default: any
+{% endoptions_yaml %}
+
+## Good to know
+
+- This condition does not use a target. It checks the sun at your configured home location.
+- Evening twilight is the sinking side of the day. The matching period before sunrise is [It is morning twilight](/conditions/sun.is_morning_twilight/).
+- The phases are stacked: civil comes first right after sunset, then nautical, then astronomical, and finally [It is night](/conditions/sun.is_night/). **Any** covers all three.
+- The length of twilight changes through the year and with your latitude. Near the poles, a phase can fail to occur on some days, and the condition does not pass then.
+
+{% include conditions/try_it.md %}
+
+{% include conditions/more_examples.md %}
+
+### Automation: switch to evening lighting at dusk
+
+When the living room is occupied during civil evening twilight, switch the lights to a warm evening scene.
+
+- **Trigger**: Living room occupancy detected
+- **Condition**: It is evening twilight (Civil)
+- **Action**: Activate the evening lighting scene
+
+{% details "YAML example for evening lighting at dusk" %}
+
+{% example %}
+automation: |
+  alias: "Evening lighting at dusk"
+  triggers:
+    - trigger: state
+      entity_id: binary_sensor.living_room_occupancy
+      to: "on"
+  conditions:
+    - condition: sun.is_evening_twilight
+      options:
+        type: civil
+  actions:
+    - action: scene.turn_on
+      target:
+        entity_id: scene.living_room_evening
+{% endexample %}
+
+{% enddetails %}
+
+{% include conditions/stuck.md %}
+
+{% include conditions/related.md %}

--- a/source/_conditions/sun.is_morning_twilight.markdown
+++ b/source/_conditions/sun.is_morning_twilight.markdown
@@ -1,0 +1,113 @@
+---
+title: "It is morning twilight"
+condition: sun.is_morning_twilight
+domain: sun
+description: "Tests if it is morning twilight, optionally of a specific type."
+related_conditions:
+  - sun.is_evening_twilight
+  - sun.is_up
+  - sun.is_night
+---
+
+The **It is morning twilight** condition passes during the gradually brightening period before sunrise, while the sun is below the horizon but climbing. You can match any morning twilight, or narrow it to a specific phase: civil, nautical, or astronomical. Home Assistant works this out from your [home location](/docs/configuration/basic/).
+
+Use it to run an automation in that pre-dawn window, like starting a gentle wake-up routine or raising the blinds as the sky begins to lighten.
+
+{% include conditions/ui_header.md %}
+
+To use this condition in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **And if** section, select **Add condition**.
+4. From the search box, search for and select **Sun: It is morning twilight**.
+5. Under **Twilight type**, select **Any**, **Civil**, **Nautical**, or **Astronomical**.
+6. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Twilight type:
+  description: |
+    Which phase of morning twilight passes the condition:
+
+    - **Any**: any twilight, from the end of night up to sunrise. This is the default.
+    - **Civil**: the sun is between 6° below the horizon and the horizon. The brightest twilight.
+    - **Nautical**: the sun is between 12° and 6° below the horizon.
+    - **Astronomical**: the sun is between 18° and 12° below the horizon. The darkest twilight, closest to night.
+{% endoptions_ui %}
+
+{% include conditions/yaml_header.md %}
+
+In YAML, refer to this condition as `sun.is_morning_twilight`. A basic example looks like this:
+
+{% example %}
+condition: |
+  condition: sun.is_morning_twilight
+{% endexample %}
+
+This passes during any morning twilight. To match a specific phase, add the `type` option:
+
+{% example %}
+condition: |
+  condition: sun.is_morning_twilight
+  options:
+    type: civil
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+type:
+  description: >
+    Which phase of morning twilight passes the condition. Accepts `any` (any twilight up to sunrise), `civil` (sun between 6° below the horizon and the horizon), `nautical` (between 12° and 6° below), or `astronomical` (between 18° and 12° below).
+  required: false
+  type: string
+  default: any
+{% endoptions_yaml %}
+
+## Good to know
+
+- This condition does not use a target. It checks the sun at your configured home location.
+- Morning twilight is the rising side of the day. The matching period after sunset is [It is evening twilight](/conditions/sun.is_evening_twilight/).
+- The phases are stacked: astronomical is darkest and comes first, then nautical, then civil, then [Sun is up](/conditions/sun.is_up/) at sunrise. **Any** covers all three.
+- The length of twilight changes through the year and with your latitude. Near the poles, a phase can fail to occur on some days, and the condition does not pass then.
+
+{% include conditions/try_it.md %}
+
+{% include conditions/more_examples.md %}
+
+### Automation: gentle wake-up light at civil dawn
+
+When your alarm helper is on, fade the bedroom light in during civil morning twilight so you wake with the brightening sky.
+
+- **Trigger**: Bedroom motion detected
+- **Condition**: It is morning twilight (Civil)
+- **Action**: Turn on the bedroom light at low brightness
+
+{% details "YAML example for a pre-dawn wake-up light" %}
+
+{% example %}
+automation: |
+  alias: "Wake-up light at civil dawn"
+  triggers:
+    - trigger: state
+      entity_id: binary_sensor.bedroom_motion
+      to: "on"
+  conditions:
+    - condition: sun.is_morning_twilight
+      options:
+        type: civil
+  actions:
+    - action: light.turn_on
+      target:
+        entity_id: light.bedroom
+      data:
+        brightness_pct: 20
+{% endexample %}
+
+{% enddetails %}
+
+{% include conditions/stuck.md %}
+
+{% include conditions/related.md %}

--- a/source/_conditions/sun.is_morning_twilight.markdown
+++ b/source/_conditions/sun.is_morning_twilight.markdown
@@ -9,7 +9,7 @@ related_conditions:
   - sun.is_night
 ---
 
-The **It is morning twilight** condition passes during the gradually brightening period before sunrise, while the sun is below the horizon but climbing. You can match any morning twilight, or narrow it to a specific phase: civil, nautical, or astronomical. Home Assistant works this out from your [home location](/docs/configuration/basic/).
+The **It is morning twilight** condition passes during the gradually brightening period before sunrise, while the sun is below the horizon but the sky is no longer completely dark. You can match any morning twilight, or narrow it to a specific phase: civil, nautical, or astronomical. Home Assistant works this out from your [home location](/docs/configuration/basic/).
 
 Use it to run an automation in that pre-dawn window, like starting a gentle wake-up routine or raising the blinds as the sky begins to lighten.
 

--- a/source/_conditions/sun.is_morning_twilight.markdown
+++ b/source/_conditions/sun.is_morning_twilight.markdown
@@ -32,7 +32,7 @@ Twilight type:
     Which phase of morning twilight passes the condition:
 
     - **Any**: any twilight, from the end of night up to sunrise. This is the default.
-    - **Civil**: the sun is between 6° below the horizon and the horizon. The brightest twilight.
+    - **Civil**: the sun is between 6° below the horizon and sunrise. The brightest twilight.
     - **Nautical**: the sun is between 12° and 6° below the horizon.
     - **Astronomical**: the sun is between 18° and 12° below the horizon. The darkest twilight, closest to night.
 {% endoptions_ui %}
@@ -60,7 +60,7 @@ condition: |
 {% options_yaml %}
 type:
   description: >
-    Which phase of morning twilight passes the condition. Accepts `any` (any twilight up to sunrise), `civil` (sun between 6° below the horizon and the horizon), `nautical` (between 12° and 6° below), or `astronomical` (between 18° and 12° below).
+    Which phase of morning twilight passes the condition. Accepts `any` (any twilight up to sunrise), `civil` (sun between 6° below the horizon and sunrise), `nautical` (between 12° and 6° below), or `astronomical` (between 18° and 12° below).
   required: false
   type: string
   default: any

--- a/source/_conditions/sun.is_morning_twilight.markdown
+++ b/source/_conditions/sun.is_morning_twilight.markdown
@@ -83,7 +83,8 @@ When your alarm helper is on, fade the bedroom light in during civil morning twi
 
 - **Trigger**: Bedroom motion detected
 - **Condition**: Sun: It is morning twilight (Civil)
-- **Action**: Turn on the bedroom light at low brightness
+- **Action**: Turn on light (at low brightness)
+  - **Target**: Bedroom light
 
 {% details "YAML example for a pre-dawn wake-up light" %}
 

--- a/source/_conditions/sun.is_morning_twilight.markdown
+++ b/source/_conditions/sun.is_morning_twilight.markdown
@@ -82,7 +82,7 @@ type:
 When your alarm helper is on, fade the bedroom light in during civil morning twilight so you wake with the brightening sky.
 
 - **Trigger**: Bedroom motion detected
-- **Condition**: It is morning twilight (Civil)
+- **Condition**: Sun: It is morning twilight (Civil)
 - **Action**: Turn on the bedroom light at low brightness
 
 {% details "YAML example for a pre-dawn wake-up light" %}

--- a/source/_conditions/sun.is_night.markdown
+++ b/source/_conditions/sun.is_night.markdown
@@ -1,0 +1,78 @@
+---
+title: "It is night"
+condition: sun.is_night
+domain: sun
+description: "Tests if it is night."
+related_conditions:
+  - sun.is_set
+  - sun.is_evening_twilight
+  - sun.is_morning_twilight
+---
+
+The **It is night** condition passes during true darkness: when the sun is more than 18° below the horizon, the point where even astronomical twilight has ended and the sky is fully dark. Home Assistant works this out from your [home location](/docs/configuration/basic/).
+
+Use it when you want an automation to run only in the dead of night, not merely after sunset. For example, dim status lights to their lowest level, or hold off on noisy tasks until the sky is genuinely dark.
+
+{% include conditions/ui_header.md %}
+
+To use this condition in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **And if** section, select **Add condition**.
+4. From the search box, search for and select **Sun: It is night**.
+5. Select **Save**.
+
+{% include conditions/yaml_header.md %}
+
+In YAML, refer to this condition as `sun.is_night`. It has no options:
+
+{% example %}
+condition: |
+  condition: sun.is_night
+{% endexample %}
+
+This passes only while the sky is fully dark.
+
+## Good to know
+
+- This condition does not use a target. It checks the sun at your configured home location.
+- Night here means the sun is below -18° elevation (the end of astronomical twilight). This is stricter than [Sun is set](/conditions/sun.is_set/), which passes during twilight as well.
+- At high latitudes in summer, the sun may never drop below -18°. On those days this condition never passes. If you need a check that always has a dark period, use [Sun is set](/conditions/sun.is_set/) instead.
+
+{% include conditions/try_it.md %}
+
+{% include conditions/more_examples.md %}
+
+### Automation: dim the hallway night light in the dead of night
+
+When motion is detected in the hallway during full darkness, turn the light on at a low brightness instead of full power.
+
+- **Trigger**: Motion detected in the hallway
+- **Condition**: It is night
+- **Action**: Turn on the hallway light at 10% brightness
+
+{% details "YAML example for a dim night light" %}
+
+{% example %}
+automation: |
+  alias: "Dim hallway light at night"
+  triggers:
+    - trigger: state
+      entity_id: binary_sensor.hallway_motion
+      to: "on"
+  conditions:
+    - condition: sun.is_night
+  actions:
+    - action: light.turn_on
+      target:
+        entity_id: light.hallway
+      data:
+        brightness_pct: 10
+{% endexample %}
+
+{% enddetails %}
+
+{% include conditions/stuck.md %}
+
+{% include conditions/related.md %}

--- a/source/_conditions/sun.is_night.markdown
+++ b/source/_conditions/sun.is_night.markdown
@@ -49,7 +49,7 @@ This passes only while the sky is fully dark.
 When motion is detected in the hallway during full darkness, turn the light on at a low brightness instead of full power.
 
 - **Trigger**: Motion detected in the hallway
-- **Condition**: It is night
+- **Condition**: Sun: It is night
 - **Action**: Turn on the hallway light at 10% brightness
 
 {% details "YAML example for a dim night light" %}

--- a/source/_conditions/sun.is_night.markdown
+++ b/source/_conditions/sun.is_night.markdown
@@ -9,7 +9,7 @@ related_conditions:
   - sun.is_morning_twilight
 ---
 
-The **It is night** condition passes during true darkness: when the sun is more than 18° below the horizon, the point where even astronomical twilight has ended and the sky is fully dark. Home Assistant works this out from your [home location](/docs/configuration/basic/).
+The **It is night** condition passes during true darkness: when the sun is 18° or more below the horizon, the point where even astronomical twilight has ended and the sky is fully dark. Home Assistant works this out from your [home location](/docs/configuration/basic/).
 
 Use it when you want an automation to run only in the dead of night, not merely after sunset. For example, dim status lights to their lowest level, or hold off on noisy tasks until the sky is genuinely dark.
 
@@ -37,7 +37,7 @@ This passes only while the sky is fully dark.
 ## Good to know
 
 - This condition does not use a target. It checks the sun at your configured home location.
-- Night here means the sun is below -18° elevation (the end of astronomical twilight). This is stricter than [Sun is set](/conditions/sun.is_set/), which passes during twilight as well.
+- Night here means the sun is at or below -18° elevation (the end of astronomical twilight). This is stricter than [Sun is set](/conditions/sun.is_set/), which passes during twilight as well.
 - At high latitudes in summer, the sun may never drop below -18°. On those days this condition never passes. If you need a check that always has a dark period, use [Sun is set](/conditions/sun.is_set/) instead.
 
 {% include conditions/try_it.md %}

--- a/source/_conditions/sun.is_night.markdown
+++ b/source/_conditions/sun.is_night.markdown
@@ -11,7 +11,7 @@ related_conditions:
 
 The **It is night** condition passes during true darkness: when the sun is 18° or more below the horizon, the point where even astronomical twilight has ended and the sky is fully dark. Home Assistant works this out from your [home location](/docs/configuration/basic/).
 
-Use it when you want an automation to run only in the dead of night, not merely after sunset. For example, dim status lights to their lowest level, or hold off on noisy tasks until the sky is genuinely dark.
+Use it when you want an automation to run only in the dead of night, not merely after sunset. For example, dim status lights to their lowest level, or run a stargazing scene that only makes sense once the sky is fully dark.
 
 {% include conditions/ui_header.md %}
 
@@ -38,7 +38,7 @@ This passes only while the sky is fully dark.
 
 - This condition does not use a target. It checks the sun at your configured home location.
 - Night here means the sun is at or below -18° elevation (the end of astronomical twilight). This is stricter than [Sun is set](/conditions/sun.is_set/), which passes during twilight as well.
-- At high latitudes in summer, the sun may never drop below -18°. On those days this condition never passes. If you need a check that always has a dark period, use [Sun is set](/conditions/sun.is_set/) instead.
+- At high latitudes in summer, the sun may never drop below -18°. On those days this condition never passes. The same can happen with [Sun is set](/conditions/sun.is_set/) when the sun does not set at all.
 
 {% include conditions/try_it.md %}
 

--- a/source/_conditions/sun.is_set.markdown
+++ b/source/_conditions/sun.is_set.markdown
@@ -1,0 +1,76 @@
+---
+title: "Sun is set"
+condition: sun.is_set
+domain: sun
+description: "Tests if the sun is set."
+related_conditions:
+  - sun.is_up
+  - sun.is_evening_twilight
+  - sun.is_night
+---
+
+The **Sun is set** condition passes when the sun is below the horizon at your location. Home Assistant works this out from your [home location](/docs/configuration/basic/), so it stays accurate as sunrise and sunset shift through the seasons.
+
+Use it to gate an automation so it only runs after dark, like turning on lights when motion is detected at night, or closing the blinds once the sun has gone down.
+
+{% include conditions/ui_header.md %}
+
+To use this condition in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **And if** section, select **Add condition**.
+4. From the search box, search for and select **Sun: Sun is set**.
+5. Select **Save**.
+
+{% include conditions/yaml_header.md %}
+
+In YAML, refer to this condition as `sun.is_set`. It has no options:
+
+{% example %}
+condition: |
+  condition: sun.is_set
+{% endexample %}
+
+This passes while the sun is below the horizon.
+
+## Good to know
+
+- This condition does not use a target. It checks the sun at your configured home location.
+- "Set" means the sun's center is below the horizon, the same moment used for sunrise and sunset. For the opposite check, use [Sun is up](/conditions/sun.is_up/).
+- The sun is set during the whole period between sunset and sunrise, including twilight and the dead of night. If you specifically want full darkness, use [It is night](/conditions/sun.is_night/).
+
+{% include conditions/try_it.md %}
+
+{% include conditions/more_examples.md %}
+
+### Automation: close the blinds when the sun goes down
+
+When motion is detected in the living room after the sun has set, close the blinds for the evening.
+
+- **Trigger**: Motion detected in the living room
+- **Condition**: Sun is set
+- **Action**: Close the living room blinds
+
+{% details "YAML example for closing blinds after sunset" %}
+
+{% example %}
+automation: |
+  alias: "Close blinds after sunset"
+  triggers:
+    - trigger: state
+      entity_id: binary_sensor.living_room_motion
+      to: "on"
+  conditions:
+    - condition: sun.is_set
+  actions:
+    - action: cover.close_cover
+      target:
+        entity_id: cover.living_room_blinds
+{% endexample %}
+
+{% enddetails %}
+
+{% include conditions/stuck.md %}
+
+{% include conditions/related.md %}

--- a/source/_conditions/sun.is_set.markdown
+++ b/source/_conditions/sun.is_set.markdown
@@ -49,8 +49,9 @@ This passes while the sun is below the horizon.
 When motion is detected in the living room after the sun has set, close the blinds for the evening.
 
 - **Trigger**: Motion detected in the living room
-- **Condition**: Sun is set
-- **Action**: Close the living room blinds
+- **Condition**: Sun: sun is set
+- **Action**: Close cover
+  - **Target**: Living room blinds
 
 {% details "YAML example for closing blinds after sunset" %}
 

--- a/source/_conditions/sun.is_set.markdown
+++ b/source/_conditions/sun.is_set.markdown
@@ -37,7 +37,7 @@ This passes while the sun is below the horizon.
 ## Good to know
 
 - This condition does not use a target. It checks the sun at your configured home location.
-- "Set" means the sun's center is below the horizon, the same moment used for sunrise and sunset. For the opposite check, use [Sun is up](/conditions/sun.is_up/).
+- "Set" uses the same horizon definition as sunrise and sunset, so the condition flips at exactly those moments. For the opposite check, use [Sun is up](/conditions/sun.is_up/).
 - The sun is set during the whole period between sunset and sunrise, including twilight and the dead of night. If you specifically want full darkness, use [It is night](/conditions/sun.is_night/).
 
 {% include conditions/try_it.md %}

--- a/source/_conditions/sun.is_up.markdown
+++ b/source/_conditions/sun.is_up.markdown
@@ -49,8 +49,10 @@ This passes while the sun is above the horizon.
 When motion is detected at the front door, turn on the porch light, but only when the sun is down.
 
 - **Trigger**: Motion detected at the front door
-- **Condition**: Sun is up (negated, so the automation runs only when the sun is down)
-- **Action**: Turn on the porch light
+- **Condition**: Not
+  - **Condition**: Sun: sun is up
+- **Action**: Turn on light
+  - **Target**: Porch light
 
 {% details "YAML example for motion lighting only after dark" %}
 

--- a/source/_conditions/sun.is_up.markdown
+++ b/source/_conditions/sun.is_up.markdown
@@ -1,0 +1,78 @@
+---
+title: "Sun is up"
+condition: sun.is_up
+domain: sun
+description: "Tests if the sun is up."
+related_conditions:
+  - sun.is_set
+  - sun.is_morning_twilight
+  - sun.elevation
+---
+
+The **Sun is up** condition passes when the sun is above the horizon at your location. Home Assistant works this out from your [home location](/docs/configuration/basic/), so it stays accurate as sunrise and sunset shift through the seasons.
+
+Use it to gate an automation so it only runs during daylight, like skipping the porch light when the sun is already up, or only watering the garden after the sun has risen.
+
+{% include conditions/ui_header.md %}
+
+To use this condition in an automation:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation, or select **Create automation** > **Create new automation**.
+3. In the **And if** section, select **Add condition**.
+4. From the search box, search for and select **Sun: Sun is up**.
+5. Select **Save**.
+
+{% include conditions/yaml_header.md %}
+
+In YAML, refer to this condition as `sun.is_up`. It has no options:
+
+{% example %}
+condition: |
+  condition: sun.is_up
+{% endexample %}
+
+This passes while the sun is above the horizon.
+
+## Good to know
+
+- This condition does not use a target. It checks the sun at your configured home location.
+- "Up" means the sun's center is at or above the horizon, the same moment used for sunrise and sunset. For the opposite check, use [Sun is set](/conditions/sun.is_set/).
+- This is a point-in-time check. It reflects whether the sun is up at the moment the automation runs, not whether it rose or set.
+
+{% include conditions/try_it.md %}
+
+{% include conditions/more_examples.md %}
+
+### Automation: only turn on the porch light after dark
+
+When motion is detected at the front door, turn on the porch light, but only when the sun is down.
+
+- **Trigger**: Motion detected at the front door
+- **Condition**: Sun is up (negated, so the automation runs only when the sun is down)
+- **Action**: Turn on the porch light
+
+{% details "YAML example for motion lighting only after dark" %}
+
+{% example %}
+automation: |
+  alias: "Porch light on motion after dark"
+  triggers:
+    - trigger: state
+      entity_id: binary_sensor.front_door_motion
+      to: "on"
+  conditions:
+    - condition: not
+      conditions:
+        - condition: sun.is_up
+  actions:
+    - action: light.turn_on
+      target:
+        entity_id: light.porch
+{% endexample %}
+
+{% enddetails %}
+
+{% include conditions/stuck.md %}
+
+{% include conditions/related.md %}

--- a/source/_conditions/sun.is_up.markdown
+++ b/source/_conditions/sun.is_up.markdown
@@ -37,7 +37,7 @@ This passes while the sun is above the horizon.
 ## Good to know
 
 - This condition does not use a target. It checks the sun at your configured home location.
-- "Up" means the sun's center is at or above the horizon, the same moment used for sunrise and sunset. For the opposite check, use [Sun is set](/conditions/sun.is_set/).
+- "Up" uses the same horizon definition as sunrise and sunset, so the condition flips at exactly those moments. For the opposite check, use [Sun is set](/conditions/sun.is_set/).
 - This is a point-in-time check. It reflects whether the sun is up at the moment the automation runs, not whether it rose or set.
 
 {% include conditions/try_it.md %}

--- a/source/_integrations/sun.markdown
+++ b/source/_integrations/sun.markdown
@@ -98,6 +98,8 @@ Because the duration of twilight varies throughout the year, a fixed offset is n
 
 {% include integrations/triggers.md %}
 
+{% include integrations/conditions.md %}
+
 ## Sensors
 
 The sensors are also available as attributes on the `sun.sun` entity for backward compatibility.


### PR DESCRIPTION
## Proposed change

Documents the new sun conditions added in [home-assistant/core#174537](https://github.com/home-assistant/core/pull/174537): sun is up, sun is set, sun is ascending, sun is descending, it is night, sun elevation, it is morning twilight, and it is evening twilight.

Each condition gets a dedicated page following the modern condition format. The Sun integration page now surfaces them through the list of conditions include, alongside the triggers list.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/174537
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
