### PR TITLE
Improved the HAOS installation instructions for VirtualBox

### DIFF
--- a/source/_includes/installation/operating_system.md
+++ b/source/_includes/installation/operating_system.md
@@ -275,6 +275,13 @@ If you are running an older Windows version or have a stricter network configura
 
 {% else %}
 
+Follow this guide if you are already running a supported virtual machine hypervisor. If you are not familiar with virtual machines, install Home Assistant OS directly on [Home Assistant Yellow](/installation/yellow), [Raspberry Pi](/installation/raspberrypi), or [ODROID](/installation/odroid).
+
+{% if page.installation_type == 'macos' %}
+
+If VirtualBox is not supported on your Mac and you have experience using virtual machines, you can try running the Home Assistant Operating System on [UTM](https://mac.getutm.app/).
+{% endif %}
+
 ### Download the appropriate image
 
 - [VirtualBox (Intel chip)][vdi] (.vdi)
@@ -291,27 +298,18 @@ If you are running an older Windows version or have a stricter network configura
 - [Hyper-V][vhdx] (.vhdx)
 {% endif %}
 
-After downloading, decompress the image. If the image comes in a ZIP file, for example, unzip it.
+After downloading the image, extract it if necessary. For example, if it comes in a ZIP file, unzip it.
 
-Follow this guide if you already are running a supported virtual machine hypervisor. If you are not familiar with virtual machines, install Home Assistant OS directly on a [Home Assistant Yellow](/installation/yellow), a [Raspberry Pi](/installation/raspberrypi), or an [ODROID](/installation/odroid).
+### Create and configure the virtual machine
 
-{% if page.installation_type == 'macos' %}
+When creating the virtual machine, assign memory and CPU resources based on your expected workload. You can increase these resources later if your workload grows.
 
-- If VirtualBox is not supported on your Mac, and you have experience using virtual machines, you can try running the Home Assistant Operating System on [UTM](https://mac.getutm.app/).
-{% endif %}
+Minimum resources:
 
-### Create the virtual machine
+- Memory: 2 GB of RAM
+- Processors: 2 vCPUs
 
-Load the appliance image into your virtual machine hypervisor. (Note: You are free to assign as much resources as you wish to the VM, please assign enough based on your app needs).
-
-Minimum recommended assignments:
-
-- 2 GB RAM
-- 2vCPU
-
-*All these can be extended if your usage calls for more resources.*
-
-### Hypervisor specific configuration
+To create the virtual machine, follow the instructions for the hypervisor you use:
 
 {% tabbed_block %}
 
@@ -319,51 +317,52 @@ Minimum recommended assignments:
   content: |
     
     #### Create the virtual machine
-    
-    1. Open VirtualBox and select the **New** button (the blue star).
-    2. **Name:** Type Home Assistant.
-    3. **ISO Image:** Leave this as **None** or **Empty**.
-    4. **Type & Version:** Select **Linux**, then select **Oracle Linux (64-bit)** (or **ARM 64-bit** if you are using a Mac with an M1/M2/M3 chip).
-    5. Select **Next**.
- 
-    #### Configure hardware
-    1. **Base Memory:** Move the slider to at least **2048 MB** (2GB).
-    2. **Number of CPUs:** Move the slider to at least **2**.
-    3. **EFI:** Check the box for **Enable EFI (special OSes only)**. This is required for Home Assistant to boot.
-    4. **Secure Boot:** Deselect **Enable Secure Boot**. Home Assistant OS does not boot with Secure Boot enabled.
-    5. Select **Next**.
 
-    #### Finalizing the wizard
+    The following steps use VirtualBox Basic Mode, which provides a simplified wizard for creating and configuring a virtual machine.
 
-    1. On the **Virtual Hard Disk** screen, leave the settings as they are (it will suggest creating a new disk). We will swap this for your downloaded file in the next step.
-    2. Select **Finish**.
+    1. Open VirtualBox, and select **New** on the toolbar.
+    2. In the **Virtual machine name and operating system** step, specify the following settings:
+       - **Name**: Enter **Home Assistant**.
+       - **VM Folder**: Select a location to store the virtual machine files.
+       - **ISO Image**: Leave blank.
+       - **OS**: Select **Linux**.
+       - **OS Distribution**: Select **Oracle Linux (64-bit)**. If you use a Mac with Apple silicon (M1, M2, or M3), select **ARM 64-bit** instead.
+    3. Select **Next**.
+    4. In the **Specify virtual hardware** step, specify the following settings:
+       - **Base Memory**: Set to at least **2048 MB**, which is 2 GB.
+       - **Number of CPUs**: Set to at least **2**.
+       - **Use EFI**: Select the checkbox to use UEFI instead of legacy BIOS. Home Assistant requires UEFI to boot.
+    5. Select **Next**.
+    6. In the **Summary** step, review the settings and select **Finish**.
 
     #### Attach the Home Assistant disk (VDI)
+  
+    Configure the virtual machine to use the Home Assistant disk (VDI) that you downloaded and extracted earlier.
 
-    1. Select your new "Home Assistant" VM in the left-hand list and select the **Settings** icon (the orange gear).
-    2. Go to the **Storage** section on the left menu.
-    3. In the **Storage Devices** list, you will see a disk already listed under **Controller: SATA**. Right-click that disk and select **Remove Attachment**. This removes the empty placeholder disk.
-    4. Select the **Add Hard Disk** icon (the small disk with a green plus symbol) located next to the words **Controller: SATA**.
-    5. In the window that pops up, select the **Add** button at the top.
-    6. Find and select the `.vdi` file you previously downloaded and unzipped.
+    1. Select your new **Home Assistant** VM in the list, and then select **Settings** on the toolbar.
+    2. Go to the **Storage** section.
+    3. In the **Storage Devices** list, under **Controller: SATA**, right-click the empty placeholder disk and select **Remove attachment**.
+    4. Next to **Controller: SATA**, select the **Add hard disk** icon (the blue disk with a plus sign).
+    5. In the dialog that appears, select the **Add** button.
+    6. Find and select the downloaded `.vdi` file.
     7. Select **Choose** to confirm the file.
 
     #### Configure network
 
     1. While still in the **Settings** window, go to the **Network** section.
-    2. Change the **Attached to** setting from **NAT** to **Bridged Adapter**.
-    3. Under **Name**, select the adapter you use for internet access. This allows Home Assistant to talk to other devices in your home.
+    2. In **Attached to**, change the setting to **Bridged Adapter**.
+    3. In **Name**, select the network adapter you use for internet access. Home Assistant uses this adapter to communicate with other devices on your network. If your computer uses Wi-Fi, select your Wi-Fi adapter. If it uses a wired connection, select your Ethernet adapter.
     4. Select **OK**.
 
-    {% icon "mdi:alert-outline" %}  By default, VirtualBox does not
-    free up unused disk space. To automatically shrink the vdi disk image the `discard` option must
-    be enabled using your host machine's terminal:
+    #### Enable automatic disk space reclamation (optional)
+
+    {% icon "mdi:alert-outline" %} By default, VirtualBox does not reclaim unused disk space from virtual disks. To enable automatic disk shrinking for the Home Assistant VDI, run the following command on the host machine:
 
     ```bash
     VBoxManage storageattach <VM name> --storagectl "SATA" --port 0 --device 0 --nonrotational on --discard on
     ```
 
-    More details can be found about the command can be found [here](https://www.virtualbox.org/manual/ch08.html#vboxmanage-storageattach).
+    For more information about the command, see [VBoxManage storageattach command](https://www.virtualbox.org/manual/ch08.html#vboxmanage-storageattach).
 
 {% unless page.installation_type == 'macos' %}
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Hi! This is my first contribution to the project. I installed HAOS on a VM for the first time and followed the docs end to end. I’m sharing a few suggestions to improve clarity based on my experience setting it up. Hope it helps :)

### UI updates and clarifications (VirtualBox 7.2+)

*Tested on VirtualBox version 7.2.10 r174163 (Qt6.8.0 on Windows) and Version 7.2.8 r173730 (Qt6.8.0 on cocoa)*

* Clarified that the instructions explicitly follow the **Basic Mode UI**. Added a brief note explaining that Basic Mode uses a simplified, step-by-step wizard, **as accidentally switching to Expert Mode changes the interface entirely.**  
* Removed the reference to the "Virtual Hard Disk" screen, as I could not find the screen in this specific wizard. There are 3 wizard steps (VM, resources, and summary). 
* VM Folder: Added to the steps to ensure users note the location (I did not pay attention to the default location, worth mentioning for beginners).
* ISO Image: There were no such options as None or Empty on the UI, so changed to “blank”.   
* Changed "**Enable EFI (special OSes only)**" to **"Use EFI"** to match the current UI. Added brief context on *why* this needs to be enabled (adds context for beginners).  
* Secure Boot:  
  * The **Secure Boot** checkbox is accessible via **Settings** and only after switching to **Expert Mode**. It is unselected by default.  
  * Consider removing the step as it is not shown in the wizard.  
  * If Secure Boot can be enabled somehow, I'd add a note after the procedure: "Go to **Settings**, switch to **Expert Mode**, and under **System**, make sure the **Secure Boot** checkbox is clear.  Home Assistant OS does not boot with Secure Boot enabled."

* Added an example about network adapters to assist beginners like me :)   
* I’d clarify the recommended disk size. The current text leaves it ambiguous whether the user should stick with the default size or allocate more space. I did not know how to proceed.  
  ChatGPT suggested the following, added as a comment `<!-- - **Disk Size**: Leave the default value. VirtualBox suggests a default disk size, but you can increase it later if your Home Assistant requires additional storage. -->`  

<img width="956" height="546" alt="secure-boot-option-expert-mode" src="https://github.com/user-attachments/assets/5abb9d55-49ce-4663-9c94-065ccd50eae9" />
<img width="973" height="486" alt="Wizard-step-1" src="https://github.com/user-attachments/assets/abb8b557-4d0e-406b-950e-acfc9775d10c" />
<img width="983" height="493" alt="Wizard-step-2-Disk-size-Use-EFI" src="https://github.com/user-attachments/assets/0758275d-2335-4e7a-a977-2570b580f2e9" />  

### Structural & hierarchy improvements

* The heading **Hypervisor specific configuration** is at the same level as the previous one, but it is a part of the VM creation workflow. I removed it and used an intro sentence instead. When previewing via Dev Container, the page loaded correctly. Hope there are no broken links.
* Renamed the initial **Create and configure the virtual machine** heading to avoid a **duplicate “Create the virtual machine”** later in the instructions for VirtualBox.  
* Consolidated wizard steps by merging three separate, small procedures into a single, cohesive section. The original structure confused me because they are all part of the same setup wizard.  
* **New section for the optimization option**: Moved the alert out of the network configuration flow. It looks like the command should be run after the VM is created and running and not within the network configuration.  
* Moved the note about alternative installations before the “Download the image” section, as it makes more sense there rather than after the user downloads the image.

### Style Guide alignment (Microsoft Manual of Style)

* Changed UI-focused phrasing to value/result-focused phrasing:  
  * *Type* \> **Enter** (focus on *what*, not *how*).  
  * *Move the slider* \> **Set to** (focus on the final value, not the mechanic).  
* Removed superfluous directional phrases like “left-hand side” or “at the top”. These are not needed unless absolutely necessary to distinguish between identical UI elements.  
* Replaced "unzipped" with **"extracted"** (a more generic term).  
* Removed generic link text like "Here" and replaced it with a descriptive hyperlink.


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [x] Spelling, grammar or other readability improvements (`current` branch).
- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
