### PR TITLE
Document CCM15 installation parameters

### DIFF
--- a/source/_integrations/ccm15.markdown
+++ b/source/_integrations/ccm15.markdown
@@ -24,6 +24,13 @@ There is currently support for the following device types within Home Assistant:
 
 {% include integrations/config_flow.md %}
 
+{% configuration_basic %}
+Host:
+  description: The hostname or IP address of your CCM15 controller.
+Port:
+  description: The TCP port of the CCM15 controller's HTTP interface.
+{% endconfiguration_basic %}
+
 ## Climate
 
 Each data controller can support up to 64 `climate` devices.


### PR DESCRIPTION
## Proposed change

Document the CCM15 installation parameters by adding a `configuration_basic`
block describing the **Host** and **Port** config-flow fields.

This covers the Silver `docs-installation-parameters` quality-scale rule for the
`ccm15` integration, which is being raised from Bronze to Silver in the codebase
PR linked below. The wording matches the `data_description` strings shown in the
config flow.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: home-assistant/core#174945
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
