### PR TITLE
Rename Modbus integration to Manual Modbus

### DIFF
--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -1,5 +1,5 @@
 ---
-title: Modbus
+title: Manual Modbus
 description: Instructions on how to integrate modbus and platforms.
 ha_category:
   - Hub

--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -1,6 +1,6 @@
 ---
 title: Manual Modbus
-description: Instructions on how to integrate modbus and platforms.
+description: Instructions on how to manually register Modbus entities and platforms.
 ha_category:
   - Hub
 ha_release: pre 0.7
@@ -22,13 +22,13 @@ related:
 
 [modbus](http://www.modbus.org/) is a communication protocol to control PLCs (Programmable Logic Controller) and RTUs (Remote Terminal Unit).
 
-The Manual Modbus {% term integration %} lets you manually register Modbus entities by describing each register in your Home Assistant configuration. It is meant for people who are comfortable working with Modbus, as it requires knowledge of the protocol and of the specific registers your device exposes.
+The Manual Modbus {% term integration %} lets you manually register Modbus entities by describing each register in your `configuration.yaml` file. It is meant for people who are comfortable working with Modbus, as it requires knowledge of the protocol and of the specific registers your device exposes.
 
 Before setting this up, we recommend looking for a vendor-specific integration that already supports your Modbus device. A dedicated integration handles the register details for you and is easier to set up and maintain.
 
 The integration adheres strictly to the [protocol specification](https://www.modbus.org/docs/Modbus_Application_Protocol_V1_1b3.pdf) using [pymodbus](https://github.com/pymodbus-dev/pymodbus) for the protocol implementation.
 
-The Manual Modbus integration supports all devices adhering to the modbus standard. The communication to the device/devices can be serial (rs-485), TCP, or UDP connections. The integration allows multiple communication channels e.g. a serial port connection combined with one or more TCP connections.
+The Manual Modbus integration supports all devices adhering to the Modbus standard. The communication to the device or devices can be serial (rs-485), TCP, or UDP connections. The integration allows multiple communication channels, for example a serial port connection combined with one or more TCP connections.
 
 # Configuring modbus communication
 

--- a/source/_integrations/modbus.markdown
+++ b/source/_integrations/modbus.markdown
@@ -22,9 +22,13 @@ related:
 
 [modbus](http://www.modbus.org/) is a communication protocol to control PLCs (Programmable Logic Controller) and RTUs (Remote Terminal Unit).
 
+The Manual Modbus {% term integration %} lets you manually register Modbus entities by describing each register in your Home Assistant configuration. It is meant for people who are comfortable working with Modbus, as it requires knowledge of the protocol and of the specific registers your device exposes.
+
+Before setting this up, we recommend looking for a vendor-specific integration that already supports your Modbus device. A dedicated integration handles the register details for you and is easier to set up and maintain.
+
 The integration adheres strictly to the [protocol specification](https://www.modbus.org/docs/Modbus_Application_Protocol_V1_1b3.pdf) using [pymodbus](https://github.com/pymodbus-dev/pymodbus) for the protocol implementation.
 
-The modbus {% term integration %} supports all devices adhering to the modbus standard. The communication to the device/devices can be serial (rs-485), TCP, or UDP connections. The modbus integration allows multiple communication channels e.g. a serial port connection combined with one or more TCP connections.
+The Manual Modbus integration supports all devices adhering to the modbus standard. The communication to the device/devices can be serial (rs-485), TCP, or UDP connections. The integration allows multiple communication channels e.g. a serial port connection combined with one or more TCP connections.
 
 # Configuring modbus communication
 


### PR DESCRIPTION
## Proposed change

Renames the Modbus integration to **Manual Modbus** to reflect that it is meant for manually registering Modbus entities. Changes:

- Update the page `title` from `Modbus` to `Manual Modbus` (the `ha_domain` and page URL are unchanged, so no redirect is needed).
- Expand the introduction to clarify that the integration lets you manually register Modbus entities, that it requires knowledge of the Modbus protocol and of your device's registers, and that we recommend looking for a vendor-specific integration that supports your specific Modbus device first.
- Update the surrounding sentences to consistently refer to "Manual Modbus" / "the integration".

This implements section 6 of https://github.com/home-assistant/architecture/discussions/1418

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/175389
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GBE9N8fL2D1mpc5sWaEvRo)_