### PR TITLE
Templating: state timestamps are stored in UTC, not the configured time zone

### DIFF
--- a/source/_docs/templating/dates-and-times.markdown
+++ b/source/_docs/templating/dates-and-times.markdown
@@ -223,7 +223,7 @@ output: "Christmas: 8 months"
 
 ## Time zones
 
-Home Assistant stores state timestamps (`last_changed`, `last_updated`) in your configured time zone. `now()` also returns your local time zone. `utcnow()` returns UTC.
+Home Assistant stores state timestamps (`last_changed`, `last_updated`) in UTC. `now()` returns the current time in your configured time zone, while `utcnow()` returns it in UTC.
 
 If you need to compare datetimes, both sides need to be in the same time zone. [`as_datetime`](/template-functions/as_datetime/) and [`strptime`](/template-functions/strptime/) return datetimes without a time zone by default. Apply the matching conversion before comparing, or stick to [`timestamp_local`](/template-functions/timestamp_local/) and [`timestamp_utc`](/template-functions/timestamp_utc/) which handle this for you.
 


### PR DESCRIPTION
## Proposed change

The "Time zones" section of the templating dates-and-times page stated that Home Assistant stores state timestamps (`last_changed`, `last_updated`) in your configured time zone. That is incorrect: these timestamps are stored in UTC. This corrects the sentence and clarifies that `now()` returns the configured time zone while `utcnow()` returns UTC, which also makes the section consistent with the `now() and utcnow()` section earlier on the same page.

Verified against home-assistant/core:
- `State.last_changed`, `last_updated`, and `last_reported` default to `dt_util.utcnow()` (`homeassistant/core.py`, `State.__init__`).
- The state machine sets them with `dt_util.utc_from_timestamp(timestamp)` (`homeassistant/core.py`, `StateMachine`).
- `dt_util.utcnow()` is `partial(datetime.now, UTC)` and is UTC-aware (`homeassistant/util/dt.py`).

## Type of change

- [x] Adjusted missing or incorrect information in the current documentation (`current` branch).

## Additional information

- This PR fixes or closes issue: fixes #46556
- AI assistance disclosure: this change was drafted with AI assistance. In line with Home Assistant's AI-contribution guidance, the change is fully understood, the corrected behavior was verified against the linked Home Assistant core source, and the wording was reviewed for correctness and compliance with the documentation standards.

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
- [x] The documentation follows the Home Assistant documentation [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
