### PR TITLE
Rename entity trigger and condition keys for consistency

### DIFF
--- a/source/_actions/vacuum.turn_off.markdown
+++ b/source/_actions/vacuum.turn_off.markdown
@@ -67,7 +67,7 @@ If your vacuum supports a separate power state, this automation turns it off aft
 automation: |
   alias: "Turn off vacuum after docking"
   triggers:
-    - trigger: vacuum.docked
+    - trigger: vacuum.returned_to_dock
       target:
         entity_id: vacuum.downstairs
   actions:

--- a/source/_conditions/climate.is_target_humidity.markdown
+++ b/source/_conditions/climate.is_target_humidity.markdown
@@ -1,6 +1,6 @@
 ---
 title: "Thermostat target humidity"
-condition: climate.target_humidity
+condition: climate.is_target_humidity
 domain: climate
 description: "Tests the target humidity of one or more thermostats."
 related_conditions:
@@ -9,7 +9,7 @@ related_conditions:
   - climate.is_heating
   - climate.is_drying
   - climate.is_hvac_mode
-  - climate.target_temperature
+  - climate.is_target_temperature
 ---
 
 The **Thermostat target humidity** condition passes when a thermostat {% term entity %}'s target humidity setting meets a threshold you define. The target humidity is the setpoint you configure on the device, not the actual current humidity reading. For example, you can use this condition in an automation to turn on a dehumidifier only if the thermostat's humidity setpoint is above 60%.
@@ -43,7 +43,7 @@ For at least:
 
 {% include conditions/yaml_header.md %}
 
-In YAML, **Thermostat target humidity** is referred to as `climate.target_humidity`. A basic example looks like this:
+In YAML, **Thermostat target humidity** is referred to as `climate.is_target_humidity`. A basic example looks like this:
 
 {% example %}
 automation: |
@@ -53,7 +53,7 @@ automation: |
       entity_id: climate.bedroom
       attribute: humidity
   conditions:
-    - condition: climate.target_humidity
+    - condition: climate.is_target_humidity
       target:
         entity_id: climate.bedroom
       options:
@@ -129,7 +129,7 @@ automation: |
       entity_id: climate.bedroom
       attribute: humidity
   conditions:
-    - condition: climate.target_humidity
+    - condition: climate.is_target_humidity
       target:
         entity_id: climate.bedroom
       options:

--- a/source/_conditions/climate.is_target_temperature.markdown
+++ b/source/_conditions/climate.is_target_temperature.markdown
@@ -1,6 +1,6 @@
 ---
 title: "Thermostat target temperature"
-condition: climate.target_temperature
+condition: climate.is_target_temperature
 domain: climate
 description: "Tests the target temperature of one or more thermostats."
 related_conditions:
@@ -9,7 +9,7 @@ related_conditions:
   - climate.is_heating
   - climate.is_drying
   - climate.is_hvac_mode
-  - climate.target_humidity
+  - climate.is_target_humidity
 ---
 
 The **Thermostat target temperature** condition passes when a thermostat {% term entity %}'s target temperature setting meets a threshold you define. The target temperature is the setpoint you configure on the device, not the actual current temperature reading. For example, you can use this condition in an automation to turn on a dehumidifier only if the thermostat is set to an unusually high or low temperature.
@@ -52,7 +52,7 @@ For at least:
 
 {% include conditions/yaml_header.md %}
 
-In YAML, **Thermostat target temperature** is referred to as `climate.target_temperature`. A basic example looks like this:
+In YAML, **Thermostat target temperature** is referred to as `climate.is_target_temperature`. A basic example looks like this:
 
 {% example %}
 automation: |
@@ -62,7 +62,7 @@ automation: |
       entity_id: climate.living_room
       attribute: temperature
   conditions:
-    - condition: climate.target_temperature
+    - condition: climate.is_target_temperature
       target:
         entity_id: climate.living_room
       options:
@@ -89,7 +89,7 @@ automation: |
       entity_id: climate.bedroom
       attribute: temperature
   conditions:
-    - condition: climate.target_temperature
+    - condition: climate.is_target_temperature
       target:
         entity_id: climate.bedroom
       options:
@@ -179,7 +179,7 @@ automation: |
       entity_id: climate.living_room
       attribute: temperature
   conditions:
