### PR TITLE
Document Subaru binary sensors and Bronze quality scale

### DIFF
--- a/source/_integrations/subaru.markdown
+++ b/source/_integrations/subaru.markdown
@@ -13,6 +13,7 @@ ha_config_flow: true
 ha_codeowners:
   - '@G-Two'
 ha_domain: subaru
+ha_quality_scale: bronze
 ha_platforms:
   - binary_sensor
   - button
@@ -94,9 +95,27 @@ PHEV vehicles get two additional binary sensors:
 
 ### Vehicle health
 
-The vehicle's warning indicators (MILs) are exposed as diagnostic binary sensors. **Vehicle health** is enabled by default and reflects the overall rollup; the individual indicators below are **disabled by default** — enable the ones you want to track. Only indicators your vehicle actually reports are created.
+The vehicle's warning indicators (Malfunction Indicator Lamps, or MILs) are exposed as diagnostic binary sensors. **Vehicle health** is enabled by default and reflects the overall rollup; the individual indicators below are **disabled by default** — enable the ones you want to track. Only indicators your vehicle actually reports are created.
 
-Airbag, AWD, ABS, transmission temperature, blind spot/rear cross traffic, check engine, electronic brakeforce distribution, electric parking brake, engine oil level, EyeSight, idle stop & start, oil pressure, electric power steering, reverse automatic braking, steering responsive headlights, telematics, tire pressure, vehicle dynamics control, and washer fluid.
+- Airbag
+- AWD
+- ABS
+- Transmission temperature
+- Blind spot / rear cross traffic
+- Check engine
+- Electronic brakeforce distribution
+- Electric parking brake
+- Engine oil level
+- EyeSight
+- Idle stop & start
+- Oil pressure
+- Electric power steering
+- Reverse automatic braking
+- Steering responsive headlights
+- Telematics
+- Tire pressure
+- Vehicle dynamics control
+- Washer fluid
 
 ## Lock
 
@@ -171,4 +190,4 @@ Vehicle polling draws power from the 12V battery. Long term use without driving 
 
 This integration follows standard integration removal. No additional steps are required when removing the integration from Home Assistant.
 
-If you also want to revoke Home Assistant's access to your MySubaru account, log in to [mysubaru.com](https://www.mysubaru.com) and remove the Home Assistant device under **Settings → Devices**.
+If you also want to revoke Home Assistant's access to your MySubaru account, log in to [mysubaru.com](https://www.mysubaru.com) and remove the Home Assistant device under **Settings** > **Devices**.

--- a/source/_integrations/subaru.markdown
+++ b/source/_integrations/subaru.markdown
@@ -2,6 +2,7 @@
 title: Subaru
 description: Instructions on how to set up your Subaru account with Home Assistant.
 ha_category:
+  - Binary sensor
   - Car
   - Lock
   - Presence detection
@@ -13,6 +14,7 @@ ha_codeowners:
   - '@G-Two'
 ha_domain: subaru
 ha_platforms:
+  - binary_sensor
   - button
   - device_tracker
   - diagnostics
@@ -71,12 +73,36 @@ Available sensors will vary by model, year, and subscription type. The integrati
 
 EV sensors (EV battery level, EV range, EV time to full charge) are only present on PHEV vehicles. The recommended tire pressure sensors are disabled by default and may report `unknown` on older Gen 2 vehicles that do not advertise the underlying tire-pressure recommendation in `vehicle_health`. The vehicle state sensor reports one of `ignition_off`, `ignition_acc` (accessory power), `ignition_on`, or `engine_on_remote_start`; if your vehicle reports a value not in that list, please file a bug and attach the integration's diagnostics download.
 
+## Binary sensors
+
+Binary sensors are added for Gen 2 and newer vehicles. Most are derived from data the vehicle pushes after engine shutdown, so a sensor may show `unknown` until the first push has been received.
+
+### Openings
+
+Each door and window reports open/closed: door front left, door front right, door rear left, door rear right, hood, tailgate, window front left, window front right, window rear left, window rear right, and sunroof.
+
+### Per-door lock status
+
+Read-only lock state for each door (front left/right, rear left/right, tailgate) — independent of the [controllable lock entity](#lock), which reflects the last command sent rather than the vehicle's actual state.
+
+### EV
+
+PHEV vehicles get two additional binary sensors:
+
+- **EV plug**: on when the charging cable is connected.
+- **Charging** *(disabled by default)*: on only while the vehicle is actively drawing charge, distinct from simply being plugged in.
+
+### Vehicle health
+
+The vehicle's warning indicators (MILs) are exposed as diagnostic binary sensors. **Vehicle health** is enabled by default and reflects the overall rollup; the individual indicators below are **disabled by default** — enable the ones you want to track. Only indicators your vehicle actually reports are created.
+
+Airbag, AWD, ABS, transmission temperature, blind spot/rear cross traffic, check engine, electronic brakeforce distribution, electric parking brake, engine oil level, EyeSight, idle stop & start, oil pressure, electric power steering, reverse automatic braking, steering responsive headlights, telematics, tire pressure, vehicle dynamics control, and washer fluid.
+
 ## Lock
 
-This integration supports remote locking and unlocking of vehicle doors. If doors are remotely unlocked, they will automatically relock if a door is not opened within a minute. There is no remote notification of this automatic relock.  
-{% note %}
-This integration does not yet support tracking the current lock/unlock state.
-{% endnote %}
+This integration supports remote locking and unlocking of vehicle doors. If doors are remotely unlocked, they will automatically relock if a door is not opened within a minute. There is no remote notification of this automatic relock.
+
+The lock entity's state reflects the last command sent, not necessarily the vehicle's actual state. To see the current lock state of each door, use the [per-door lock status binary sensors](#per-door-lock-status).
 
 ### Unlock specific door
 
@@ -140,3 +166,9 @@ Vehicle polling draws power from the 12V battery. Long term use without driving 
 **Q:** Should I enable the vehicle polling option?
 
 **A:** Probably not. One use case is if you have a PHEV and want to monitor your charging progress. Otherwise, the data isn't going to change much after you've shutdown your vehicle (tire pressures are only updated when the vehicle is in motion). A future revision will expose vehicle polling as an action to enable incorporation into automations.
+
+## Removing the integration
+
+This integration follows standard integration removal. No additional steps are required when removing the integration from Home Assistant.
+
+If you also want to revoke Home Assistant's access to your MySubaru account, log in to [mysubaru.com](https://www.mysubaru.com) and remove the Home Assistant device under **Settings → Devices**.


### PR DESCRIPTION
## Proposed change

Documents the `binary_sensor` platform being added for the Subaru integration: openings (doors/windows/sunroof/hood/tailgate), per-door lock status, EV plug/charging, and MIL warning indicators. Updates the Lock section to point at the new per-door lock status sensors instead of the old "not yet supported" note. Adds a "Removing the integration" section.

## Type of change

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information

- Link to parent pull request in the codebase: home-assistant/core#176164
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
