### PR TITLE
Document per-API MCP server endpoint

### DIFF
--- a/source/_integrations/mcp_server.markdown
+++ b/source/_integrations/mcp_server.markdown
@@ -73,12 +73,12 @@ The `/api/mcp` endpoint serves the LLM API you select when you set up the
 integration. If you have more than one LLM API available, you can also connect a
 client to a specific one by adding its ID to the URL:
 
-`/api/mcp/<API ID>`
+`/api/mcp/<api_id>`
 
 For example, the built-in Assist API is always available at `/api/mcp/assist`.
 Point your MCP client at this URL in the same way you would use the base
 `/api/mcp` endpoint. If you request an API ID that does not exist, Home Assistant
-responds with a 404 error.
+responds with a 404 Not Found error.
 
 Connecting to any API other than Assist requires the authenticated user to be an
 administrator. The Assist API stays available to non-administrator users, just

--- a/source/_integrations/mcp_server.markdown
+++ b/source/_integrations/mcp_server.markdown
@@ -67,6 +67,23 @@ will likely continue to evolve.
 The Home Assistant MCP server is exposed as `/api/mcp` and requires the
 client to provide an authentication token.
 
+### Exposing a specific LLM API
+
+The `/api/mcp` endpoint serves the LLM API you select when you set up the
+integration. If you have more than one LLM API available, you can also connect a
+client to a specific one by adding its ID to the URL:
+
+`/api/mcp/<API ID>`
+
+For example, the built-in Assist API is always available at `/api/mcp/assist`.
+Point your MCP client at this URL in the same way you would use the base
+`/api/mcp` endpoint. If you request an API ID that does not exist, Home Assistant
+responds with a 404 error.
+
+Connecting to any API other than Assist requires the authenticated user to be an
+administrator. The Assist API stays available to non-administrator users, just
+like the base `/api/mcp` endpoint.
+
 ### Access control
 
 #### OAuth


### PR DESCRIPTION
## Proposed change

Documents the new `/api/mcp/<API ID>` endpoint added to the **Model Context Protocol Server** integration. In addition to the base `/api/mcp` endpoint (which serves the LLM API selected during setup), MCP clients can now connect to any registered LLM API directly by including its ID in the URL.

The new "Exposing a specific LLM API" subsection covers:

- The `/api/mcp/<API ID>` URL format and the `/api/mcp/assist` example for the built-in Assist API.
- The 404 response returned for an unknown API ID.
- The requirement that connecting to any API other than Assist needs an administrator user, while Assist stays available to non-administrator users like the base endpoint.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: home-assistant/core#175570
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015pHX9vtarivAUdrzYLPSok)_