-    - condition: climate.target_temperature
+    - condition: climate.is_target_temperature
       target:
         entity_id: climate.living_room
       options:
@@ -210,7 +210,7 @@ automation: |
       entity_id: climate.bedroom
       attribute: temperature
   conditions:
-    - condition: climate.target_temperature
+    - condition: climate.is_target_temperature
       target:
         entity_id: climate.bedroom
       options:

--- a/source/_includes/conditions/threshold_value_steps.md
+++ b/source/_includes/conditions/threshold_value_steps.md
@@ -1,7 +1,7 @@
 {% comment %}
 Reusable "To use ... in an automation" steps for entity conditions that test a
 reading against the threshold-mapping schema (above/below/in range/outside
-range). Used by humidity.is_value; reusable by climate.target_humidity,
+range). Used by humidity.is_value; reusable by climate.is_target_humidity,
 light.is_brightness, counter.is_value, and similar.
 
 Parameters:

--- a/source/_integrations/lawn_mower.markdown
+++ b/source/_integrations/lawn_mower.markdown
@@ -56,7 +56,7 @@ When the mower returns to dock, send a message so you know the job is finished w
 automation: |
   alias: "Notify when the mower is done"
   triggers:
-    - trigger: lawn_mower.docked
+    - trigger: lawn_mower.returned_to_dock
       target:
         entity_id: lawn_mower.backyard
   actions:

--- a/source/_integrations/schedule.markdown
+++ b/source/_integrations/schedule.markdown
@@ -175,7 +175,7 @@ If you use a schedule to define when your porch light should be active, you can 
 automation: |
   alias: "Turn on the porch light when the evening schedule starts"
   triggers:
-    - trigger: schedule.turned_on
+    - trigger: schedule.block_started
       target:
         entity_id: schedule.evening_porch_light
   actions:

--- a/source/_integrations/timer.markdown
+++ b/source/_integrations/timer.markdown
@@ -141,7 +141,7 @@ Get a reminder shortly before a timer finishes, like when laundry or cooking tim
 automation: |
   alias: "Notify when five minutes remain on the laundry timer"
   triggers:
-    - trigger: timer.time_remaining
+    - trigger: timer.remaining_time_reached
       target:
         entity_id: timer.laundry
       options:

--- a/source/_integrations/update.markdown
+++ b/source/_integrations/update.markdown
@@ -86,7 +86,7 @@ notification to your phone right away.
 automation: |
   alias: "Send a notification when an update becomes available"
   triggers:
-    - trigger: update.update_became_available
+    - trigger: update.became_available
       target:
         entity_id: update.office_router_firmware
   actions:

--- a/source/_redirects
+++ b/source/_redirects
@@ -801,3 +801,15 @@ layout: null
 /template-functions/category/state/ /template-functions/#state
 /template-functions/category/strings/ /template-functions/#strings
 /template-functions/category/type/ /template-functions/#type
+
+# Renamed entity triggers and conditions (consistent keys)
+/triggers/battery.low /triggers/battery.became_low/ 301
+/triggers/battery.not_low /triggers/battery.no_longer_low/ 301
+/triggers/lawn_mower.docked /triggers/lawn_mower.returned_to_dock/ 301
+/triggers/schedule.turned_off /triggers/schedule.block_ended/ 301
+/triggers/schedule.turned_on /triggers/schedule.block_started/ 301
+/triggers/timer.time_remaining /triggers/timer.remaining_time_reached/ 301
+/triggers/update.update_became_available /triggers/update.became_available/ 301
+/triggers/vacuum.docked /triggers/vacuum.returned_to_dock/ 301
+/conditions/climate.target_humidity /conditions/climate.is_target_humidity/ 301
+/conditions/climate.target_temperature /conditions/climate.is_target_temperature/ 301

--- a/source/_triggers/battery.became_low.markdown
+++ b/source/_triggers/battery.became_low.markdown
@@ -1,10 +1,10 @@
 ---
 title: "Battery low"
-trigger: battery.low
+trigger: battery.became_low
 domain: battery
 description: "Triggers after one or more battery sensors report a low battery."
 related_triggers:
-  - battery.not_low
+  - battery.no_longer_low
 ---
 
 The **Battery low** trigger fires when a battery sensor reports that the battery is low.
@@ -44,11 +44,11 @@ For at least:
 
 {% include triggers/yaml_header.md %}
 
-In YAML, **Battery low** is referred to as `battery.low`. A basic example looks like this:
+In YAML, **Battery low** is referred to as `battery.became_low`. A basic example looks like this:
 
 {% example %}
 trigger: |
-  trigger: battery.low
+  trigger: battery.became_low
   target:
     entity_id: binary_sensor.front_door_lock_battery
 {% endexample %}
@@ -59,7 +59,7 @@ To watch all battery sensors in a room and fire only after every sensor in the a
 
 {% example %}
 trigger: |
-  trigger: battery.low
+  trigger: battery.became_low
   target:
     area_id: living_room
   options:
@@ -116,7 +116,7 @@ Sensors in out-of-the-way spots like a mailbox or garden shed can run out of bat
 automation: |
   alias: "Notify when a garden sensor battery is low"
   triggers:
-    - trigger: battery.low
+    - trigger: battery.became_low
       target:
         area_id: garden
   actions:

--- a/source/_triggers/battery.no_longer_low.markdown
+++ b/source/_triggers/battery.no_longer_low.markdown
@@ -1,10 +1,10 @@
 ---
 title: "Battery not low"
-trigger: battery.not_low
+trigger: battery.no_longer_low
 domain: battery
 description: "Triggers after one or more battery sensors stop reporting a low battery."
 related_triggers:
-  - battery.low
+  - battery.became_low
 ---
 
 The **Battery not low** trigger fires when a battery sensor stops reporting that the battery is low. This happens when batteries are replaced or, for rechargeable devices, when the battery charges back above the low threshold.
@@ -44,11 +44,11 @@ For at least:
 
 {% include triggers/yaml_header.md %}
 
-In YAML, **Battery not low** is referred to as `battery.not_low`. A basic example looks like this:
+In YAML, **Battery not low** is referred to as `battery.no_longer_low`. A basic example looks like this:
 
 {% example %}
 trigger: |
-  trigger: battery.not_low
+  trigger: battery.no_longer_low
   target:
     entity_id: binary_sensor.front_door_lock_battery
 {% endexample %}
@@ -59,7 +59,7 @@ To watch all battery sensors in a room and fire when any of them returns to a no
 
 {% example %}
 trigger: |
-  trigger: battery.not_low
+  trigger: battery.no_longer_low
   target:
     area_id: living_room
 {% endexample %}
@@ -93,7 +93,7 @@ for:
 
 - This trigger works with `binary_sensor` entities that have the `battery` device class. These are separate from battery percentage sensors (`sensor` entities with the `battery` device class). If your device only exposes a percentage sensor, use [Battery level crossed threshold](/triggers/battery.level_crossed/) instead.
 - What counts as "low" depends on the device and its integration. The battery binary sensor is controlled by the device or its integration, not by Home Assistant.
-- Use this trigger together with [Battery low](/triggers/battery.low/) to build a complete low-battery workflow: alert when a device goes low, and confirm or log when it is healthy again.
+- Use this trigger together with [Battery low](/triggers/battery.became_low/) to build a complete low-battery workflow: alert when a device goes low, and confirm or log when it is healthy again.
 
 {% include triggers/try_it.md %}
 
@@ -114,7 +114,7 @@ After you replace batteries or recharge a device, it can be useful to know that 
 automation: |
   alias: "Notify when front door lock battery is no longer low"
   triggers:
-    - trigger: battery.not_low
+    - trigger: battery.no_longer_low
       target:
         entity_id: binary_sensor.front_door_lock_battery
   actions:

--- a/source/_triggers/lawn_mower.returned_to_dock.markdown
+++ b/source/_triggers/lawn_mower.returned_to_dock.markdown
@@ -1,6 +1,6 @@
 ---
 title: "Lawn mower returned to dock"
-trigger: lawn_mower.docked
+trigger: lawn_mower.returned_to_dock
 domain: lawn_mower
 description: "Triggers after one or more lawn mowers have returned to dock."
 ---
@@ -32,11 +32,11 @@ For at least:
 
 {% include triggers/yaml_header.md %}
 
