### PR TITLE
NuHeat: migrate actions to dedicated pages

### DIFF
--- a/source/_actions/nuheat.set_hvac_mode.markdown
+++ b/source/_actions/nuheat.set_hvac_mode.markdown
@@ -1,0 +1,65 @@
+---
+title: "Set HVAC mode"
+action: climate.set_hvac_mode
+domain: nuheat
+description: "Sets the HVAC mode for a NuHeat thermostat."
+related_actions:
+  - climate.set_hvac_mode
+---
+
+Use this action to set the HVAC mode for a NuHeat thermostat.
+
+{% include actions/ui_header.md %}
+
+To set the HVAC mode from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the NuHeat thermostat.
+6. From the actions shown for that target, select **Set HVAC mode**.
+7. Select the **HVAC mode**.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+HVAC mode:
+  description: The HVAC mode to set.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `climate.set_hvac_mode`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: climate.set_hvac_mode
+  target:
+    entity_id: climate.bathroom_floor
+  data:
+    hvac_mode: heat
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+hvac_mode:
+  description: The HVAC mode to set.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="climate" %}
+
+## Good to know
+
+- NuHeat thermostats do not have an off mode.
+- Setting the temperature to the minimum temperature and changing the mode to `heat` puts the thermostat in `Permanent Hold` and stops heating unless freeze protection is needed.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/nuheat.set_preset_mode.markdown
+++ b/source/_actions/nuheat.set_preset_mode.markdown
@@ -1,0 +1,65 @@
+---
+title: "Set preset mode"
+action: climate.set_preset_mode
+domain: nuheat
+description: "Sets the preset mode for a NuHeat thermostat."
+related_actions:
+  - climate.set_preset_mode
+---
+
+Use this action to set how a NuHeat thermostat follows or holds its schedule.
+
+{% include actions/ui_header.md %}
+
+To set the preset mode from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the NuHeat thermostat.
+6. From the actions shown for that target, select **Set preset mode**.
+7. Select the **Preset mode**.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Preset mode:
+  description: The preset mode to set. Available values are `Run Schedule`, `Temporary Hold`, and `Permanent Hold`.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `climate.set_preset_mode`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: climate.set_preset_mode
+  target:
+    entity_id: climate.bathroom_floor
+  data:
+    preset_mode: "Run Schedule"
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+preset_mode:
+  description: The preset mode to set. Available values are `Run Schedule`, `Temporary Hold`, and `Permanent Hold`.
+  required: true
+  type: string
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="climate" %}
+
+## Good to know
+
+- Use `Run Schedule` to return the thermostat to its normal schedule.
+- Use `Temporary Hold` or `Permanent Hold` when you want the thermostat to hold a selected temperature instead of following its schedule.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_actions/nuheat.set_temperature.markdown
+++ b/source/_actions/nuheat.set_temperature.markdown
@@ -1,0 +1,65 @@
+---
+title: "Set target temperature"
+action: climate.set_temperature
+domain: nuheat
+description: "Sets the target temperature for a NuHeat thermostat."
+related_actions:
+  - climate.set_temperature
+---
+
+Use this action to set the target floor temperature for a NuHeat thermostat.
+
+{% include actions/ui_header.md %}
+
+To set the temperature from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select what you want to control. Under **By target** (see [Targets](#targets)), select the NuHeat thermostat.
+6. From the actions shown for that target, select **Set target temperature**.
+7. Enter the **Temperature**.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Temperature:
+  description: The target temperature to set.
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `climate.set_temperature`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: climate.set_temperature
+  target:
+    entity_id: climate.bathroom_floor
+  data:
+    temperature: 24
+{% endexample %}
+
+### Options in YAML
+
+{% options_yaml %}
+temperature:
+  description: The target temperature to set.
+  required: true
+  type: float
+{% endoptions_yaml %}
+
+{% include actions/targets.md domain="climate" %}
+
+## Good to know
+
+- If the thermostat is in auto mode, setting the temperature puts it in a temporary hold.
+- If the thermostat is in heat mode, setting the temperature puts it in a permanent hold.
+
+{% include actions/try_it.md %}
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/nuheat.markdown
+++ b/source/_integrations/nuheat.markdown
@@ -110,18 +110,4 @@ Returns the maximum supported temperature by the thermostat
 | ---------------| ----------- |
 | Integer | Maximum supported temperature
 
-## Actions
-
-The following actions are provided by the NuHeat Thermostat: `set_temperature`, `set_hvac_mode`, `set_preset_mode`.
-
-### Action: Set HVAC mode
-
-The `climate.set_hvac_mode` action ([Climate integration](/integrations/climate/)) sets the HVAC mode for NuHeat Thermostats. NuHeat Thermostats do not have an off concept. Setting the temperature to `min_temp` and changing the mode to `heat` will cause the device to enter a `Permanent Hold` preset and will stop the thermostat from turning on unless you happen to live in a freezing climate.
-
-### Action: Set temperature
-
-The `climate.set_temperature` action ([Climate integration](/integrations/climate/)) sets the temperature for NuHeat Thermostats. If the thermostat is in auto mode, it puts the thermostat into a temporary hold at the given temperature. If the thermostat is in heat mode, it puts the thermostat into a permanent hold at the given temperature.
-
-### Action: Set preset mode
-
-The `climate.set_preset_mode` action ([Climate integration](/integrations/climate/)) sets the preset mode for NuHeat Thermostats. The following presets are available: `Run Schedule`, `Temporary Hold`, `Permanent Hold`.
+{% include integrations/actions.md %}


### PR DESCRIPTION
## Proposed change

Moves NuHeat action documentation to dedicated action pages.

Related epic: https://github.com/home-assistant/epics/issues/96

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: 
- Related epic: https://github.com/home-assistant/epics/issues/96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards