### PR TITLE
Remove "advanced" wording from Risco documentation

### DIFF
--- a/source/_integrations/risco.markdown
+++ b/source/_integrations/risco.markdown
@@ -39,7 +39,7 @@ has the event timestamp as the state, and other event information in attributes.
 
 If you have multiple sites, only the first site will be used.
 
-## Local (advanced)
+## Local
 
 The integration will connect locally to your system.
 No dependency on the cloud, and instantaneous updates, but is harder to set up.
@@ -66,7 +66,7 @@ Maximum concurrent requests in Risco local:
 {% endconfiguration_basic %}
 
 Apart from these options, you can also define a custom mapping between your Home Assistant Alarm states and the Risco arming modes.
-This is an advanced configuration, and unless you're using group arming, the default mapping should probably be best.
+This is optional, and unless you're using group arming, the default mapping is probably best.
 This is a two-way mapping, meaning you can map:
 
 - What Home Assistant state your partition entity will report when Risco is armed in a specific mode.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change

Aligns the Risco docs with the renamed config-flow option in core: the setup menu option "Local Risco Panel (advanced)" becomes "Local Risco Panel", so this drops the "(advanced)" wording from the matching `## Local` heading and rewords "advanced configuration" to "optional configuration". Part of the effort to remove "Advanced"/"Expert" terminology (home-assistant/core#173016).

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: home-assistant/core#174643
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
