### PR TITLE
Downloader: migrate action to dedicated page

### DIFF
--- a/source/_actions/downloader.download_file.markdown
+++ b/source/_actions/downloader.download_file.markdown
@@ -1,0 +1,95 @@
+---
+title: "Download file"
+action: downloader.download_file
+domain: downloader
+description: "Downloads a file to the configured download location."
+---
+
+Use this action to download a file to the location configured for the Downloader integration.
+
+The download directory must exist and be writable by Home Assistant.
+
+{% include actions/ui_header.md %}
+
+To download a file from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select **Downloader: Download file**.
+6. Enter the URL to download.
+7. Set the other options if you need them.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+URL:
+  description: The URL of the file to download.
+Subdirectory:
+  description: The subdirectory inside the configured download location.
+  required: false
+Filename:
+  description: The filename to use for the downloaded file.
+  required: false
+Overwrite:
+  description: Whether to overwrite an existing file.
+  required: false
+  default: false
+Headers:
+  description: Custom HTTP headers to add to the request.
+  required: false
+  default: {}
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `downloader.download_file`. A basic example looks like this:
+
+{% example %}
+action: |
+  action: downloader.download_file
+  data:
+    url: "https://example.com/file.txt"
+{% endexample %}
+
+This downloads `file.txt` to the configured download location.
+
+### Options in YAML
+
+{% options_yaml %}
+url:
+  description: The URL of the file to download.
+  required: true
+  type: string
+subdir:
+  description: The subdirectory inside the configured download location.
+  required: false
+  type: string
+filename:
+  description: The filename to use for the downloaded file.
+  required: false
+  type: string
+overwrite:
+  description: Whether to overwrite an existing file.
+  required: false
+  type: boolean
+  default: false
+headers:
+  description: Custom HTTP headers to add to the request.
+  required: false
+  type: map
+  default: {}
+{% endoptions_yaml %}
+
+This action does not support targets.
+
+## Good to know
+
+- If the configured path is not absolute, Home Assistant treats it as relative to the configuration directory.
+- When a download finishes, Home Assistant emits either `downloader_download_completed` or `downloader_download_failed` on the event bus.
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/downloader.markdown
+++ b/source/_integrations/downloader.markdown
@@ -18,23 +18,7 @@ The **Downloader** {% term integration %} provides an action to download files. 
 
 If the path is not absolute, it’s assumed to be relative to the Home Assistant configuration directory (for example, `/config/downloads`). So if you have a folder called `/config/my_download_folder`, when prompted to **Select a location to get to store downloads**, enter `my_download_folder`. Home Assistant checks if the directory exists.
 
-### Use the action
-
-Go to the "Developer tools", then to "Actions", and choose `downloader.download_file` from the list of available actions. Fill the "data" field as shown in the example below and select "Perform action".
-
-```json
-{"url":"http://domain.tld/path/to/file"}
-```
-
-This will download the file from the given URL.
-
-| Data attribute | Optional | Description                                    |
-| ---------------------- | -------- | ---------------------------------------------- |
-| `url`                  |       no | The URL of the file to download.               |
-| `subdir`               |      yes | Download into subdirectory of **download_dir** |
-| `filename`             |      yes | Determine the filename.                        |
-| `overwrite`            |      yes | Whether to overwrite the file or not, defaults to `false`. |
-| `headers`              |      yes | Dictionary of custom HTTP headers to add to the request.  |
+{% include integrations/actions.md %}
 
 ### Download status events
 
@@ -58,6 +42,6 @@ Along with the event the following payload parameters are available:
   actions:
     - action: persistent_notification.create
       data:
-        message: "{{trigger.event.data.filename}} download failed"
+        message: "{{ trigger.event.data.filename }} download failed"
         title: "Download Failed"
  ```


### PR DESCRIPTION
## Proposed change
Moves Downloader download file documentation to a dedicated action page.

Related epic: https://github.com/home-assistant/epics/issues/96

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase:
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue:
- Related epic: https://github.com/home-assistant/epics/issues/96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards