### PR TITLE
Add more-info pages for filesystem check unhealthy reasons

### DIFF
--- a/source/more-info/unhealthy/data_filesystem_check_error.md
+++ b/source/more-info/unhealthy/data_filesystem_check_error.md
@@ -15,11 +15,11 @@ Try rebooting your system first. The filesystem check may be able to repair mino
 
 {% my hardware badge %}
 
-If the system is still accessible after rebooting, create a full backup immediately and download it to another device before doing anything else.
+If the system is still accessible after rebooting, create a full [backup][backups] immediately and download it to another device before doing anything else.
 
 {% my supervisor_backups badge %}
 
-If the issue persists, you can wipe and reformat the data partition using the CLI:
+If the issue persists, you can wipe and reformat the data partition using the CLI. Note that this erases all data on the partition, so you will need to restore from a backup afterwards. If the underlying cause is a failing storage device, this may not resolve the issue permanently.
 
 ```bash
 ha os datadisk wipe
@@ -30,5 +30,7 @@ If the data partition is on a failing physical device, move it to a new one befo
 {% my storage badge %}
 
 Once the data partition is ready, restore from your backup.
+
+[backups]: /common-tasks/general/#backups
 
 To reduce the risk of this happening in the future, always shut down Home Assistant cleanly rather than cutting power, and keep regular backups stored on a separate device.

--- a/source/more-info/unhealthy/data_filesystem_check_error.md
+++ b/source/more-info/unhealthy/data_filesystem_check_error.md
@@ -1,0 +1,34 @@
+---
+title: "Filesystem check failed on the data partition"
+description: "More information on what to do when a filesystem check fails on the Home Assistant data partition."
+---
+
+## The issue
+
+At every boot, Home Assistant checks the integrity of its storage partitions. This check failed on the data partition, which means the filesystem is corrupted — files may be missing, unreadable, or in an inconsistent state.
+
+The data partition stores your configuration, automations, add-ons, and backups. This is most commonly caused by an unexpected power loss or a failing storage device (SD card, USB drive, or eMMC).
+
+## The solution
+
+Try rebooting your system first. The filesystem check may be able to repair minor corruption automatically on the next boot attempt.
+
+{% my hardware badge title="**Settings** > **System** > **Hardware**" %}
+
+If the system is still accessible after rebooting, create a full backup immediately and download it to another device before doing anything else.
+
+{% my supervisor_backups badge title="**Settings** > **System** > **Backups**" %}
+
+If the issue persists, you can wipe and reformat the data partition using the CLI:
+
+```bash
+ha os datadisk wipe
+```
+
+If the data partition is on a failing physical device, move it to a new one before restoring your backup. You can do this from the Storage page in your settings.
+
+{% my storage badge title="**Settings** > **System** > **Storage**" %}
+
+Once the data partition is ready, restore from your backup.
+
+To reduce the risk of this happening in the future, always shut down Home Assistant cleanly rather than cutting power, and keep regular backups stored on a separate device.

--- a/source/more-info/unhealthy/data_filesystem_check_error.md
+++ b/source/more-info/unhealthy/data_filesystem_check_error.md
@@ -5,9 +5,9 @@ description: "More information on what to do when a filesystem check fails on th
 
 ## The issue
 
-At every boot, Home Assistant checks the integrity of its storage partitions. This check failed on the data partition, which means the filesystem is corrupted — files may be missing, unreadable, or in an inconsistent state.
+At every boot, Home Assistant checks the integrity of its storage partitions. This check failed on the data partition, which means the filesystem is corrupted. Files may be missing, unreadable, or in an inconsistent state.
 
-The data partition stores your configuration, automations, add-ons, and backups. This is most commonly caused by an unexpected power loss or a failing storage device (SD card, USB drive, or eMMC).
+The data partition stores your configuration, automations, apps, and backups. This is most commonly caused by an unexpected power loss or a failing storage device (such as an SD card, USB drive, or eMMC).
 
 ## The solution
 

--- a/source/more-info/unhealthy/data_filesystem_check_error.md
+++ b/source/more-info/unhealthy/data_filesystem_check_error.md
@@ -11,23 +11,19 @@ The data partition stores your configuration, automations, add-ons, and backups.
 
 ## The solution
 
-Try rebooting your system first. The filesystem check may be able to repair minor corruption automatically on the next boot attempt.
-
-{% my hardware badge %}
+Try rebooting your system first. The filesystem check may be able to repair minor corruption automatically on the next boot attempt. You can reboot by going to {% my hardware title="**Settings** > **System** > **Hardware**" %}, opening the menu in the top right corner, and selecting **Reboot system**.
 
 If the system is still accessible after rebooting, create a full [backup][backups] immediately and download it to another device before doing anything else.
 
 {% my supervisor_backups badge %}
 
-If the issue persists, you can wipe and reformat the data partition using the CLI. Note that this erases all data on the partition, so you will need to restore from a backup afterwards. If the underlying cause is a failing storage device, this may not resolve the issue permanently.
+If the issue persists, you can wipe and reformat the data disk from the local terminal (a monitor and keyboard connected to your Home Assistant device) by running the command below. Note that this deletes all user data, automatically reboots your system, and reinstalls the Home Assistant components, so you will need to restore from a backup afterwards. If the underlying cause is a failing storage device, this may not resolve the issue permanently.
 
 ```bash
 ha os datadisk wipe
 ```
 
-If the data partition is on a failing physical device, move it to a new one before restoring your backup. You can do this from the Storage page in your settings.
-
-{% my storage badge %}
+If the data partition is on a failing physical device, move it to a new one before restoring your backup. You can do this from {% my storage title="**Settings** > **System** > **Storage**" %}.
 
 Once the data partition is ready, restore from your backup.
 

--- a/source/more-info/unhealthy/data_filesystem_check_error.md
+++ b/source/more-info/unhealthy/data_filesystem_check_error.md
@@ -13,11 +13,11 @@ The data partition stores your configuration, automations, add-ons, and backups.
 
 Try rebooting your system first. The filesystem check may be able to repair minor corruption automatically on the next boot attempt.
 
-{% my hardware badge title="**Settings** > **System** > **Hardware**" %}
+{% my hardware badge %}
 
 If the system is still accessible after rebooting, create a full backup immediately and download it to another device before doing anything else.
 
-{% my supervisor_backups badge title="**Settings** > **System** > **Backups**" %}
+{% my supervisor_backups badge %}
 
 If the issue persists, you can wipe and reformat the data partition using the CLI:
 
@@ -27,7 +27,7 @@ ha os datadisk wipe
 
 If the data partition is on a failing physical device, move it to a new one before restoring your backup. You can do this from the Storage page in your settings.
 
-{% my storage badge title="**Settings** > **System** > **Storage**" %}
+{% my storage badge %}
 
 Once the data partition is ready, restore from your backup.
 

--- a/source/more-info/unhealthy/os_filesystem_check_error.md
+++ b/source/more-info/unhealthy/os_filesystem_check_error.md
@@ -1,0 +1,28 @@
+---
+title: "Filesystem check failed on an OS partition"
+description: "More information on what to do when a filesystem check fails on a Home Assistant OS partition."
+---
+
+## The issue
+
+At every boot, Home Assistant checks the integrity of its storage partitions. This check failed on one of the OS partitions, which means the filesystem is corrupted — files may be missing, unreadable, or in an inconsistent state.
+
+This is most commonly caused by an unexpected power loss or a failing storage device (SD card, USB drive, or eMMC).
+
+Your data partition — which stores your configuration, automations, and add-ons — is on a separate partition and is not affected by this issue.
+
+## The solution
+
+Try rebooting your system first. Home Assistant OS uses two OS slots, so the system may switch to a healthy slot automatically, and the check may pass on the next boot.
+
+{% my hardware badge title="**Settings** > **System** > **Hardware**" %}
+
+If the issue persists and the storage device holding the OS is failing, you can replace it without losing your data:
+
+1. Install Home Assistant OS on the new device.
+2. Connect the device holding your data partition to the new installation.
+3. Home Assistant OS will detect the existing data and offer to adopt it, letting you pick up right where you left off.
+
+If your data partition is on the same physical device as the OS, make sure you have a recent backup downloaded to another device before replacing the storage.
+
+{% my supervisor_backups badge title="**Settings** > **System** > **Backups**" %}

--- a/source/more-info/unhealthy/os_filesystem_check_error.md
+++ b/source/more-info/unhealthy/os_filesystem_check_error.md
@@ -13,9 +13,7 @@ Your data partition — which stores your configuration, automations, and add-on
 
 ## The solution
 
-Try rebooting your system first. Home Assistant OS uses two OS slots, so the system may switch to a healthy slot automatically, and the check may pass on the next boot.
-
-{% my hardware badge %}
+Try rebooting your system first. Home Assistant OS uses two OS slots, so the system may switch to a healthy slot automatically, and the check may pass on the next boot. You can reboot by going to {% my hardware title="**Settings** > **System** > **Hardware**" %}, opening the menu in the top right corner, and selecting **Reboot system**.
 
 If the issue persists and the storage device holding the OS is failing, you can replace it without losing your data:
 

--- a/source/more-info/unhealthy/os_filesystem_check_error.md
+++ b/source/more-info/unhealthy/os_filesystem_check_error.md
@@ -5,11 +5,11 @@ description: "More information on what to do when a filesystem check fails on a 
 
 ## The issue
 
-At every boot, Home Assistant checks the integrity of its storage partitions. This check failed on one of the OS partitions, which means the filesystem is corrupted — files may be missing, unreadable, or in an inconsistent state.
+At every boot, Home Assistant checks the integrity of its storage partitions. This check failed on one of the OS partitions, which means the filesystem is corrupted. Files may be missing, unreadable, or in an inconsistent state.
 
 This is most commonly caused by an unexpected power loss or a failing storage device (SD card, USB drive, or eMMC).
 
-Your data partition — which stores your configuration, automations, and add-ons — is on a separate partition and is not affected by this issue.
+Your data partition—which stores your configuration, automations, and add-ons—is on a separate partition and is not affected by this issue.
 
 ## The solution
 

--- a/source/more-info/unhealthy/os_filesystem_check_error.md
+++ b/source/more-info/unhealthy/os_filesystem_check_error.md
@@ -15,7 +15,7 @@ Your data partition — which stores your configuration, automations, and add-on
 
 Try rebooting your system first. Home Assistant OS uses two OS slots, so the system may switch to a healthy slot automatically, and the check may pass on the next boot.
 
-{% my hardware badge title="**Settings** > **System** > **Hardware**" %}
+{% my hardware badge %}
 
 If the issue persists and the storage device holding the OS is failing, you can replace it without losing your data:
 
@@ -25,4 +25,4 @@ If the issue persists and the storage device holding the OS is failing, you can 
 
 If your data partition is on the same physical device as the OS, make sure you have a recent backup downloaded to another device before replacing the storage.
 
-{% my supervisor_backups badge title="**Settings** > **System** > **Backups**" %}
+{% my supervisor_backups badge %}


### PR DESCRIPTION
## Proposed change

Adds documentation pages for the two new unhealthy reasons introduced in [home-assistant/supervisor#6976](https://github.com/home-assistant/supervisor/pull/6976): `os_filesystem_check_error` and `data_filesystem_check_error`. These are triggered when `fsck` fails on the OS or data partition at boot, indicating filesystem corruption.

Each page explains what the failure means in plain language and provides remediation steps appropriate to the affected partition.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/supervisor/pull/6976
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards