### PR TITLE
Document disabling the container log file

### DIFF
--- a/source/_integrations/logger.markdown
+++ b/source/_integrations/logger.markdown
@@ -167,4 +167,4 @@ Or read the file directly:
 tail -f /config/home-assistant.log
 ```
 
-To only use the container runtime logs and avoid writing `home-assistant.log`, set the `HA_DISABLE_LOG_FILE` environment variable to a truthy value, such as `1` or `true`. When the log file is disabled, `/config/home-assistant.log` is not available, and **Show raw logs** and log file download in the Home Assistant UI are unavailable.
+To rely only on the container runtime logs and prevent Home Assistant from writing `home-assistant.log`, set the `HA_DISABLE_LOG_FILE` environment variable to `1` (or `true`). When the log file is disabled, `/config/home-assistant.log` is not available, and you cannot enable **Show raw logs** or download the log file in the Home Assistant UI.

--- a/source/_integrations/logger.markdown
+++ b/source/_integrations/logger.markdown
@@ -166,3 +166,5 @@ Or read the file directly:
 ```bash
 tail -f /config/home-assistant.log
 ```
+
+To only use the container runtime logs and avoid writing `home-assistant.log`, set the `HA_DISABLE_LOG_FILE` environment variable to `1`. When the log file is disabled, the raw log view and log file download in the Home Assistant UI are unavailable.

--- a/source/_integrations/logger.markdown
+++ b/source/_integrations/logger.markdown
@@ -167,4 +167,4 @@ Or read the file directly:
 tail -f /config/home-assistant.log
 ```
 
-To only use the container runtime logs and avoid writing `home-assistant.log`, set the `HA_DISABLE_LOG_FILE` environment variable to `1`. When the log file is disabled, the raw log view and log file download in the Home Assistant UI are unavailable.
+To only use the container runtime logs and avoid writing `home-assistant.log`, set the `HA_DISABLE_LOG_FILE` environment variable to a true boolean value, such as `1`, `true`, `yes`, `on`, or `enable`. When the log file is disabled, `/config/home-assistant.log` is not available, and **Show raw logs** and log file download in the Home Assistant UI are unavailable.

--- a/source/_integrations/logger.markdown
+++ b/source/_integrations/logger.markdown
@@ -167,4 +167,4 @@ Or read the file directly:
 tail -f /config/home-assistant.log
 ```
 
-To only use the container runtime logs and avoid writing `home-assistant.log`, set the `HA_DISABLE_LOG_FILE` environment variable to a true boolean value, such as `1`, `true`, `yes`, `on`, or `enable`. When the log file is disabled, `/config/home-assistant.log` is not available, and **Show raw logs** and log file download in the Home Assistant UI are unavailable.
+To only use the container runtime logs and avoid writing `home-assistant.log`, set the `HA_DISABLE_LOG_FILE` environment variable to a truthy value, such as `1` or `true`. When the log file is disabled, `/config/home-assistant.log` is not available, and **Show raw logs** and log file download in the Home Assistant UI are unavailable.


### PR DESCRIPTION
## Proposed change

Document the `HA_DISABLE_LOG_FILE` environment variable for Home Assistant Container installations on the Logger integration page. This explains how to rely only on container runtime logs and calls out that raw log view and log download are unavailable when Home Assistant is not writing `home-assistant.log`.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: home-assistant/core#170374
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
