### PR TITLE
Support overriding delay_time when triggering an alarm control panel

### DIFF
--- a/source/_actions/alarm_control_panel.alarm_trigger.markdown
+++ b/source/_actions/alarm_control_panel.alarm_trigger.markdown
@@ -2,7 +2,7 @@
 title: "Trigger alarm"
 action: alarm_control_panel.alarm_trigger
 domain: alarm_control_panel
-description: "Manually trigger an alarm control panel. Optionally provide a code if your alarm panel requires one."
+description: "Manually trigger an alarm control panel. Optionally provide a code if your alarm panel requires one and override pending delay."
 related_actions:
   - alarm_control_panel.alarm_disarm
 ---
@@ -30,6 +30,9 @@ To trigger an alarm from an automation or a script:
 Code:
   description: The code to trigger the alarm. Not every alarm panel requires a code for triggering.
   required: false
+Delay time:
+  description: The overriden time of the ‘pending’ state before triggering the alarm.
+  required: false
 {% endoptions_ui %}
 
 {% include actions/yaml_header.md %}
@@ -56,6 +59,17 @@ action: |
     code: "1234"
 {% endexample %}
 
+If you need to override the time of 'pending' state provided by the alarm configuration, specify the delay time in the `data` section:
+
+{% example %}
+action: |
+  action: alarm_control_panel.alarm_trigger
+  target:
+    entity_id: alarm_control_panel.home_alarm
+  data:
+    delay_time: 0
+{% endexample %}
+
 ### Options in YAML
 
 {% options_yaml %}
@@ -64,6 +78,11 @@ code:
     The code to trigger the alarm. Not every alarm panel requires a code for triggering.
   required: false
   type: string
+delay_time:
+  description: >
+    Time of 'pending' state before triggering the alarm. Overrides the value provided in the alarm configuration. Not every alarm panel supports overriding the delay.
+  required: false
+  type: integer
 {% endoptions_yaml %}
 
 {% include actions/targets.md %}

--- a/source/_actions/alarm_control_panel.alarm_trigger.markdown
+++ b/source/_actions/alarm_control_panel.alarm_trigger.markdown
@@ -80,7 +80,7 @@ code:
   type: string
 delay_time:
   description: >
-    Time of 'pending' state before triggering the alarm. Overrides the value provided in the alarm configuration. Not every alarm panel supports overriding the delay.
+    Time in seconds that the alarm stays in the `pending` state before it triggers. Overrides the delay configured on the alarm control panel. Set to 0 to trigger immediately. Not every alarm panel supports overriding the delay.
   required: false
   type: integer
 {% endoptions_yaml %}

--- a/source/_actions/alarm_control_panel.alarm_trigger.markdown
+++ b/source/_actions/alarm_control_panel.alarm_trigger.markdown
@@ -31,7 +31,7 @@ Code:
   description: The code to trigger the alarm. Not every alarm panel requires a code for triggering.
   required: false
 Delay time:
-  description: The overriden time of the ‘pending’ state before triggering the alarm.
+  description: The overridden time of the 'pending' state before triggering the alarm.
   required: false
 {% endoptions_ui %}
 

--- a/source/_actions/alarm_control_panel.alarm_trigger.markdown
+++ b/source/_actions/alarm_control_panel.alarm_trigger.markdown
@@ -2,7 +2,7 @@
 title: "Trigger alarm"
 action: alarm_control_panel.alarm_trigger
 domain: alarm_control_panel
-description: "Manually trigger an alarm control panel. Optionally provide a code if your alarm panel requires one and override pending delay."
+description: "Manually trigger an alarm control panel. Optionally provide a code if your alarm panel requires one. If supported, you can also override the pending delay."
 related_actions:
   - alarm_control_panel.alarm_disarm
 ---
@@ -31,7 +31,7 @@ Code:
   description: The code to trigger the alarm. Not every alarm panel requires a code for triggering.
   required: false
 Delay time:
-  description: The overridden time of the 'pending' state before triggering the alarm.
+  description: Time in seconds to keep the alarm in the `pending` state before it triggers. Set to 0 to trigger immediately.
   required: false
 {% endoptions_ui %}
 
@@ -59,7 +59,7 @@ action: |
     code: "1234"
 {% endexample %}
 
-If you need to override the time of 'pending' state provided by the alarm configuration, specify the delay time in the `data` section:
+To override the pending delay configured on the alarm control panel, set `delay_time` in the `data` section:
 
 {% example %}
 action: |


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Improve the `alarm_control_panel.alarm_trigger` action to support overriding the `delay_time` set in the configuration.

The main use case is to support various delays depending on what sensors triggers the alarm. If it's the entrance door, maybe you need 30s but if it's the back door that is further away from the panel, you need another minute to reach it. And if it's an opening sensor on the wooden shutters, you don't want any delay at all!

In this PR, only the "manual" alarm control panel has been modified to truly support overriding the delay.

The only modification in other alarm panels is the change in the prototype of their `async_alarm_trigger` method, to take the new `delay_time` as optional parameter. But they don't do anything with it.

Example of an alarm configured with:

```yaml
alarm_control_panel:
  - platform: manual
    name: My Alarm
    unique_id: my_alarm
    code: '1234'
    delay_time: 60
```

This PR makes it possible to trigger it without any 'pending' state at all, like so:

```yaml
action: alarm_control_panel.alarm_trigger
target:
  entity_id: alarm_control_panel.home_alarm
data:
  delay_time: 0
```

Of course, this `delay_time` is optional and the delay set in the config is used when not set in the action (60s in the example above).

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/174980
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue:

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - **I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.**
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
