### PR TITLE
Add binary sensor platform to Evohome for low batteries

### DIFF
--- a/source/_integrations/evohome.markdown
+++ b/source/_integrations/evohome.markdown
@@ -82,7 +82,7 @@ Each heating zone is represented as a **Climate** entity that exposes the zone's
 
 Each zone also provides a **Button** entity to clear any override and return the zone to Evohome's **FollowSchedule** mode.
 
-Each zone also provides a diagnostic **Binary sensor** entity that is on when any device in the zone — the thermostat or a <abbr title="thermostatic radiator valve">TRV</abbr> actuator — is reporting a low battery.
+Each zone also provides a diagnostic **Binary sensor** entity that is on when any device in the zone — the thermostat or a <abbr title="thermostatic radiator valve">TRV</abbr> — is reporting a low battery.
 
 The Evohome controller is also represented as a **Climate** entity that exposes the system's current operating mode. A controller has neither a current temperature nor a setpoint, but all **Climate** entities in Home Assistant are required to report a temperature, so this value is calculated as the average of all zones.
 

--- a/source/_integrations/evohome.markdown
+++ b/source/_integrations/evohome.markdown
@@ -2,6 +2,7 @@
 title: Honeywell Total Connect Comfort (Europe)
 description: Instructions on how to integrate a Honeywell Evohome/TCC system with Home Assistant.
 ha_category:
+  - Binary sensor
   - Climate
   - Hub
   - Water heater
@@ -11,6 +12,7 @@ ha_codeowners:
   - '@zxdavb'
 ha_domain: evohome
 ha_platforms:
+  - binary_sensor
   - button
   - climate
   - water_heater
@@ -80,13 +82,19 @@ Each heating zone is represented as a **Climate** entity that exposes the zone's
 
 Each zone also provides a **Button** entity to clear any override and return the zone to Evohome's **FollowSchedule** mode.
 
+Each zone also provides a diagnostic **Binary sensor** entity that is on when any device in the zone — the thermostat or a TRV actuator — is reporting a low battery.
+
 The Evohome controller is also represented as a **Climate** entity that exposes the system's current operating mode. A controller has neither a current temperature nor a setpoint, but all **Climate** entities in Home Assistant are required to report a temperature, so this value is calculated as the average of all zones.
 
 The controller also provides a **Button** entity to reset the system mode. This returns the system to **AutoWithReset** when supported, or **Auto** when **AutoWithReset** is unsupported, and resets all zones and DHW to **FollowSchedule**.
 
+The controller also provides a diagnostic **Binary sensor** entity that is on when the controller is reporting a low battery. Not all controller hardware has a battery, so this sensor may never activate on some systems.
+
 The DHW controller is represented as a **WaterHeater** entity which will report its current temperature and can be turned on or off. Due to limitations with the vendor's RESTful API, the setpoint is not reported and cannot be changed.
 
 If present, it also provides a **Button** entity to clear any DHW override and return the DHW controller to Evohome's **FollowSchedule** mode.
+
+If present, the DHW temperature sensor also provides a diagnostic **Binary sensor** entity that is on when it is reporting a low battery.
 
 Note that support for schedules is limited. They cannot be changed, and there is no way to back up or restore that data. For that functionality, refer to the [evohome-async documentation](https://github.com/zxdavb/evohome-async).
 
@@ -281,16 +289,16 @@ The Zones will expose the current/upcoming scheduled `setpoints`:
 
 {% endraw %}
 
-All Evohome entities may have faults, and these can be turned into sensors, or:
+All Evohome entities may have faults. Low battery faults are exposed directly as **Binary sensor** entities. For other fault types, such as communication faults, you can use the `active_faults` attribute:
 
 {% raw %}
 
 ```text
 {% if state_attr('climate.bedroom', 'status').active_faults %}
-  {% if state_attr('climate.bedroom', 'status').active_faults[0].faultType == 'TempZoneActuatorLowBattery' %}
-    There is a low battery
+  {% if state_attr('climate.bedroom', 'status').active_faults[0].faultType.endswith('CommunicationLost') %}
+    A device has lost communication
   {% endif %}
-    There is a Fault!
+    There is a fault!
 {% else %}
   Yay, everything is OK :)
 {% endif %}

--- a/source/_integrations/evohome.markdown
+++ b/source/_integrations/evohome.markdown
@@ -82,7 +82,7 @@ Each heating zone is represented as a **Climate** entity that exposes the zone's
 
 Each zone also provides a **Button** entity to clear any override and return the zone to Evohome's **FollowSchedule** mode.
 
-Each zone also provides a diagnostic **Binary sensor** entity that is on when any device in the zone — the thermostat or a TRV actuator — is reporting a low battery.
+Each zone also provides a diagnostic **Binary sensor** entity that is on when any device in the zone — the thermostat or a <abbr title="thermostatic radiator valve">TRV</abbr> actuator — is reporting a low battery.
 
 The Evohome controller is also represented as a **Climate** entity that exposes the system's current operating mode. A controller has neither a current temperature nor a setpoint, but all **Climate** entities in Home Assistant are required to report a temperature, so this value is calculated as the average of all zones.
 

--- a/source/_integrations/evohome.markdown
+++ b/source/_integrations/evohome.markdown
@@ -289,16 +289,13 @@ The Zones will expose the current/upcoming scheduled `setpoints`:
 
 {% endraw %}
 
-All Evohome entities may have faults. Low battery faults are exposed directly as **Binary sensor** entities. For other fault types, such as communication faults, you can use the `active_faults` attribute:
+All Evohome entities may have faults. Low battery faults are exposed directly as **Binary sensor** entities. For other fault types, such as communication faults, you can use the `status` attribute:
 
 {% raw %}
 
 ```text
-{% if state_attr('climate.bedroom', 'status').active_faults %}
-  {% if state_attr('climate.bedroom', 'status').active_faults[0].faultType.endswith('CommunicationLost') %}
-    A device has lost communication
-  {% endif %}
-    There is a fault!
+{% if state_attr('climate.bedroom', 'status').activeFaults %}
+  There is a fault!
 {% else %}
   Yay, everything is OK :)
 {% endif %}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  Before submitting your pull request, please verify that you have chosen the correct target branch,
  and that the PR preview looks fine and does not include unrelated changes.
-->
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Add a low-battery diagnostic binary sensor for the Evohome integration (adds the binary sensor platform).

Evohome zones, DHW, and the system controller can each report an active "low battery" fault via the vendor API, but Home Assistant currently has no way to expose this to the user. This PR adds a binary_sensor entity (device_class: battery, diagnostic category) for the controller, each zone, and the hot water device (if present), so users get a clear signal when a battery-powered sensor/actuator needs replacing instead of having to check the Evohome app.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/175499
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
