### PR TITLE
Document Fronius backup mode and battery standby binary sensors

### DIFF
--- a/source/_integrations/fronius.markdown
+++ b/source/_integrations/fronius.markdown
@@ -3,6 +3,7 @@ title: Fronius
 description: Instructions on how to connect your Fronius SolarAPI devices to Home Assistant.
 ha_release: 0.96
 ha_category:
+  - Binary sensor
   - Energy
   - Sensor
 ha_codeowners:
@@ -11,6 +12,7 @@ ha_config_flow: true
 ha_domain: fronius
 ha_iot_class: Local Polling
 ha_platforms:
+  - binary_sensor
   - diagnostics
   - sensor
 ha_dhcp: true
@@ -82,7 +84,9 @@ Each device adds a set of sensors to Home Assistant.
     - Energy produced on the current day, year and total produced energy
     - Power fed to the grid (if positive) or consumed from the grid (if negative)
     - Power load as a generator (if positive) or consumer (if negative)
-    - Battery charging power (if positive) or discharging power (if negative) and information about backup or standby mode
+    - Battery charging power (if positive) or discharging power (if negative)
+    - Whether the battery is in standby, on Gen24 devices with a battery
+    - Whether the system is currently supplying backup power during a grid outage, on Gen24, Tauro, and Verto devices with backup power configured
     - Photovoltaic production
     - Current relative self-consumption of produced energy
     - Current relative autonomy


### PR DESCRIPTION
## Proposed change

Documents the new `binary_sensor` platform for the Fronius integration, added in home-assistant/core#176056. The power flow data now provides two binary sensors:

- **Backup mode** — on when the system is supplying backup power during a grid outage (Gen24, Tauro, and Verto devices with backup power configured).
- **Battery standby** — on when the battery is in standby (Gen24 devices with a battery).

Changes: adds `binary_sensor` to the platforms and category front matter, and replaces the vague "backup or standby mode" note in the power flow section with accurate descriptions of the two entities and the devices that report them.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: home-assistant/core#176056
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