-In YAML, refer to this trigger as `lawn_mower.docked`. A basic example looks like this:
+In YAML, refer to this trigger as `lawn_mower.returned_to_dock`. A basic example looks like this:
 
 {% example %}
 trigger: |
-  trigger: lawn_mower.docked
+  trigger: lawn_mower.returned_to_dock
   target:
     entity_id: lawn_mower.backyard
 {% endexample %}
@@ -92,7 +92,7 @@ If you want a simple heads-up when yard work is done, use this trigger to send a
 automation: |
   alias: "Notify when the mower docks"
   triggers:
-    - trigger: lawn_mower.docked
+    - trigger: lawn_mower.returned_to_dock
       target:
         entity_id: lawn_mower.backyard
   actions:
@@ -120,7 +120,7 @@ If you turn on the patio light earlier in the mowing routine to help the mower r
 automation: |
   alias: "Turn off the patio light after docking"
   triggers:
-    - trigger: lawn_mower.docked
+    - trigger: lawn_mower.returned_to_dock
       target:
         entity_id: lawn_mower.backyard
       options:

--- a/source/_triggers/schedule.block_ended.markdown
+++ b/source/_triggers/schedule.block_ended.markdown
@@ -1,10 +1,10 @@
 ---
 title: "Schedule block ended"
-trigger: schedule.turned_off
+trigger: schedule.block_ended
 domain: schedule
 description: "Triggers when a schedule block ends."
 related_triggers:
-  - schedule.turned_on
+  - schedule.block_started
 ---
 
 The **Schedule block ended** trigger is useful when you want something to happen as soon as a scheduled time block finishes. Use it to turn something off at the end of a routine, or to wait until a schedule has been inactive for a while before continuing.
@@ -37,11 +37,11 @@ For at least:
 
 {% include triggers/yaml_header.md %}
 
-In YAML, refer to this trigger as `schedule.turned_off`. A basic example looks like this:
+In YAML, refer to this trigger as `schedule.block_ended`. A basic example looks like this:
 
 {% example %}
 trigger: |
-  trigger: schedule.turned_off
+  trigger: schedule.block_ended
   target:
     entity_id: schedule.focus_time
   options:
@@ -73,7 +73,7 @@ for:
 
 - A schedule in the `unknown` or `unavailable` state does not trigger this automation.
 - If another schedule block starts before the **For at least** time finishes, the timer resets.
-- To react when a schedule block starts instead, use [Schedule block started](/triggers/schedule.turned_on/).
+- To react when a schedule block starts instead, use [Schedule block started](/triggers/schedule.block_started/).
 
 {% include triggers/try_it.md %}
 
@@ -94,7 +94,7 @@ If you use a schedule to define office hours, you can turn off a space heater as
 automation: |
   alias: "Turn off the heater when the office schedule ends"
   triggers:
-    - trigger: schedule.turned_off
+    - trigger: schedule.block_ended
       target:
         entity_id: schedule.office_heating
   actions:
@@ -121,7 +121,7 @@ If a quiet period has ended and stayed inactive for a while, you can send yourse
 automation: |
   alias: "Send a reminder after quiet time has ended"
   triggers:
-    - trigger: schedule.turned_off
+    - trigger: schedule.block_ended
       target:
         entity_id: schedule.quiet_time
       options:

--- a/source/_triggers/schedule.block_started.markdown
+++ b/source/_triggers/schedule.block_started.markdown
@@ -1,10 +1,10 @@
 ---
 title: "Schedule block started"
-trigger: schedule.turned_on
+trigger: schedule.block_started
 domain: schedule
 description: "Triggers when a schedule block starts."
 related_triggers:
-  - schedule.turned_off
+  - schedule.block_ended
 ---
 
 The **Schedule block started** trigger is useful when you want an automation to begin exactly when a scheduled time block starts. Use it to turn something on at the start of a routine, or to begin a follow-up action after a schedule has been active for a while.
@@ -37,11 +37,11 @@ For at least:
 
 {% include triggers/yaml_header.md %}
 
-In YAML, refer to this trigger as `schedule.turned_on`. A basic example looks like this:
+In YAML, refer to this trigger as `schedule.block_started`. A basic example looks like this:
 
 {% example %}
 trigger: |
