### PR TITLE
SQL: document that the Query action requires the SQL integration

### DIFF
--- a/source/_actions/sql.query.markdown
+++ b/source/_actions/sql.query.markdown
@@ -7,7 +7,11 @@ description: "Executes a read-only SQL query and returns the result."
 
 The **Query** action runs a read-only `SELECT` query against a database and returns the rows it finds.
 
-This is useful when you want an automation or script to pull data on demand, for example to look up recent history or summarize values, without creating a dedicated sensor for it. Only `SELECT` statements are allowed.
+This is useful when you want an automation or script to pull data on demand, for example to look up recent history or summarize values, without adding a separate sensor for each query. Only `SELECT` statements are allowed.
+
+{% important %}
+The **Query** action only becomes available after the [SQL integration](/integrations/sql/) is set up. Setting up the integration adds at least one SQL sensor, and that is what makes this action appear. If the **SQL: Query** action is missing, add the SQL integration first from {% my integrations title="**Settings** > **Devices & services**" %}, or configure it in YAML.
+{% endimportant %}
 
 This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label. Instead, you enter the query to run, and optionally the database to run it against.
 

--- a/source/_actions/sql.query.markdown
+++ b/source/_actions/sql.query.markdown
@@ -10,7 +10,7 @@ The **Query** action runs a read-only `SELECT` query against a database and retu
 This is useful when you want an automation or script to pull data on demand, for example to look up recent history or summarize values, without adding a separate sensor for each query. Only `SELECT` statements are allowed.
 
 {% important %}
-The **Query** action only becomes available after the [SQL integration](/integrations/sql/) is set up. Setting up the integration adds at least one SQL sensor, and that is what makes this action appear. If the **SQL: Query** action is missing, add the SQL integration first from {% my integrations title="**Settings** > **Devices & services**" %}, or configure it in YAML.
+The **Query** action is only available once the [SQL integration](/integrations/sql/) has been set up.
 {% endimportant %}
 
 This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label. Instead, you enter the query to run, and optionally the database to run it against.

--- a/source/_actions/sql.query.markdown
+++ b/source/_actions/sql.query.markdown
@@ -10,7 +10,7 @@ The **Query** action runs a read-only `SELECT` query against a database and retu
 This is useful when you want an automation or script to pull data on demand, for example to look up recent history or summarize values, without adding a separate sensor for each query. Only `SELECT` statements are allowed.
 
 {% important %}
-The **Query** action is only available once the [SQL integration](/integrations/sql/) has been set up.
+The **Query** action is only available after you set up the [SQL integration](/integrations/sql/) by adding at least one SQL sensor.
 {% endimportant %}
 
 This action does not support targets. In the UI, you are not prompted to choose an area, device, entity, or label. Instead, you enter the query to run, and optionally the database to run it against.


### PR DESCRIPTION
## Proposed change

The `sql.query` action page implied you can run queries "without creating a dedicated sensor for it," but the action is only registered when the SQL integration is actually loaded. This adds a prerequisite note and rewords the misleading sentence so readers know the action does not appear until the SQL integration is set up.

Verified against home-assistant/core:
- The `query` service is registered only in `async_setup_services()` (`homeassistant/components/sql/services.py`), which is called only from `async_setup()` (`homeassistant/components/sql/__init__.py`).
- SQL is `config_flow: true` (`manifest.json`) and is not part of `default_config`, so `async_setup` does not run — and the action is not registered — until at least one SQL sensor (config entry or YAML) exists.
- Upstream core issue home-assistant/core#172365 was closed as "not planned," confirming this is the intended behavior, so it belongs in the docs.

Fixes #46341

## Type of change

- [x] Document existing feature (existing functionality, requires a Home Assistant version number)

## Additional information

- This PR fixes or closes issue: fixes #46341

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - `current` for documentation of existing functionality
- [x] The documentation follows the Home Assistant documentation standards.
