### PR TITLE
Revise and extend Zigbee updates and details in 2026.7 Beta release notes

### DIFF
--- a/source/_posts/2026-07-01-release-20267.markdown
+++ b/source/_posts/2026-07-01-release-20267.markdown
@@ -510,7 +510,7 @@ Thanks, [@balloob]!
 
 ### Zigbee got some major overhauls
 
-Home Assistant's built-in Zigbee gateway, the [ZHA integartion](/integrations/zha/) got part of its UI overhauled and a major changes under-the-hood to how custom ZHA Device Handlers (a.k.a. zha-quirks) for Zigbee devices are made and handled.
+Home Assistant's built-in Zigbee gateway, the [ZHA integration](/integrations/zha/), got a refresh to parts of its UI. It also includes major behind-the-scenes changes to how custom ZHA device handlers (also known as `zha-quirks`) are created and managed.
 
 #### ZHA Zigbee device management got UX improvements
 
@@ -537,9 +537,9 @@ Thanks, [@puddly] and [@TheJulianJES]!
 
 #### Public beta of Ziggurat Zigbee-stack
 
-This release also includes support for a public beta of [Ziggurat](https://github.com/zigpy/ziggurat/), a 100% open-source, Rust-based host-side Zigbee-stack that can replace closed-source Zigbee Coordinator firmware on Zigbee adapters. 
+This release also includes support for a public beta of [Ziggurat](https://github.com/zigpy/ziggurat/), a 100% open-source, Rust-based, host-side Zigbee stack that can replace closed-source Zigbee coordinator firmware on supported Zigbee adapters. 
 
-It is meant to replace the closed-source Zigbee Coordinator firmware on any Zigbee adapter with OpenThread RCP ([more info](https://github.com/zigpy/ziggurat/#ziggurat)) and runs inside of a new Home Assistant [app](https://github.com/zigpy/addons). 
+It is designed to run with an OpenThread RCP ([more info](https://github.com/zigpy/ziggurat/#ziggurat)) and is packaged as an Home Assistant [app](https://github.com/zigpy/addons).
 
 Ziggurat is fast, 100% open source, written in safe Rust, and lets your Zigbee network benefit from the computing power of a general purpose computer.
 

--- a/source/_posts/2026-07-01-release-20267.markdown
+++ b/source/_posts/2026-07-01-release-20267.markdown
@@ -526,9 +526,9 @@ Thanks, [@jpbede]!
 
 #### ZHA libraries updated to new major release
 
-The built-in Zigbee gateway, the [ZHA integration(/integrations/zha/), got all of its libraries (zigpy, zha, and zha-device-handlers) updated to 2.0.0 version. 
+The built-in Zigbee gateway, the [ZHA integration](/integrations/zha/), got all of its libraries (zigpy, zha, and zha-device-handlers) updated to version 2.0.0.
 
-This are major releases because they completely invert and revamp the Quirks API for ZHA Device Handlers so that it will allow the community to faster add support for new and complex Zigbee devices, (which is a [wanted change tracked on the Open Home Foundation's roadmap]( https://github.com/OpenHomeFoundation/roadmap/issues/194)).
+These major releases revamp the quirks API for ZHA device handlers, making it faster for the community to add support for new and complex Zigbee devices (a [requested change tracked on the Open Home Foundation roadmap](https://github.com/OpenHomeFoundation/roadmap/issues/194)).
 
 Thanks, [@puddly] and [@TheJulianJES]!
 

--- a/source/_posts/2026-07-01-release-20267.markdown
+++ b/source/_posts/2026-07-01-release-20267.markdown
@@ -102,7 +102,10 @@ Enjoy the (beta) release!
 - [Other noteworthy changes](#other-noteworthy-changes)
   - [Time format selection](#time-format-selection)
   - [Dedicated panels for infrared and radio frequency](#dedicated-panels-for-infrared-and-radio-frequency)
-  - [The ZHA Zigbee device management got an overhaul](#the-zha-zigbee-device-management-got-an-overhaul)
+  - [Zigbee got some major overhauls](#zigbee-got-some-major-overhauls)
+    - [ZHA Zigbee device management got UX improvements](#zha-zigbee-device-management-got-ux-improvements)
+    - [ZHA libraries updated to new major release](#zha-libraries-updated-to-new-major-release)
+    - [Public beta of Ziggurat Zigbee-stack](#public-beta-of-ziggurat-zigbee-stack)
 - [Need help? Join the community](#need-help-join-the-community)
 - [Backward-incompatible changes](#backward-incompatible-changes)
 - [All changes](#all-changes)
@@ -504,7 +507,12 @@ Thanks, [@balloob]!
 
 [@balloob]: https://github.com/balloob
 
-### The ZHA Zigbee device management got an overhaul
+
+### Zigbee got some major overhauls
+
+Home Assistant's built-in Zigbee gateway, the [ZHA integartion](/integrations/zha/) got part of its UI overhauled and a major changes under-the-hood to how custom ZHA Device Handlers (a.k.a. zha-quirks) for Zigbee devices are made and handled.
+
+#### ZHA Zigbee device management got UX improvements
 
 Managing a Zigbee device through [ZHA](/integrations/zha/) used to mean squinting at a cramped dialog. The clusters, bindings, signature, and neighbors tools were all there, but crammed into a small popup that left little room to breathe.
 
@@ -515,6 +523,29 @@ This release moves all of that onto a dedicated, full-page device view. The same
 Thanks, [@jpbede]!
 
 [@jpbede]: https://github.com/jpbede
+
+#### ZHA libraries updated to new major release
+
+The built-in Zigbee gateway, the [ZHA integration(/integrations/zha/), got all of its libraries (zigpy, zha, and zha-device-handlers) updated to 2.0.0 version. 
+
+This are major releases because they completely invert and revamp the Quirks API for ZHA Device Handlers so that it will allow the community to faster add support for new and complex Zigbee devices, (which is a [wanted change tracked on the Open Home Foundation's roadmap]( https://github.com/OpenHomeFoundation/roadmap/issues/194)).
+
+Thanks, [@puddly] and [@TheJulianJES]!
+
+[@puddly]: https://github.com/puddly
+[@TheJulianJES]: https://github.com/TheJulianJES
+
+#### Public beta of Ziggurat Zigbee-stack
+
+This release also includes support for a public beta of [Ziggurat](https://github.com/zigpy/ziggurat/), a 100% open-source, Rust-based host-side Zigbee-stack that can replace closed-source Zigbee Coordinator firmware on Zigbee adapters. 
+
+It is meant to replace the closed-source Zigbee Coordinator firmware on any Zigbee adapter with OpenThread RCP ([more info](https://github.com/zigpy/ziggurat/#ziggurat)) and runs inside of a new Home Assistant [app](https://github.com/zigpy/addons). 
+
+Ziggurat is fast, 100% open source, written in safe Rust, and lets your Zigbee network benefit from the computing power of a general purpose computer.
+
+Thanks, [@puddly]!
+
+[@puddly]: https://github.com/puddly
 
 ## Need help? Join the community
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Updated the Zigbee section in 2026.7 Beta release notes to reflect major changes, including UX improvements, major library updates which change how quirks for Zigbee devices are made for ZHA, and the introduction of the new Ziggurat Zigbee-stack as public beta.

Ping @puddly @TheJulianJES

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

It was not mentioned in the beta release-notes is that all the libraries for the ZHA (Zigbee) integartion has been bumped to 2.0.0 version because they contain a major update with a huge change where the Quirks API for ZHA Device Handlers is now fully revamped which is first step to make adding support for new Zigbee devices simpler so that the ZHA community can support advanced/complex devices more quickly: 

* https://github.com/home-assistant/core/pull/174586
  * https://github.com/zigpy/zha-device-handlers/pull/5113  
  * https://github.com/zigpy/zha/pull/762
  * https://github.com/zigpy/zigpy/pull/1846

  "_**Our quirks API is now fully revamped: complex ZHA entities can now be created entirely within with quirks, allowing for faster community support of new devices and new complex devices.**_"

For reference, the first major step towards improving zigpy/zha APIs to make adding new devices simpler so that the ZHA community can support new devices more quickly. See that this is also raised and tracked as an Open Home Foundation roadmap item too:

* https://github.com/OpenHomeFoundation/roadmap/issues/194

Note that niether ZHA integration documentation or repository description and readme files has been updated yet to reflect these changes, see:

* https://github.com/home-assistant/home-assistant.io/pull/46445

and

* https://github.com/zigpy/zha-device-handlers/discussions/5129


Ziggurat now in public beta was also mentioned in https://github.com/home-assistant/core/pull/174586 as a kind of stealth announcement

* https://github.com/zigpy/ziggurat/
  * https://github.com/zigpy/zigpy-ziggurat
    *   * https://github.com/zigpy/addons

An alternative could be to make a new dedicated Home Assistant blog-post to high-light all the major change ZHA under the hood 😀   It is kind of a huge dubble-whammy by announcing both the major zha and zigpy libaries updates that change how quirks works and Open Home Foundation's new fully open-source host-side Zigbee stack, [Ziggurat](https://github.com/zigpy/ziggurat/) that was not yet mentioned in the release notes but is now in public beta and possible to use with the Home Assistant 2026.7 release and later. Ziggurat can replace closed-source Zigbee Coordinator firmware on any Zigbee adapter with OpenThread RCP ([more info](https://github.com/zigpy/ziggurat/#ziggurat)) and runs inside of a Home Assistant [app](https://github.com/zigpy/addons). Ziggurat is not yet mature, but it is 100% open source, very *fast*, written in safe Rust, and lets your Zigbee network benefit from the computing power of a general purpose computer.

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
