### PR TITLE
WiiM: remove unsupported custom action note

### DIFF
--- a/source/_integrations/wiim.markdown
+++ b/source/_integrations/wiim.markdown
@@ -39,11 +39,6 @@ The button entities provide some additional WiiM features available on the devic
 - **Time Sync**: Synchronizes the device’s internal clock with the current time on your Home Assistant server, ensuring features like scheduled playback or time-based automations remain accurate.
 - **Restart Device**: Reboots the device remotely, providing a quick way to recover from connectivity issues or apply configuration changes without physical interaction.
 
-## Actions
-
-The WiiM integration makes various custom actions available in addition to the [standard media player actions](/integrations/media_player/#actions).
-
-
 ## Removing the integration
 
 This integration follows the standard integration removal process; no extra steps are required.


### PR DESCRIPTION
## Proposed change
Removes the unsupported WiiM custom action note after Core verification.

Related epic: https://github.com/home-assistant/epics/issues/96

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase:
- Link to parent pull request in the Brands repository:
- This PR fixes or closes issue:
- Related epic: https://github.com/home-assistant/epics/issues/96

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards