### PR TITLE
notify: migrate actions to split docs

### DIFF
--- a/source/_actions/notify.notify.markdown
+++ b/source/_actions/notify.notify.markdown
@@ -1,0 +1,165 @@
+---
+title: "Send a notification"
+action: notify.notify
+domain: notify
+description: "Sends a notification message to selected targets."
+related_actions:
+  - notify.send_message
+  - notify.persistent_notification
+---
+
+The **Send a notification** action sends a message through the legacy notify action. Use it when a notify integration has not moved to notify entities yet, or when an existing automation still uses the generic `notify.notify` action.
+
+When possible, choose a specific notify entity and use [Send a notification message](/actions/notify.send_message/) instead. Specific targets make it clearer where the message goes.
+
+{% include actions/ui_header.md %}
+
+To send a notification from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create** to start a new one.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Send a notification**.
+6. In **Message**, enter the notification text.
+7. _Optional_: In **Title**, enter a title for the notification.
+8. _Optional_: Use **Target** or **Data** if the notify integration supports those fields.
+9. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Message:
+  description: Message body of the notification.
+  required: true
+Title:
+  description: Title for your notification.
+  required: false
+Target:
+  description: Some integrations allow you to specify which recipients receive the notification. Support and accepted values depend on the notify integration.
+  required: false
+Data:
+  description: Additional data for integrations that provide extended notification features. Support and accepted values depend on the notify integration.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `notify.notify`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: notify.notify
+  data:
+    message: "The garage door has been open for 10 minutes."
+{% endexample %}
+
+This sends a message through the first notify action Home Assistant can find.
+
+### Options in YAML
+
+{% options_yaml %}
+message:
+  description: >
+    Message body of the notification.
+  required: true
+  type: string
+title:
+  description: >
+    Title for your notification.
+  required: false
+  type: string
+target:
+  description: >
+    Optional recipient targets. Support and accepted values depend on the notify integration.
+  required: false
+  type: list
+data:
+  description: >
+    Additional data for integrations that provide extended notification features. Support and accepted values depend on the notify integration.
+  required: false
+  type: map
+{% endoptions_yaml %}
+
+## Good to know
+
+- `notify.notify` is shorthand for the first notify action Home Assistant can find. It might not send the message to the place you expect.
+- Prefer a specific action, such as `notify.send_message` with a notify entity, when one is available.
+- The `target` and `data` fields are integration-specific. Check the documentation for the notify integration you use before adding them.
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: send a generic reminder notification
+
+Send a reminder through the generic notify action every weekday morning.
+
+- **Trigger**: Time: 08:00
+- **Condition**: Day of the week is Monday to Friday
+- **Action**: Send a notification
+  - **Message**: Remember to check today's calendar.
+
+{% details "YAML example for a weekday reminder notification" %}
+
+{% example %}
+automation: |
+  alias: "Send a weekday reminder notification"
+  triggers:
+    - trigger: time
+      at: "08:00:00"
+  conditions:
+    - condition: time
+      weekday:
+        - mon
+        - tue
+        - wed
+        - thu
+        - fri
+  actions:
+    - action: notify.notify
+      data:
+        message: "Remember to check today's calendar."
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: send a generic notification when motion is detected
+
+Send a notification when motion is detected while nobody is home.
+
+- **Trigger**: State
+  - **Entity**: Hall motion (`binary_sensor.hall_motion`)
+  - **To**: On
+- **Condition**: State
+  - **Entity**: Paulus (`person.paulus`)
+  - **State**: Not home
+- **Action**: Send a notification
+  - **Title**: Motion detected
+  - **Message**: Hall motion was detected while nobody was home.
+
+{% details "YAML example for a motion notification" %}
+
+{% example %}
+automation: |
+  alias: "Send a motion notification when nobody is home"
+  triggers:
+    - trigger: state
+      entity_id: binary_sensor.hall_motion
+      to: "on"
+  conditions:
+    - condition: state
+      entity_id: person.paulus
+      state: not_home
+  actions:
+    - action: notify.notify
+      data:
+        title: "Motion detected"
+        message: "Hall motion was detected while nobody was home."
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/notify.persistent_notification.markdown
+++ b/source/_actions/notify.persistent_notification.markdown
@@ -1,0 +1,151 @@
+---
+title: "Send a persistent notification"
+action: notify.persistent_notification
+domain: notify
+description: "Sends a notification that is visible in the notifications panel."
+related_actions:
+  - notify.send_message
+  - notify.notify
+---
+
+The **Send a persistent notification** action shows a notification in the Home Assistant interface. Use it for messages you want to keep visible in Home Assistant until someone dismisses them.
+
+Persistent notifications are useful for local reminders, maintenance messages, and other information that should stay available in the notifications panel.
+
+{% include actions/ui_header.md %}
+
+To show a persistent notification from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create** to start a new one.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. From the search box, search for and select **Send a persistent notification**.
+6. In **Message**, enter the notification text.
+7. _Optional_: In **Title**, enter a title for the notification.
+8. _Optional_: In **Data**, add integration-specific data such as a notification ID.
+9. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Message:
+  description: Message body of the notification.
+  required: true
+Title:
+  description: Title of the notification.
+  required: false
+Data:
+  description: Additional data for the notification. You can include a `notification_id` to update an existing notification instead of creating a new one.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `notify.persistent_notification`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: notify.persistent_notification
+  data:
+    title: "Reminder"
+    message: "Check the laundry."
+{% endexample %}
+
+This shows a notification in the Home Assistant notifications panel.
+
+### Options in YAML
+
+{% options_yaml %}
+message:
+  description: >
+    Message body of the notification.
+  required: true
+  type: string
+title:
+  description: >
+    Title of the notification.
+  required: false
+  type: string
+data:
+  description: >
+    Additional data for the notification. You can include `notification_id` to update an existing notification instead of creating a new one.
+  required: false
+  type: map
+{% endoptions_yaml %}
+
+## Good to know
+
+- Persistent notifications appear in the Home Assistant notifications panel, not as push notifications on a phone or browser.
+- A persistent notification stays visible until someone dismisses it or another action updates or removes it.
+- If you include `notification_id` in `data`, Home Assistant updates the existing notification with that ID instead of creating a new notification.
+- To send a message to a notify entity, use [Send a notification message](/actions/notify.send_message/).
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: show a notification when a leak is detected
+
+When a leak sensor detects moisture, show a notification in Home Assistant.
+
+- **Trigger**: State
+  - **Entity**: Kitchen leak sensor (`binary_sensor.kitchen_leak`)
+  - **To**: On
+- **Action**: Send a persistent notification
+  - **Title**: Water leak detected
+  - **Message**: The kitchen leak sensor detected moisture.
+
+{% details "YAML example for a leak notification" %}
+
+{% example %}
+automation: |
+  alias: "Show a kitchen leak notification"
+  triggers:
+    - trigger: state
+      entity_id: binary_sensor.kitchen_leak
+      to: "on"
+  actions:
+    - action: notify.persistent_notification
+      data:
+        title: "Water leak detected"
+        message: "The kitchen leak sensor detected moisture."
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: keep one water leak notification updated
+
+If a leak sensor reports moisture, show or update one persistent notification with the same notification ID.
+
+- **Trigger**: State
+  - **Entity**: Kitchen leak sensor (`binary_sensor.kitchen_leak`)
+  - **To**: On
+- **Action**: Send a persistent notification
+  - **Title**: Water leak detected
+  - **Message**: The kitchen leak sensor detected moisture.
+  - **Data**: `notification_id: kitchen_leak`
+
+{% details "YAML example for updating one leak notification" %}
+
+{% example %}
+automation: |
+  alias: "Show a kitchen leak notification"
+  triggers:
+    - trigger: state
+      entity_id: binary_sensor.kitchen_leak
+      to: "on"
+  actions:
+    - action: notify.persistent_notification
+      data:
+        title: "Water leak detected"
+        message: "The kitchen leak sensor detected moisture."
+        data:
+          notification_id: kitchen_leak
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/notify.send_message.markdown
+++ b/source/_actions/notify.send_message.markdown
@@ -1,0 +1,152 @@
+---
+title: "Send a notification message"
+action: notify.send_message
+domain: notify
+description: "Sends a notification message to one or more notify entities."
+related_actions:
+  - notify.persistent_notification
+  - notify.notify
+---
+
+The **Send a notification message** action sends a message to one or more notify {% term entities %}. Use it when you want an automation or script to send a message to a phone, browser, speaker, or another notification target that provides a notify entity.
+
+This is the recommended action for notify entities. It lets you choose targets the same way you choose other Home Assistant entities: by entity, device, area, floor, or label.
+
+{% include actions/ui_header.md %}
+
+To send a notification from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create** to start a new one.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), pick the notify entity, device, area, floor, or label that should receive the message.
+6. From the actions shown for that target, select **Send a notification message**.
+7. In **Message**, enter the notification text.
+8. _Optional_: In **Title**, enter a title for the notification if the selected notify entity supports titles.
+9. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Message:
+  description: Your notification message.
+  required: true
+Title:
+  description: Title for your notification message. This field is shown only for notify entities that support notification titles.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `notify.send_message`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: notify.send_message
+  target:
+    entity_id: notify.my_device
+  data:
+    message: "The garage door has been open for 10 minutes."
+{% endexample %}
+
+This sends the message to `notify.my_device`.
+
+### Options in YAML
+
+{% options_yaml %}
+message:
+  description: >
+    Your notification message.
+  required: true
+  type: string
+title:
+  description: >
+    Title for your notification message. This field is used only by notify entities that support notification titles.
+  required: false
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/targets.md %}
+
+## Good to know
+
+- The action targets notify entities. If an integration still provides only a legacy notify action, use that integration's action instead.
+- The **Title** field is available only for notify entities that support titles. If the target does not support titles, Home Assistant sends the message without a title.
+- After a message is sent, the notify entity state is updated to the date and time when the message was last sent.
+- To show a notification in the Home Assistant interface instead, use [Send a persistent notification](/actions/notify.persistent_notification/).
+
+{% include actions/try_it.md %}
+
+{% include actions/more_examples.md %}
+
+### Automation: send a notification when the garage door stays open
+
+If the garage door stays open for 10 minutes, send a message to your phone.
+
+- **Trigger**: State
+  - **Entity**: Garage door (`binary_sensor.garage_door`)
+  - **To**: On
+  - **For**: 00:10:00
+- **Action**: Send a notification message
+  - **Target**: My Device (`notify.my_device`)
+  - **Message**: The garage door has been open for 10 minutes.
+
+{% details "YAML example for a garage door notification" %}
+
+{% example %}
+automation: |
+  alias: "Notify when the garage door stays open"
+  triggers:
+    - trigger: state
+      entity_id: binary_sensor.garage_door
+      to: "on"
+      for: "00:10:00"
+  actions:
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_device
+      data:
+        message: >
+          The garage door has been open for 10 minutes.
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: send a notification when someone arrives home
+
+When a person arrives home after dark, send a short message to your device.
+
+- **Trigger**: State
+  - **Entity**: Paulus (`person.paulus`)
+  - **To**: Home
+- **Condition**: Sun is below horizon
+- **Action**: Send a notification message
+  - **Target**: My Device (`notify.my_device`)
+  - **Message**: Paulus arrived home.
+
+{% details "YAML example for an arrival notification" %}
+
+{% example %}
+automation: |
+  alias: "Notify when Paulus arrives home after dark"
+  triggers:
+    - trigger: state
+      entity_id: person.paulus
+      to: home
+  conditions:
+    - condition: sun
+      after: sunset
+  actions:
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_device
+      data:
+        message: "Paulus arrived home."
+{% endexample %}
+
+{% enddetails %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/notify.markdown
+++ b/source/_integrations/notify.markdown
@@ -31,96 +31,88 @@ In addition, the entity can have the following states:
 - **Unavailable**: The entity is currently unavailable.
 - **Unknown**: The state is not yet known.
 
-## Action
-
-The legacy `notify` platform will expose a generic `notify` action that can be called to send notifications.
-
-| Data attribute | Optional | Description                                                                                                                |
-| -------------- | -------- | -------------------------------------------------------------------------------------------------------------------------- |
-| `message`      | no       | Body of the notification.                                                                                                  |
-| `title`        | yes      | Title of the notification.                                                                                                 |
-| `target`       | yes      | Some platforms allow specifying a recipient that will receive the notification. See your platform page if it is supported. |
-| `data`         | yes      | On platforms who have extended functionality. See your platform page if it is supported.                                   |
-
-## Usage
-
-The different **Notify** integrations you have set up will each show up as a different automation {% term action %} that you can use.
-
-One notification integration is automatically included, the Persistent Notifications which creates a notification in the sidebar of the web interface of Home Assistant. This can be chosen with the action named "Notifications: Send a persistent notification" which uses the `notify.persistent_notification` action.
-
-## Notify action
-
-Integrations can also implement the notify entity platform. Entity platform implementations will replace the legacy notify action in time. There is an entity platform action `notify.send_message` which allows you to send notification messages to one or multiple notify entities, mobile phones or other devices. You just need to add them in the `target` block. 
-
-| Data attribute | Optional | Description               |
-| -------------- | -------- | ------------------------  |
-| `message`      | no       | Body of the notification. |
-| `title`        | yes      | Title of the notification.|
+{% include integrations/actions.md %}
 
 ## Companion app notifications
 
-A common notification integration is via the Home Assistant Companion app for Android or iOS. This can be chosen with the action "Send a notification via mobile_app_your_phone_name", which uses the `notify.mobile_app_your_phone_name` action. Refer to the [Companion app documentation](https://companion.home-assistant.io/docs/notifications/notifications-basic) for lots of customization options.
+A common notification integration is via the Home Assistant Companion app for Android or iOS. If your phone is available as a notify entity, use the **Send a notification message** action and select that phone as the target. Some older setups may still provide a phone-specific action such as `notify.mobile_app_your_phone_name`. Refer to the [Companion app documentation](https://companion.home-assistant.io/docs/notifications/notifications-basic) for lots of customization options.
 
-With any of these integrations, the `message` data input in the automation editor is the main text that will be sent. Other fields are optional, and some integrations support additional `data` or `target` information to customize the action. For more details, refer to their integration documentation.
+With any of these integrations, the **Message** field in the automation editor is the main text that will be sent. Other fields are optional, and some integrations support additional **Data** or **Target** information to customize the action. For more details, refer to their integration documentation.
 
 Be aware that the `notify.notify` action is shorthand for the first notify action the system can find. It might not work as intended. Choose a specific action to make sure your message goes to the right place.
 
 Notifications can also be sent using [Notify groups](/integrations/group/#notify-groups). These allow you to send notifications to multiple devices with a single call, or to update which device is notified by only changing it in a single place.
 
-### Test if it works
+## Notifications automation examples
 
-After you set up a [notifier](/integrations/#notifications), a simple way to test if you have set up your notify platform correctly is to open {% my developer_services title="**Settings** > **Developer tools** > **Actions**" %} tab from the sidebar. Choose your action from the **Action** dropdown menu depending on the integration you want to test, such as **Send a persistent notification** or **Send a notification via mobile_app_your_phone_name**. Enter your message into the **Message** field, and select the **Perform action** button.
+Notifications are most useful when Home Assistant sends them at the right moment, such as when something needs your attention or when you want a message to stay visible in the interface. The examples below show two common ways to use notification actions in automations.
 
-To test the entity platform action, select the `notify.send_message` action, and select one or more of `entity`, `device`, `area`, or `label`. Then, supply a `message`.
+{% include docs/paste_yaml_tip.md %}
 
-### Example with the entity platform notify action
+### Automation: send a notification when the garage door stays open
 
-Under {% my developer_services title="**Settings** > **Developer tools** > **Actions**" %}, select the **Send a notification message** action. Select some target entities using the entity selectors, enter a message and test sending it.
+This automation sends a message to your phone when the garage door has been open for 10 minutes.
 
-If you switch to view the YAML data under **Developer tools**, it will appear as below. The same {% term action %} can be chosen in {% term automation %}. The YAML will appear the same:
+- **Trigger**: State
+  - **Entity**: Garage door (`binary_sensor.garage_door`)
+  - **To**: On
+  - **For**: 00:10:00
+- **Action**: Send a notification message
+  - **Target**: My Device (`notify.my_device`)
+  - **Message**: The garage door has been open for 10 minutes.
 
-```yaml
-action: notify.send_message
-data:
-  entity_id: notify.my_direct_message_notifier
-  message: "You have an update!"
-  title: "Status changed"
-```
+{% details "YAML example for a garage door notification" %}
 
-The notify integration supports specifying [templates](/docs/templating/). This will allow you to use the current state of entities in Home Assistant in your notifications, or use more complex logic to decide the message that is sent.
+{% example %}
+automation: |
+  alias: "Notify when the garage door stays open"
+  triggers:
+    - trigger: state
+      entity_id: binary_sensor.garage_door
+      to: "on"
+      for: "00:10:00"
+  actions:
+    - action: notify.send_message
+      target:
+        entity_id: notify.my_device
+      data:
+        message: >
+          The garage door has been open for 10 minutes.
+{% endexample %}
 
-```yaml
-actions:
-  action: notify.send_message
-  data:
-    entity_id: notify.my_direct_message_notifier
-    message: "You have {{ states('todo.shopping_list') }} items on your shopping list."
-```
+{% enddetails %}
 
-### Examples with the legacy notify action
+### Automation: show a persistent notification when a leak is detected
 
-In the **Developer tools**, on the **Action** tab, select the **Send a persistent notification** action. Enter a message and test sending it.
+This automation shows a notification in the Home Assistant interface when a leak sensor detects moisture.
 
-If you switch to view the YAML data under **Developer tools**, it will appear as below. The same {% term action %} can be chosen in {% term automation %} actions, whose YAML will appear the same:
+- **Trigger**: State
+  - **Entity**: Kitchen leak sensor (`binary_sensor.kitchen_leak`)
+  - **To**: On
+- **Action**: Send a persistent notification
+  - **Title**: Water leak detected
+  - **Message**: The kitchen leak sensor detected moisture.
 
-```yaml
-action: notify.persistent_notification
-data:
-  message: "Can you hear me now?"
-```
+{% details "YAML example for a leak notification" %}
 
-The notify integration supports specifying [templates](/docs/templating/). This will allow you to use the current state of entities in Home Assistant in your notifications, or use more complex logic to decide the message that is sent.
+{% example %}
+automation: |
+  alias: "Show a kitchen leak notification"
+  triggers:
+    - trigger: state
+      entity_id: binary_sensor.kitchen_leak
+      to: "on"
+  actions:
+    - action: notify.persistent_notification
+      data:
+        title: "Water leak detected"
+        message: "The kitchen leak sensor detected moisture."
+{% endexample %}
 
-```yaml
-actions:
-  - action: notify.persistent_notification
-    data:
-      message: "You have {{ states('todo.shopping_list') }} items on your shopping list."
-```
+{% enddetails %}
 
-```yaml
-actions:
-  - action: notify.persistent_notification
-    data:
-      message: "The sun is {% if is_state('sun.sun', 'above_horizon') %}up{% else %}down{% endif %}!"
-```
+## Test if it works
+
+After you set up a [notifier](/integrations/#notifications), a simple way to test if you have set up your notify platform correctly is to open {% my developer_services title="**Settings** > **Developer tools** > **Actions**" %} tab from the sidebar. Choose your action from the **Action** dropdown menu depending on the integration you want to test, such as **Send a notification message** or **Send a persistent notification**. Enter your message into the **Message** field, and select the **Perform action** button.
+
+To test the entity platform action, select the `notify.send_message` action, and select one or more of `entity`, `device`, `area`, `floor`, or `label`. Then, supply a `message`.

--- a/source/_integrations/notify.markdown
+++ b/source/_integrations/notify.markdown
@@ -35,7 +35,7 @@ In addition, the entity can have the following states:
 
 ## Companion app notifications
 
-A common notification integration is via the Home Assistant Companion app for Android or iOS. If your phone is available as a notify entity, use the **Send a notification message** action and select that phone as the target. Some older setups may still provide a phone-specific action such as `notify.mobile_app_your_phone_name`. Refer to the [Companion app documentation](https://companion.home-assistant.io/docs/notifications/notifications-basic) for lots of customization options.
+A common notification integration is via the Home Assistant Companion app for Android or iOS. If your phone is available as a notify entity, use the **Send a notification message** action and select that phone as the target. Some older setups may still provide a phone-specific action such as `notify.mobile_app_your_phone_name`. Refer to the [Companion app documentation](https://companion.home-assistant.io/docs/notifications/notifications-basic) for many customization options.
 
 With any of these integrations, the **Message** field in the automation editor is the main text that will be sent. Other fields are optional, and some integrations support additional **Data** or **Target** information to customize the action. For more details, refer to their integration documentation.
 

--- a/source/_integrations/notify.markdown
+++ b/source/_integrations/notify.markdown
@@ -111,8 +111,12 @@ automation: |
 
 {% enddetails %}
 
-## Test if it works
+## Testing a notification action
 
-After you set up a [notifier](/integrations/#notifications), a simple way to test if you have set up your notify platform correctly is to open {% my developer_services title="**Settings** > **Developer tools** > **Actions**" %} tab from the sidebar. Choose your action from the **Action** dropdown menu depending on the integration you want to test, such as **Send a notification message** or **Send a persistent notification**. Enter your message into the **Message** field, and select the **Perform action** button.
+After you set up a [notifier](/integrations/#notifications), test its action from the developer tools.
 
-To test the entity platform action, select the `notify.send_message` action, and select one or more of `entity`, `device`, `area`, `floor`, or `label`. Then, supply a `message`.
+1. Go to {% my developer_services title="**Settings** > **Developer tools** > **Actions**" %}.
+2. From the **Action** dropdown menu, choose the action you want to test, such as **Send a notification message** or **Send a persistent notification**.
+3. If you are testing `notify.send_message`, select one or more targets using **Entity**, **Device**, **Area**, **Floor**, or **Label**.
+4. In **Message**, enter the notification text.
+5. Select **Perform action**.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change

Migrate actions for [notifications](https://www.home-assistant.io/integrations/notify/) to current style.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: related to https://github.com/home-assistant/epics/issues/96

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
