### PR TITLE
Add Google Health integration documentation

### DIFF
--- a/source/_integrations/google_health.markdown
+++ b/source/_integrations/google_health.markdown
@@ -1,0 +1,181 @@
+---
+title: Google Health
+description: Instructions on how to integrate Google Health within Home Assistant.
+ha_release: 2026.7
+ha_category:
+  - Health
+ha_iot_class: Cloud Polling
+ha_domain: google_health
+ha_codeowners:
+  - '@allenporter'
+ha_config_flow: true
+ha_platforms:
+  - sensor
+ha_integration_type: service
+related:
+  - url: https://developers.google.com/health-api
+    title: Google Health API
+  - url: https://console.cloud.google.com/apis/library/health.googleapis.com
+    title: Google Developers Console
+---
+
+The **Google Health** {% term integration %} allows you to expose health and fitness data from Google Health (including Fitbit, Pixel Watch, and other devices connected to your Google Account) to Home Assistant.
+
+## Prerequisites
+
+You need to configure developer credentials to allow Home Assistant to access your Google Account. These credentials are the same as the ones for [Google Photos](/integrations/google_photos), [Nest](/integrations/nest), [Google Tasks](/integrations/google_tasks), and [Google Mail](/integrations/google_mail).
+
+If you have already set up the correct credentials, you can enable the API and then skip the consent screen and credential creation steps.
+
+{% details "Generate client ID and client secret" %}
+
+This section explains how to enable the API, configure the consent screen, and generate a client ID and client secret on the Google Developers Console.
+
+1. First, go to the Google Developers Console to enable the [Google Health API](https://console.cloud.google.com/apis/library/health.googleapis.com).
+2. Select a project and select **Continue**. Verify that the API is enabled.
+3. Go to the [Branding page](https://console.cloud.google.com/auth/branding) in the Google Auth Platform Console.
+4. If prompted to configure OAuth, select **Get started** and follow the setup wizard. When the wizard asks for the user type, select **External**, and continue once the OAuth consent configuration is created.
+5. Select **Branding** in the left sidebar. Fill in the required fields:
+   - **App name**: Enter a name (like *Home Assistant*). This is shown during the OAuth login flow.
+   - **User support email**: Select your Google Account email.
+   - **Developer contact email**: Enter your email address.
+   Leave all other fields empty to avoid triggering Google's verification process. Select **Save**.
+6. Select **Audience** in the left sidebar.
+   - Under **User type**, confirm it shows **External**.
+   - Under **Test users**, select **+ Add users** and add your Google Account email address. Select **Save**.
+7. Under **Publishing status**, select **Publish app** to set the status to **In production**. Make sure the status is not **Testing**, or your authentication token will expire every 7 days.
+8. Select **Credentials** in the left sidebar.
+9. Select **Create Credentials** at the top of the page, then select **OAuth client ID**.
+10. Set the Application type to **Web application** and give these credentials a name (like *Home Assistant Credentials*).
+11. Under **Authorized redirect URIs**, enter `https://my.home-assistant.io/redirect/oauth` and select **Create**. This is not a placeholder and is the URI that must be used.
+12. Copy the **Client ID** and **Client Secret** from the pop-up, or select the pencil icon next to your client ID to view them later.
+
+{% enddetails %}
+
+{% include integrations/config_flow.md %}
+
+The integration setup will next give you instructions to enter the [Application Credentials](/integrations/application_credentials/) (OAuth Client ID and Client Secret) and authorize Home Assistant to access your Google Health data.
+
+{% details "OAuth and authorization steps" %}
+
+1. Continue through the steps of selecting the Google Account you want to authorize.
+2. You will be asked to grant access to specific data in your Google Health account. The integration will dynamically adjust based on the permissions you grant:
+    - **Profile** (required): Allows Home Assistant to verify your account identity.
+    - **Activity and fitness** (optional): Granting this scope creates daily steps and distance sensors.
+    - **Health metrics and measurements** (optional): Granting this scope creates weight and resting heart rate sensors.
+3. You may get a message telling you that the app has not been verified. Acknowledge this to proceed.
+4. You can now see the details of what you are authorizing Home Assistant to access with options at the bottom. Select **Continue**.
+5. The page will now display **Link account to Home Assistant?**, noting **Your instance URL**. If this is not correct, refer to [My Home Assistant](/integrations/my). If everything looks good, select **Link Account**.
+6. You may close the window and return to Home Assistant, where you should see a **Success!** message.
+
+{% enddetails %}
+
+## Supported functionality
+
+The **Google Health** integration provides the following entities:
+
+### Sensors
+
+- **Distance**
+  - **Description**: Daily distance in meters.
+  - **Available for**: All authorized accounts that grant the activity and fitness scope.
+- **Resting heart rate**
+  - **Description**: Daily resting heart rate in beats per minute (bpm).
+  - **Available for**: All authorized accounts that grant the health metrics and measurements scope.
+- **Steps**
+  - **Description**: Daily steps count.
+  - **Available for**: All authorized accounts that grant the activity and fitness scope.
+- **Weight**
+  - **Description**: Body weight in kilograms (kg).
+  - **Available for**: All authorized accounts that grant the health metrics and measurements scope.
+
+## Google Health automation examples
+
+The real power of this integration is automating your home environment or notifications based on your health metrics. Here are a few ideas to get you started.
+
+{% include docs/paste_yaml_tip.md %}
+
+### Automation: Step goal reminder
+
+Send a notification in the evening if you have not met your daily step goal.
+
+- **Trigger**: Time: 20:00 (8:00 PM)
+- **Condition**: Numeric state: steps sensor is below your goal (for example, 10,000 steps)
+- **Action**: Send a notification to your mobile phone
+
+{% details "YAML example for step goal reminder" %}
+
+{% example %}
+automation: |
+  alias: "Reminder to meet daily step goal"
+  triggers:
+    - trigger: time
+      at: "20:00:00"
+  conditions:
+    - condition: numeric_state
+      entity_id: sensor.google_health_steps
+      below: 10000
+  actions:
+    - action: notify.mobile_app_your_phone
+      data:
+        message: >
+          You have only completed
+          {{ states('sensor.google_health_steps') }} steps today.
+          Time for a short walk!
+{% endexample %}
+
+{% enddetails %}
+
+### Automation: Resting heart rate alert
+
+Notify you if your daily resting heart rate goes above a certain threshold (for example, 80 bpm), which could indicate fatigue or stress.
+
+- **Trigger**: State: resting heart rate sensor state changes
+- **Condition**: Numeric state: resting heart rate is above 80 bpm
+- **Action**: Send a notification
+
+{% details "YAML example for resting heart rate alert" %}
+
+{% example %}
+automation: |
+  alias: "Alert on high resting heart rate"
+  triggers:
+    - trigger: state
+      entity_id: sensor.google_health_resting_heart_rate
+  conditions:
+    - condition: numeric_state
+      entity_id: sensor.google_health_resting_heart_rate
+      above: 80
+  actions:
+    - action: notify.mobile_app_your_phone
+      data:
+        message: >
+          Your resting heart rate is higher than usual at
+          {{ states('sensor.google_health_resting_heart_rate') }}
+          bpm. Make sure to rest!
+{% endexample %}
+
+{% enddetails %}
+
+## Data updates
+
+The integration updates sensors on different intervals based on the data type:
+
+- Activity sensors (Steps and Distance) are updated every 15 minutes.
+- Body sensors (Weight and Resting heart rate) are updated every hour.
+
+## Troubleshooting
+
+### Resetting a broken or incorrect configuration
+
+If the Google Health integration was initially configured incorrectly, you can delete the credentials in the [Application Credentials](/integrations/application_credentials/) user interface and start the setup again.
+
+### Connection failed after authorization
+
+If authorization appears to succeed but Home Assistant returns a connection error, verify that you granted the required **Profile** permission. Home Assistant requires the profile scope to verify your account identity and setup the integration.
+
+## Removing the integration
+
+This integration follows standard integration removal.
+
+{% include integrations/remove_device_service.md %}


### PR DESCRIPTION
## Proposed change

Add documentation for the new Google Health integration (`google_health`). The documentation includes setup steps for the new Google Auth Platform Console layout, describes the supported sensors (steps, distance, weight, resting heart rate), explains how sensors are created dynamically depending on authorized scopes, and provides two automation examples using the updated `action` syntax.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [x] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/175417
- Link to parent pull request in the Brands repository: https://github.com/home-assistant/brands/pull/10674
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].