-  trigger: schedule.turned_on
+  trigger: schedule.block_started
   target:
     entity_id: schedule.morning_routine
   options:
@@ -73,7 +73,7 @@ for:
 
 - A schedule in the `unknown` or `unavailable` state does not trigger this automation.
 - If the schedule stops being active before the **For at least** time finishes, the timer resets.
-- To react when a schedule block ends instead, use [Schedule block ended](/triggers/schedule.turned_off/).
+- To react when a schedule block ends instead, use [Schedule block ended](/triggers/schedule.block_ended/).
 
 {% include triggers/try_it.md %}
 
@@ -94,7 +94,7 @@ If you use a schedule to define when your porch light should be active, you can 
 automation: |
   alias: "Turn on the porch light when the evening schedule starts"
   triggers:
-    - trigger: schedule.turned_on
+    - trigger: schedule.block_started
       target:
         entity_id: schedule.evening_porch_light
   actions:
@@ -121,7 +121,7 @@ If you want a short delay before starting ventilation, you can wait until the sc
 automation: |
   alias: "Start the kitchen fan after 10 minutes"
   triggers:
-    - trigger: schedule.turned_on
+    - trigger: schedule.block_started
       target:
         entity_id: schedule.kitchen_ventilation
       options:

--- a/source/_triggers/timer.finished.markdown
+++ b/source/_triggers/timer.finished.markdown
@@ -4,7 +4,7 @@ trigger: timer.finished
 domain: timer
 description: "Triggers when one or more timers finish."
 related_triggers:
-  - timer.time_remaining
+  - timer.remaining_time_reached
   - timer.cancelled
 ---
 

--- a/source/_triggers/timer.remaining_time_reached.markdown
+++ b/source/_triggers/timer.remaining_time_reached.markdown
@@ -1,6 +1,6 @@
 ---
 title: "Timer time remaining"
-trigger: timer.time_remaining
+trigger: timer.remaining_time_reached
 domain: timer
 description: "Triggers when one or more timers reach a specific remaining time."
 related_triggers:
@@ -31,11 +31,11 @@ Time remaining:
 
 {% include triggers/yaml_header.md %}
 
-In YAML, refer to this trigger as `timer.time_remaining`. A basic example looks like this:
+In YAML, refer to this trigger as `timer.remaining_time_reached`. A basic example looks like this:
 
 {% example %}
 trigger: |
-  trigger: timer.time_remaining
+  trigger: timer.remaining_time_reached
   target:
     entity_id: timer.laundry
   options:
@@ -80,7 +80,7 @@ Get a reminder before the cycle finishes so you can be ready to empty the machin
 automation: |
   alias: "Notify when the laundry timer has five minutes left"
   triggers:
-    - trigger: timer.time_remaining
+    - trigger: timer.remaining_time_reached
       target:
         entity_id: timer.laundry
       options:
@@ -110,7 +110,7 @@ Use a short visual warning before a timed hallway light is about to turn off.
 automation: |
   alias: "Flash the hallway light when the entry timer has one minute left"
   triggers:
-    - trigger: timer.time_remaining
+    - trigger: timer.remaining_time_reached
       target:
         entity_id: timer.entry
       options:

--- a/source/_triggers/update.became_available.markdown
+++ b/source/_triggers/update.became_available.markdown
@@ -1,6 +1,6 @@
 ---
 title: "Update became available"
-trigger: update.update_became_available
+trigger: update.became_available
 domain: update
 description: "Triggers after one or more updates become available."
 ---
@@ -41,12 +41,12 @@ For at least:
 
 {% include triggers/yaml_header.md %}
 
-In YAML, refer to this trigger as `update.update_became_available`. A basic
+In YAML, refer to this trigger as `update.became_available`. A basic
 example looks like this:
 
 {% example %}
 trigger: |
-  trigger: update.update_became_available
+  trigger: update.became_available
   target:
     entity_id: update.office_router_firmware
 {% endexample %}
@@ -107,7 +107,7 @@ notification to your phone right away.
 automation: |
   alias: "Send a notification when an update becomes available"
   triggers:
-    - trigger: update.update_became_available
+    - trigger: update.became_available
       target:
         entity_id: update.office_router_firmware
   actions:
