### PR TITLE
Fix section layout when linked via fragment identifier

### DIFF
--- a/sass/homeassistant/pages/community/_base.scss
+++ b/sass/homeassistant/pages/community/_base.scss
@@ -72,6 +72,12 @@ section {
     padding: var(--section-spacing-y) 0;
     position: relative;
     z-index: 1;
+
+    // The global `:target` rule sets `display: inline-block`, which breaks
+    // the section layout when it is linked to via a fragment identifier.
+    &:target {
+        display: block;
+    }
 }
 
 main#page-community {


### PR DESCRIPTION
## Proposed change

This PR fixes a layout issue where sections break when linked to via a fragment identifier (URL hash). The global `:target` CSS rule was setting `display: inline-block`, which caused sections to lose their proper block layout when navigated to directly.

The fix adds a specific override for section elements to restore `display: block` when they are the target of a fragment link, ensuring the section layout remains intact.

## Type of change

- [x] Spelling, grammar or other readability improvements (`current` branch).

## Additional information

This is a styling fix for the community pages that resolves a visual layout issue when users navigate to a specific section using a URL fragment identifier.

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards

https://claude.ai/code/session_019JSTTYFu5LGQTVm61q61sn