### PR TITLE
Document scene position+tilt stutter workaround for Overkiz

### DIFF
--- a/source/_integrations/overkiz.markdown
+++ b/source/_integrations/overkiz.markdown
@@ -186,6 +186,12 @@ cover:
               entity_id: cover.rts_test_shutter # change to your device id
 ```
 
+### Scenes and automations that set both position and tilt
+
+If a scene or automation sets both the position and the tilt of a cover, Home Assistant sends these as two separate actions: [Set cover position](/actions/cover.set_cover_position/) followed by [Set cover tilt position](/actions/cover.set_cover_tilt_position/). On Somfy venetian blinds and similar IO motors, the second command interrupts the first while it's still moving, so the cover only makes a short stuttering move instead of reaching the target position and tilt.
+
+To move a cover to a target position and tilt in one smooth motion, use the [Set cover position and tilt](/actions/overkiz.set_cover_position_and_tilt/) action instead.
+
 ### Troubleshooting connection issues with the local API
 
 If your entities frequently become unavailable for short periods, this usually indicates connection problems between Home Assistant and your gateway. To improve reliability, try connecting to your gateway using its IP address instead of the `gateway-xxxx-xxxx-xxx.local` hostname.


### PR DESCRIPTION
## Proposed change

Users hitting home-assistant/core#156234 see Overkiz cover scenes that set both position and tilt only make a short stuttering move instead of reaching the target. This isn't an Overkiz bug: Home Assistant sends position and tilt as two separate actions, and on Somfy/Overkiz IO motors the second command interrupts the first mid-move.

The integration already ships `overkiz.set_cover_position_and_tilt` (documented in `/actions/overkiz.set_cover_position_and_tilt/`), which avoids this by sending both values in one atomic command, but nothing on the integration page explained the symptom or pointed to that action as the fix. This adds a "Scenes and automations that set both position and tilt" section under Known limitations that does both.

## Type of change

- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes home-assistant/core#156234

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards