### PR TITLE
ViCare: add "Invalid redirection URI" troubleshooting, drop obsolete password note

### DIFF
--- a/source/_integrations/vicare.markdown
+++ b/source/_integrations/vicare.markdown
@@ -98,7 +98,7 @@ Additional data for a device is available as separate sensors. The sensors are a
 
 ### Button
 
-Button entities are available for actions such as triggering a one-time charge of the water heater.
+Button entities are available to trigger actions like a one-time charge of the water heater.
 
 ### Number
 
@@ -134,15 +134,13 @@ The `climate.set_preset_mode` action supports the *eco* and *comfort* preset mod
 
 ### Invalid redirection URI
 
-If you get this error in the browser when adding or re-authenticating the integration:
+When adding or re-authenticating the integration, you get this error in the browser:
 
-`{"error":"invalid_request", "error_description":"Invalid redirection URI."}`
+```text
+{"error":"invalid_request", "error_description":"Invalid redirection URI."}
+```
 
-set the **Redirect URIs** on your API client in the [Viessmann developer portal](https://app.developer.viessmann-climatesolutions.com) to exactly:
-
-`https://my.home-assistant.io/redirect/oauth`
-
-Save the client (it may take up to an hour to become active) and try again.
+Set the **Redirect URIs** on your API client in the [Viessmann developer portal](https://app.developer.viessmann-climatesolutions.com) to exactly `https://my.home-assistant.io/redirect/oauth`, save (it may take up to an hour to become active), and try again.
 
 ### GATEWAY_OFFLINE
 

--- a/source/_integrations/vicare.markdown
+++ b/source/_integrations/vicare.markdown
@@ -32,7 +32,7 @@ Most recent network-connected Viessmann heating devices (e.g., gas boilers) shou
 
 ## Prerequisites
 
-You will need to sign in on the [Viessmann developer portal](https://app.developer.viessmann-climatesolutions.com) with **your existing ViCare app user credentials**.
+You will need to sign in to the [Viessmann developer portal](https://app.developer.viessmann-climatesolutions.com) with **your existing ViCare app user credentials**.
 
 Create a new API client by selecting **Add** in the **Clients** section on the developer dashboard with the following settings:
    - Name: `HomeAssistant`
@@ -59,7 +59,7 @@ For the paid API plans this limit increases to 3000 calls in 24 hours. The {% te
 {% important %}
 For any Viessmann API plan except the most expensive "Advanced" tier, Viessmann imposes certain limits on which APIs are accessible for end-user consumption. Unfortunately, this also affects APIs useful for smart home integrations, like controlling thermostats (TRVs) and climate sensors, which are only available in the "Advanced" plan API tier. In case you set up the integration with a lower-tier plan, TRVs and other smart home entities will not become accessible in your Home Assistant installation.
 
-Please consider providing feedback to Viessmann as described in [their FAQ](https://developer.viessmann-climatesolutions.com/start/faq.html) "Where can I give feedback on the API?" in case you consider this as a limitation for your use-case.
+Please consider providing feedback to Viessmann as described in [their FAQ](https://developer.viessmann-climatesolutions.com/start/faq.html) "Where can I give feedback on the API?" if you consider this a limitation for your use case.
 {% endimportant %}
 
 {% note %}
@@ -98,7 +98,7 @@ Additional data for a device is available as separate sensors. The sensors are a
 
 ### Button
 
-Button entities are available for triggering like a one-time charge of the water heater.
+Button entities are available for actions such as triggering a one-time charge of the water heater.
 
 ### Number
 
@@ -132,9 +132,17 @@ The `climate.set_preset_mode` action supports the *eco* and *comfort* preset mod
 
 ## Troubleshooting
 
-### UTF-8 characters in passwords
+### Invalid redirection URI
 
-The underlying PyViCare Python library cannot handle UTF-8 characters in passwords, so do not use for example `ü` or `ø` in passwords.
+If you get this error in the browser when adding or re-authenticating the integration:
+
+`{"error":"invalid_request", "error_description":"Invalid redirection URI."}`
+
+set the **Redirect URIs** on your API client in the [Viessmann developer portal](https://app.developer.viessmann-climatesolutions.com) to exactly:
+
+`https://my.home-assistant.io/redirect/oauth`
+
+Save the client (it may take up to an hour to become active) and try again.
 
 ### GATEWAY_OFFLINE
 


### PR DESCRIPTION
## Proposed change

The ViCare integration moved to OAuth2 (PKCE) authentication. Two documentation
updates for that, plus minor readability fixes:

- Add an **Invalid redirection URI** troubleshooting entry. Users migrating from
  an older setup hit `{"error":"invalid_request", "error_description":"Invalid
  redirection URI."}` when re-authentication is needed and their API client's
  redirect URI does not match the one Home Assistant uses. The entry is
  searchable by the error string and explains how to fix it.
- Remove the **UTF-8 characters in passwords** entry. The config flow no longer
  accepts a password (authentication happens on the Viessmann web login via
  OAuth2), so the note is obsolete.
- Minor grammar fixes (sign in to, use case, Button section wording).

## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [x] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #46562

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