@@ -138,7 +138,7 @@ automation turns on a light after an update has stayed available for 7 days.
 automation: |
   alias: "Turn on a reminder light if an update stays available for a week"
   triggers:
-    - trigger: update.update_became_available
+    - trigger: update.became_available
       target:
         entity_id: update.guest_room_speaker_firmware
       options:

--- a/source/_triggers/vacuum.errored.markdown
+++ b/source/_triggers/vacuum.errored.markdown
@@ -5,7 +5,7 @@ domain: vacuum
 description: "Triggers when one or more vacuum cleaners encounter an error."
 related_triggers:
   - vacuum.paused_cleaning
-  - vacuum.docked
+  - vacuum.returned_to_dock
 ---
 
 The **Vacuum cleaner encountered an error** trigger fires as soon as your vacuum reports an error state.

--- a/source/_triggers/vacuum.returned_to_dock.markdown
+++ b/source/_triggers/vacuum.returned_to_dock.markdown
@@ -1,6 +1,6 @@
 ---
 title: "Vacuum returned to dock"
-trigger: vacuum.docked
+trigger: vacuum.returned_to_dock
 domain: vacuum
 description: "Triggers when a vacuum cleaner docks."
 related_triggers:
@@ -39,11 +39,11 @@ For at least:
 
 {% include triggers/yaml_header.md %}
 
-In YAML, refer to this trigger as `vacuum.docked`. A basic example looks like this:
+In YAML, refer to this trigger as `vacuum.returned_to_dock`. A basic example looks like this:
 
 {% example %}
 trigger: |
-  trigger: vacuum.docked
+  trigger: vacuum.returned_to_dock
   target:
     entity_id:
       - vacuum.upstairs
@@ -101,7 +101,7 @@ When the vacuum docks, the cleaning run is usually complete. This automation sen
 automation: |
   alias: "Vacuum finished cleaning"
   triggers:
-    - trigger: vacuum.docked
+    - trigger: vacuum.returned_to_dock
       target:
         entity_id: vacuum.downstairs
   actions:

--- a/source/_triggers/vacuum.started_cleaning.markdown
+++ b/source/_triggers/vacuum.started_cleaning.markdown
@@ -5,7 +5,7 @@ domain: vacuum
 description: "Triggers when one or more vacuum cleaners start cleaning."
 related_triggers:
   - vacuum.paused_cleaning
-  - vacuum.docked
+  - vacuum.returned_to_dock
 ---
 
 The **Vacuum cleaner started cleaning** trigger fires when the vacuum begins a new cleaning run. Use it for automations that need to respond when cleaning starts, like announcements, status changes, or notifications.

--- a/source/_triggers/vacuum.started_returning.markdown
+++ b/source/_triggers/vacuum.started_returning.markdown
@@ -4,7 +4,7 @@ trigger: vacuum.started_returning
 domain: vacuum
 description: "Triggers when one or more vacuum cleaners start returning to dock."
 related_triggers:
-  - vacuum.docked
+  - vacuum.returned_to_dock
   - vacuum.started_cleaning
 ---
 


### PR DESCRIPTION
## Proposed change

Processes the entity trigger and condition key renames from [home-assistant/core#174463](https://github.com/home-assistant/core/pull/174463), which makes the purpose-specific trigger and condition keys consistent across domains.

Renamed the affected pages, updated their keys, in-page YAML references, cross-page links, and `related_triggers` / `related_conditions` entries, and added `_redirects` for the old URLs.

Triggers:
- `battery.low` → `battery.became_low`
- `battery.not_low` → `battery.no_longer_low`
- `lawn_mower.docked` → `lawn_mower.returned_to_dock`
- `schedule.turned_off` → `schedule.block_ended`
- `schedule.turned_on` → `schedule.block_started`
- `timer.time_remaining` → `timer.remaining_time_reached`
- `update.update_became_available` → `update.became_available`
- `vacuum.docked` → `vacuum.returned_to_dock`

Conditions:
- `climate.target_humidity` → `climate.is_target_humidity`
- `climate.target_temperature` → `climate.is_target_temperature`

Only the keys change here. Following the core PR, titles and descriptions are left untouched for a separate pass.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/174463
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
