### PR TITLE
Volvo: migrate action to dedicated page

### DIFF
--- a/source/_actions/volvo.get_image_url.markdown
+++ b/source/_actions/volvo.get_image_url.markdown
@@ -57,7 +57,7 @@ entry:
 images:
   description: The image angles to retrieve. This option accepts a list of image angle values. Leave empty to get all available images.
   required: false
-  type: string
+  type: [string, list]
 {% endoptions_yaml %}
 
 This action does not support targets.

--- a/source/_actions/volvo.get_image_url.markdown
+++ b/source/_actions/volvo.get_image_url.markdown
@@ -1,0 +1,87 @@
+---
+title: "Get image URL"
+action: volvo.get_image_url
+domain: volvo
+description: "Retrieves URLs for vehicle-specific Volvo images."
+---
+
+Use this action to retrieve URLs for one or more vehicle-specific Volvo images.
+
+{% include actions/ui_header.md %}
+
+To get Volvo image URLs from an automation or a script:
+
+1. Go to {% my automations title="**Settings** > **Automations & scenes**" %}.
+2. Open an existing automation or script, or select **Create automation** > **Create new automation**.
+3. If you're setting up a new automation, add a trigger in the **When** section. Scripts don't need a trigger. They run when something else calls them.
+4. In the **Then do** section, select **Add action**.
+5. Select **Volvo: Get image URL**.
+6. Select the vehicle entry.
+7. Select one or more image angles, or leave the image list empty to retrieve all available image URLs.
+8. Select **Save**.
+
+### Options in the UI
+
+{% options_ui %}
+Entry:
+  description: The Volvo vehicle entry to retrieve image URLs for.
+Images:
+  description: The image angles to retrieve. Leave empty to get all available images.
+  required: false
+{% endoptions_ui %}
+
+{% include actions/yaml_header.md %}
+
+In YAML, refer to this action as `volvo.get_image_url`. Store the result in a response variable so you can use it in later steps:
+
+{% example %}
+action: |
+  action: volvo.get_image_url
+  data:
+    entry: VOLVO_CONFIG_ENTRY_ID
+    images:
+      - exterior_front
+      - exterior_side_left
+  response_variable: volvo_images
+{% endexample %}
+
+This retrieves URLs for the selected vehicle image angles.
+
+### Options in YAML
+
+{% options_yaml %}
+entry:
+  description: The Volvo vehicle entry to retrieve image URLs for.
+  required: true
+  type: string
+images:
+  description: The image angles to retrieve. This option accepts a list of image angle values. Leave empty to get all available images.
+  required: false
+  type: string
+{% endoptions_yaml %}
+
+This action does not support targets.
+
+## Available image angles
+
+- `exterior_back`
+- `exterior_back_left`
+- `exterior_back_right`
+- `exterior_front`
+- `exterior_front_left`
+- `exterior_front_right`
+- `exterior_side_left`
+- `exterior_side_right`
+- `interior`
+
+## Response data
+
+The action response contains the requested image URLs.
+
+## Good to know
+
+If you leave `images` empty, the action retrieves all available image URLs for the selected vehicle.
+
+{% include actions/stuck.md %}
+
+{% include actions/related.md %}

--- a/source/_integrations/volvo.markdown
+++ b/source/_integrations/volvo.markdown
@@ -230,19 +230,7 @@ Go to Volvo's developer portal to view [the list of supported models](https://de
 - **Trip automatic average fuel consumption**: Average fuel consumption on the automatic trip meter.
 - **Trip manual average fuel consumption**: Average fuel consumption on the manual trip meter.
 
-## Actions
-
-### Get image URL
-
-The action `get_image_url` retrieves the URL of your vehicle-specific images.
-Get all URLs at once, or select one or more angles.
-
-{% configuration_basic %}
-Entry:
-  description: "The entry ID to retrieve the vehicle images for."
-Images:
-  description: "The image angles to retrieve. Leave empty to get all images."
-{% endconfiguration_basic %}
+{% include integrations/actions.md %}
 
 ## Examples
 
@@ -252,7 +240,6 @@ Send a notification to your mobile phone if at least one door is open for 5 minu
 
 ```yaml
 alias: Notify me if doors are left open for 5 minutes
-description: ""
 triggers:
   - trigger: state
     entity_id:
@@ -263,18 +250,14 @@ triggers:
       - binary_sensor.volvo_YOUR_MODEL_tailgate
     to: "on"
     for:
-      hours: 0
       minutes: 5
-      seconds: 0
-conditions: []
 actions:
-  - data:
+  - action: notify.mobile_app_phone_john_doe
+    data:
       data:
         url: /lovelace/volvo
       title: 🚘 Volvo
-      message: You've left some doors open. Don't give thiefs a chance!
-    action: notify.mobile_app_phone_john_doe
-mode: single
+      message: "You've left some doors open."
 ```
 
 ### Estimated charging finish time
@@ -284,7 +267,8 @@ The Volvo API only provides an estimated charging time (in minutes). To calculat
 {% raw %}
 
 ```jinja2
-{% set charging_time = states('sensor.volvo_YOUR_MODEL_estimated_charging_time') | int(0) %}
+{% set charging_time =
+  states('sensor.volvo_YOUR_MODEL_estimated_charging_time') | int(0) %}
 {% if charging_time > 0 -%}
   {% set new_time = now() + timedelta(minutes=charging_time) %}
   {{ new_time }}


### PR DESCRIPTION
## Proposed change
Moves Volvo image URL documentation to a dedicated action page.

Related epic: https://github.com/home-assistant/epics/issues/96

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase:
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue:
- Related epic: https://github.com/home-assistant/epics/issues/96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards